### PR TITLE
save commit_idx on leader demotion and use that value for ae msgs

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -915,6 +915,9 @@ int raft_set_current_term(raft_server_t* me, const raft_term_t term);
  * @param[in] commit_idx The new commit index. */
 void raft_set_commit_idx(raft_server_t* me, raft_index_t commit_idx);
 
+/** saves the commit idx, for when node is demoted */
+void raft_save_commit_idx(raft_server_t *me_);
+
 /** Add an entry to the server's log.
  * This should be used to reload persistent state, ie. the commit log.
  * @param[in] ety The entry to be appended

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -52,6 +52,9 @@ typedef struct {
     /* idx of highest log entry known to be committed */
     raft_index_t commit_idx;
 
+    /* idx of highest log entry before node was demoted */
+    raft_index_t demoted_commit_idx;
+
     /* idx of highest log entry applied to state machine */
     raft_index_t last_applied_idx;
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1256,11 +1256,17 @@ void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_i
         case RAFT_LOGTYPE_DEMOTE_NODE:
             if (node)
                 raft_node_set_voting(node, 0);
+
+            if (is_self) {
+                raft_save_commit_idx(me_);
+            }
+
             break;
 
         case RAFT_LOGTYPE_REMOVE_NODE:
             if (node)
                 raft_node_set_active(node, 0);
+
             break;
 
         default:

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -119,6 +119,12 @@ void raft_set_commit_idx(raft_server_t* me_, raft_index_t idx)
     me->commit_idx = idx;
 }
 
+void raft_save_commit_idx(raft_server_t *me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    me->demoted_commit_idx = me->commit_idx;
+}
+
 void raft_set_last_applied_idx(raft_server_t* me_, raft_index_t idx)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
@@ -133,6 +139,23 @@ raft_index_t raft_get_last_applied_idx(raft_server_t* me_)
 raft_index_t raft_get_commit_idx(raft_server_t* me_)
 {
     return ((raft_server_private_t*)me_)->commit_idx;
+}
+
+raft_index_t raft_get_demoted_commit_idx(raft_server_t* me_)
+{
+    return ((raft_server_private_t*)me_)->demoted_commit_idx;
+}
+
+raft_index_t raft_get_ae_commit_idx(raft_server_t* me_)
+{
+    raft_node_t *node = raft_get_my_node(me_);
+    assert(node != NULL);
+
+    if (raft_node_is_voting(node)) {
+        return raft_get_commit_idx(me_);
+    } else {
+        return raft_get_demoted_commit_idx(me_);
+    }
 }
 
 void raft_set_state(raft_server_t* me_, int state)


### PR DESCRIPTION
when a node (only matters for leader) is demoted to non voting state, it will become a non voting leader, while we still have to update commit_idx as new entries come in, appendentry heartbeats it sends out should use the commit_idx as time of demotion