### PR TITLE
if removing leader, unset current_leader

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1128,6 +1128,12 @@ void raft_remove_node(raft_server_t* me_, raft_node_t* node)
     memmove(&me->nodes[i], &me->nodes[i + 1], sizeof(*me->nodes) * (me->num_nodes - i - 1));
     me->num_nodes--;
 
+    /* if we are removing the current leader, have to reset it, as this data is now stale */
+    raft_node_t *current_leader_node = raft_get_current_leader_node(me_);
+    if (node == current_leader_node) {
+        me->current_leader = NULL;
+    }
+
     raft_node_free(node);
 }
 


### PR DESCRIPTION
current_leader points to the node object corresponding to the leader node.  But we are about to free() it.  to prevent an access after free, have to unset it here.