### PR TITLE
Virtraft changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ else
 SHAREDFLAGS = -shared
 SHAREDEXT = so
 endif
+VIRTRAFT_OPTS = $(or $(TEST),)
 
 OBJECTS = src/raft_server.o src/raft_server_properties.o src/raft_node.o src/raft_log.o
 
@@ -73,13 +74,13 @@ tests_full:
 
 .PHONY: test_virtraft
 test_virtraft:
-	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3
-	python3 tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3
-	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3
-	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3
-	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3
-	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3
-	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 $(VIRTRAFT_OPTS)
 
 .PHONY: amalgamation
 amalgamation:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ else
 SHAREDFLAGS = -shared
 SHAREDEXT = so
 endif
-VIRTRAFT_OPTS = $(or $(TEST),)
 
 OBJECTS = src/raft_server.o src/raft_server_properties.o src/raft_node.o src/raft_log.o
 

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -508,6 +508,8 @@ class Network(object):
         server.set_connection_status(NODE_CONNECTING)
         lib.raft_add_non_voting_node(server.raft, server.udata, server.id, 1)
         lib.raft_become_leader(server.raft)
+        e = lib.raft_set_current_term(server.raft, 1)
+        assert e == 0
 
         # Configuration change entry to bootstrap other nodes
         ety = self.add_entry(lib.RAFT_LOGTYPE_ADD_NODE,

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -1078,10 +1078,10 @@ class RaftServer(object):
         if ety.type == lib.RAFT_LOGTYPE_NO_OP:
             return 0
 
-        if ety.type == lib.RAFT_LOGTYPE_DEMOTE_NODE or \
-                ety.type == lib.RAFT_LOGTYPE_REMOVE_NODE or \
-                ety.type == lib.RAFT_LOGTYPE_ADD_NONVOTING_NODE or \
-                ety.type == lib.RAFT_LOGTYPE_ADD_NODE:
+        if (ety.type == lib.RAFT_LOGTYPE_DEMOTE_NODE or
+                ety.type == lib.RAFT_LOGTYPE_REMOVE_NODE or
+                ety.type == lib.RAFT_LOGTYPE_ADD_NONVOTING_NODE or
+                ety.type == lib.RAFT_LOGTYPE_ADD_NODE):
 
             change = ffi.from_handle(lib.raft_entry_getdata(ety))
             server = self.network.id2server(change.node_id)

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -185,6 +185,7 @@ def raft_applylog(raft, udata, ety, idx):
     except:
         logger.error(f"raft_applylog: failure on {lib.raft_get_nodeid(raft)}")
         logger.error(traceback.format_exc())
+        # we really should want to exit here, but can't figure out how to
         return lib.RAFT_ERR_SHUTDOWN
 
 


### PR DESCRIPTION
these are changes fixing a couple of bugs in virtraft and making it better to debug with more controllable logging

bugs

1) _check_log_matching never worked in the presence of a failure (I actually think it still doesn't work, right, and should hard fail when it happens), but at least it doesn't a) silently fail when it fails and b) actually fail and ignore it.

now, it will print out when it fails and actually doesn't fail

2) entry_pop also just didn't work.  you aren't poping cfg change entries off the "targeted" node which is what the code thinks is happening, you are popping them (most likely) off a former leader that recv'd entries that are now invalid because leadership changed to another node.