### PR TITLE
prevented a non voting leader from accepting entries

### DIFF
--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -3084,6 +3084,8 @@ void TestRaft_leader_recv_entry_resets_election_timeout(
     void *r = raft_new();
     raft_set_election_timeout(r, 1000);
     raft_set_state(r, RAFT_STATE_LEADER);
+    raft_add_node(r, NULL, 1, 1);
+//    raft_node_set_voting(raft_get_node(r, 1), 1);
 
     raft_periodic(r, 900);
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -1,4 +1,3 @@
-
 #include <stdbool.h>
 #include <assert.h>
 #include <stdlib.h>
@@ -3085,7 +3084,6 @@ void TestRaft_leader_recv_entry_resets_election_timeout(
     raft_set_election_timeout(r, 1000);
     raft_set_state(r, RAFT_STATE_LEADER);
     raft_add_node(r, NULL, 1, 1);
-//    raft_node_set_voting(raft_get_node(r, 1), 1);
 
     raft_periodic(r, 900);
 


### PR DESCRIPTION
a non voting leader (i.e. demoted itself), shouldn't be able to recv new entries.  A similar case would be when its bootstrapping a cluster, as it would want to add itself, therefore we disallow it if the number of nodes is > 1.  If the demoted leader is in a cluster by itself, it can recv_entry()

this required a fix to tests to make sure the server had a node object created for the cluster, so it can accept an entry