### PR TITLE
bug fixes:handle sendsnapshot, the last_log_term of requestvote equals to 0, resulting in  lose an election(镜像拷贝后，requestvote的last_log_term为0，导致无法选举的bug)

### DIFF
--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -224,6 +224,10 @@ raft_term_t raft_get_last_log_term(raft_server_t* me_)
             raft_entry_release(ety);
             return term;
         }
+        else if (current_idx == raft_get_snapshot_last_idx(instance_->raft_ctx()))
+        {
+            return raft_get_snapshot_last_term(me_);
+        }
     }
     return 0;
 }


### PR DESCRIPTION
After sendsnapshot, log entry will be empty and last_log_term equals 0 when requestvote. Change to, when judging current_idx == snapshot_last_idx(lastIncludedIndex), use snapshot_last_term(lastIncludedTerm) as last_log_term 
修复镜像拷贝后，log entry为空，requestvote时获取last_log_term为0的bug。改成，判断current_idx == snapshot_last_idx(lastIncludedIndex)时，用snapshot_last_term(lastIncludedTerm)作为last_log_term
