### PR TITLE
bug fixes:handle sendsnapshot, the last_log_term of requestvote equals to 0, resulting in lose an election(镜像拷贝后，requestvote的last_log_term为0，导致无法选举的bug)

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -843,6 +843,10 @@ raft_index_t raft_get_last_applied_idx(raft_server_t* me);
  * @param[in] the node's next index */
 void raft_node_set_next_idx(raft_node_t* node, raft_index_t nextIdx);
 
+/** Set the node's match index.
+ * @param[in] the node's next match */
+void raft_node_set_match_idx(raft_node_t* node, raft_index_t matchIdx);
+
 /**
  * @return the node's next index */
 raft_index_t raft_node_get_next_idx(raft_node_t* node);

--- a/include/raft.h
+++ b/include/raft.h
@@ -10,6 +10,10 @@
 #ifndef RAFT_H_
 #define RAFT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "raft_types.h"
 
 typedef enum {
@@ -1225,5 +1229,9 @@ void raft_queue_read_request(raft_server_t* me_, func_read_request_callback_f cb
 /** Attempt to process read queue.
  */
 void raft_process_read_queue(raft_server_t* me_);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* RAFT_H_ */

--- a/include/raft.h
+++ b/include/raft.h
@@ -998,6 +998,10 @@ int raft_entry_is_voting_cfg_change(raft_entry_t* ety);
  * @return 1 if this is a configuration change. */
 int raft_entry_is_cfg_change(raft_entry_t* ety);
 
+/**
+ * @return number of items within log in log compaction */
+raft_index_t raft_get_num_snapshottable_logs(raft_server_t *me_);
+
 /** Begin snapshotting.
  *
  * While snapshotting, raft will:

--- a/include/raft.h
+++ b/include/raft.h
@@ -835,6 +835,10 @@ int raft_get_request_timeout(raft_server_t* me);
  * @return index of last applied entry */
 raft_index_t raft_get_last_applied_idx(raft_server_t* me);
 
+/** Set the node's next index.
+ * @param[in] the node's next index */
+void raft_node_set_next_idx(raft_node_t* node, raft_index_t nextIdx);
+
 /**
  * @return the node's next index */
 raft_index_t raft_node_get_next_idx(raft_node_t* node);

--- a/include/raft.h
+++ b/include/raft.h
@@ -927,6 +927,8 @@ int raft_set_current_term(raft_server_t* me, const raft_term_t term);
  * @param[in] commit_idx The new commit index. */
 void raft_set_commit_idx(raft_server_t* me, raft_index_t commit_idx);
 
+int raft_election_start(raft_server_t* me);
+
 /** Add an entry to the server's log.
  * This should be used to reload persistent state, ie. the commit log.
  * @param[in] ety The entry to be appended

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -107,8 +107,6 @@ typedef struct {
     raft_read_request_t *read_queue_tail;
 } raft_server_private_t;
 
-int raft_election_start(raft_server_t* me);
-
 int raft_become_candidate(raft_server_t* me);
 
 void raft_randomize_election_timeout(raft_server_t* me_);

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -142,6 +142,8 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id);
 
 void raft_node_free(raft_node_t* me_);
 
+void raft_clear_node(raft_server_t* me_, raft_node_t* node);
+
 void raft_node_set_match_idx(raft_node_t* node, raft_index_t matchIdx);
 
 raft_index_t raft_node_get_match_idx(raft_node_t* me_);

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -144,8 +144,6 @@ void raft_node_free(raft_node_t* me_);
 
 void raft_clear_node(raft_server_t* me_, raft_node_t* node);
 
-void raft_node_set_match_idx(raft_node_t* node, raft_index_t matchIdx);
-
 raft_index_t raft_node_get_match_idx(raft_node_t* me_);
 
 void raft_node_vote_for_me(raft_node_t* me_, const int vote);

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -142,8 +142,6 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id);
 
 void raft_node_free(raft_node_t* me_);
 
-void raft_node_set_next_idx(raft_node_t* node, raft_index_t nextIdx);
-
 void raft_node_set_match_idx(raft_node_t* node, raft_index_t matchIdx);
 
 raft_index_t raft_node_get_match_idx(raft_node_t* me_);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -467,7 +467,7 @@ int raft_recv_appendentries(
     /* NOTE: the log starts at 1 */
     if (0 < ae->prev_log_idx)
     {
-        raft_entry_t* ety = raft_get_entry_from_idx(me_, ae->prev_log_idx);
+        raft_entry_t* ety = NULL;
 
         /* Is a snapshot */
         if (ae->prev_log_idx == me->snapshot_last_idx)
@@ -484,7 +484,7 @@ int raft_recv_appendentries(
         }
         /* 2. Reply false if log doesn't contain an entry at prevLogIndex
            whose term matches prevLogTerm (§5.3) */
-        else if (!ety)
+        else if (!(ety = raft_get_entry_from_idx(me_, ae->prev_log_idx)))
         {
             __log(me_, node, "AE no log at prev_idx %d", ae->prev_log_idx);
             goto out;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1613,14 +1613,15 @@ raft_msg_id_t quorum_msg_id(raft_server_t* me_)
 
     for (i = 0; i < me->num_nodes; i++) {
         raft_node_t* node = me->nodes[i];
-        if (me->node == node) {
-            msg_ids[msg_ids_count++] = me->msg_id;
-            continue;
-        }
+
         if (!raft_node_is_active(node) || !raft_node_is_voting(node))
             continue;
 
-        msg_ids[msg_ids_count++] = raft_node_get_last_acked_msgid(node);
+        if (me->node == node) {
+            msg_ids[msg_ids_count++] = me->msg_id;
+        } else {
+            msg_ids[msg_ids_count++] = raft_node_get_last_acked_msgid(node);
+        }
     }
 
     qsort(msg_ids, msg_ids_count, sizeof(raft_msg_id_t), msgid_cmp);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -992,15 +992,17 @@ int raft_send_appendentries(raft_server_t* me_, raft_node_t* node)
     /* previous log is the log just before the new logs */
     if (1 < next_idx)
     {
-        raft_entry_t* prev_ety = raft_get_entry_from_idx(me_, next_idx - 1);
-        if (!prev_ety)
+        raft_index_t prev_idx = next_idx - 1;
+        raft_entry_t* prev_ety = NULL;
+
+        if (me->snapshot_last_idx == prev_idx || !(prev_ety = raft_get_entry_from_idx(me_, prev_idx)))
         {
             ae.prev_log_idx = me->snapshot_last_idx;
             ae.prev_log_term = me->snapshot_last_term;
         }
         else
         {
-            ae.prev_log_idx = next_idx - 1;
+            ae.prev_log_idx = prev_idx;
             ae.prev_log_term = prev_ety->term;
             raft_entry_release(prev_ety);
         }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -224,6 +224,10 @@ raft_term_t raft_get_last_log_term(raft_server_t* me_)
             raft_entry_release(ety);
             return term;
         }
+        else if (current_idx == raft_get_snapshot_last_idx(me_))
+        {
+            return raft_get_snapshot_last_term(me_);
+        }
     }
     return 0;
 }


### PR DESCRIPTION
After sendsnapshot, log entry will be empty and last_log_term equals 0 when requestvote. Change to, when judging current_idx == snapshot_last_idx(lastIncludedIndex), use snapshot_last_term(lastIncludedTerm) as last_log_term
修复镜像拷贝后，log entry为空，requestvote时获取last_log_term为0的bug。改成，判断current_idx == snapshot_last_idx(lastIncludedIndex)时，用snapshot_last_term(lastIncludedTerm)作为last_log_term