### PR TITLE
fix set commit_idx if leader is no longer voting, but no election

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *~
 libraft.a
 libraft.so
+libcraft.so
+libcraft.a
 CLinkedListQueue/
 .env/
 .hypothesis/

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -810,7 +810,7 @@ int raft_recv_entry(raft_server_t* me_,
     }
 
     /* if we're the only node, we can consider the entry committed */
-    if (1 == raft_get_num_voting_nodes(me_) && (raft_node_is_voting(me->node) || me->num_nodes > 1))
+    if (1 == raft_get_num_voting_nodes(me_) && raft_node_is_voting(me->node))
         raft_set_commit_idx(me_, raft_get_current_idx(me_));
 
     r->id = ety->id;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -388,7 +388,8 @@ int raft_recv_appendentries_response(raft_server_t* me_,
         raft_entry_t* ety = raft_get_entry_from_idx(me_, point);
         if (raft_get_commit_idx(me_) < point && ety->term == me->current_term)
         {
-            int i, votes = 1;
+            int i, votes = raft_node_is_voting(me_) ? 1 : 0;
+
             for (i = 0; i < me->num_nodes; i++)
             {
                 raft_node_t* node = me->nodes[i];
@@ -811,7 +812,7 @@ int raft_recv_entry(raft_server_t* me_,
     }
 
     /* if we're the only node, we can consider the entry committed */
-    if (1 == raft_get_num_voting_nodes(me_))
+    if (1 == raft_get_num_voting_nodes(me_) && raft_node_is_voting(me_))
         raft_set_commit_idx(me_, raft_get_current_idx(me_));
 
     r->id = ety->id;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -69,8 +69,7 @@ void raft_randomize_election_timeout(raft_server_t* me_)
 
 raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
 {
-    raft_server_private_t* me =
-        (raft_server_private_t*)__raft_calloc(1, sizeof(raft_server_private_t));
+    raft_server_private_t* me = (raft_server_private_t*)__raft_calloc(1, sizeof(raft_server_private_t));
     if (!me)
         return NULL;
     me->current_term = 0;
@@ -388,8 +387,7 @@ int raft_recv_appendentries_response(raft_server_t* me_,
         raft_entry_t* ety = raft_get_entry_from_idx(me_, point);
         if (raft_get_commit_idx(me_) < point && ety->term == me->current_term)
         {
-            int i, votes = raft_node_is_voting(me_) ? 1 : 0;
-
+            int i, votes = raft_node_is_voting(node) ? 1 : 0;
             for (i = 0; i < me->num_nodes; i++)
             {
                 raft_node_t* node = me->nodes[i];
@@ -812,7 +810,7 @@ int raft_recv_entry(raft_server_t* me_,
     }
 
     /* if we're the only node, we can consider the entry committed */
-    if (1 == raft_get_num_voting_nodes(me_) && raft_node_is_voting(me_))
+    if (1 == raft_get_num_voting_nodes(me_) && (raft_node_is_voting(me->node) || me->num_nodes > 1))
         raft_set_commit_idx(me_, raft_get_current_idx(me_));
 
     r->id = ety->id;


### PR DESCRIPTION
Currently, raftlib lets the leader be demoted but remain leader until the next election.  It is therefore not a voter, but lots of code considers it inherently a voter.  this fixes that for the context of updating the commit.