### PR TITLE
remove REMOVE_NODE log type and include its semantics in DEMOTE 

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -62,9 +62,11 @@ typedef enum {
     RAFT_LOGTYPE_ADD_NODE,
     /**
      * Membership change.
-     * Nodes become demoted when we want to remove them from the cluster.
+     * Nodes become demoted when we want to remove them from the cluster
+     * Nodes become demoted upon appending of the log message
      * Demoted nodes can't take part in voting or start elections.
      * Demoted nodes become inactive, as per raft_node_is_active.
+     * Demoted nodes are removed from cluster when the log message is committed and applied
      */
     RAFT_LOGTYPE_DEMOTE_NODE,
     /**

--- a/include/raft.h
+++ b/include/raft.h
@@ -68,7 +68,7 @@ typedef enum {
      * Demoted nodes become inactive, as per raft_node_is_active.
      * Demoted nodes are removed from cluster when the log message is committed and applied
      */
-    RAFT_LOGTYPE_DEMOTE_NODE,
+    RAFT_LOGTYPE_REMOVE_NODE,
     /**
      * Users can piggyback the entry mechanism by specifying log types that
      * are higher than RAFT_LOGTYPE_NUM.

--- a/include/raft.h
+++ b/include/raft.h
@@ -68,13 +68,6 @@ typedef enum {
      */
     RAFT_LOGTYPE_DEMOTE_NODE,
     /**
-     * Membership change.
-     * The node is removed from the cluster.
-     * This happens after the node has been demoted.
-     * Removing nodes is a 2 step process: first demote, then remove.
-     */
-    RAFT_LOGTYPE_REMOVE_NODE,
-    /**
      * Users can piggyback the entry mechanism by specifying log types that
      * are higher than RAFT_LOGTYPE_NUM.
      */

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -129,7 +129,7 @@ void raft_node_set_voting(raft_node_t* me_, int voting)
 int raft_node_is_voting(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
-    return (me->flags & RAFT_NODE_VOTING) != 0;
+    return (me->flags & RAFT_NODE_VOTING && !(me->flags & RAFT_NODE_INACTIVE));
 }
 
 int raft_node_has_sufficient_logs(raft_node_t* me_)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -223,9 +223,7 @@ int raft_become_candidate(raft_server_t* me_)
     {
         raft_node_t* node = me->nodes[i];
 
-        if (me->node != node &&
-            raft_node_is_active(node) &&
-            raft_node_is_voting(node))
+        if (me->node != node && raft_node_is_voting(node))
         {
             raft_send_requestvote(me_, node);
         }
@@ -394,7 +392,6 @@ int raft_recv_appendentries_response(raft_server_t* me_,
             {
                 raft_node_t* node = me->nodes[i];
                 if (me->node != node &&
-                    raft_node_is_active(node) &&
                     raft_node_is_voting(node) &&
                     point <= raft_node_get_match_idx(node))
                 {
@@ -1134,7 +1131,6 @@ int raft_get_nvotes_for_me(raft_server_t* me_)
     for (i = 0, votes = 0; i < me->num_nodes; i++)
     {
         if (me->node != me->nodes[i] &&
-            raft_node_is_active(me->nodes[i]) &&
             raft_node_is_voting(me->nodes[i]) &&
             raft_node_has_vote_for_me(me->nodes[i]))
         {
@@ -1249,7 +1245,6 @@ void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_i
 
         case RAFT_LOGTYPE_REMOVE_NODE:
             if (node) {
-                raft_node_set_voting(node, 0);
                 raft_node_set_active(node, 0);
             }
 
@@ -1278,7 +1273,6 @@ void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const 
             {
             raft_node_t* node = raft_get_node(me_, node_id);
             raft_node_set_active(node, 1);
-            raft_node_set_voting(node, 1);
             }
             break;
 
@@ -1591,7 +1585,7 @@ raft_msg_id_t quorum_msg_id(raft_server_t* me_)
     for (i = 0; i < me->num_nodes; i++) {
         raft_node_t* node = me->nodes[i];
 
-        if (!raft_node_is_active(node) || !raft_node_is_voting(node))
+        if (!raft_node_is_voting(node))
             continue;
 
         if (me->node == node) {

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -908,7 +908,6 @@ int raft_apply_entry(raft_server_t* me_)
             break;
         case RAFT_LOGTYPE_REMOVE_NODE:
             if (node) {
-                raft_node_set_voting_committed(node, 0);
                 raft_remove_node(me_, node);
             }
             break;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -910,12 +910,10 @@ int raft_apply_entry(raft_server_t* me_)
             raft_node_set_addition_committed(node, 1);
             break;
         case RAFT_LOGTYPE_DEMOTE_NODE:
-            if (node)
+            if (node) {
                 raft_node_set_voting_committed(node, 0);
-            break;
-        case RAFT_LOGTYPE_REMOVE_NODE:
-            if (node)
                 raft_remove_node(me_, node);
+            }
             break;
         default:
             break;
@@ -1209,8 +1207,7 @@ int raft_entry_is_cfg_change(raft_entry_t* ety)
     return (
         RAFT_LOGTYPE_ADD_NODE == ety->type ||
         RAFT_LOGTYPE_ADD_NONVOTING_NODE == ety->type ||
-        RAFT_LOGTYPE_DEMOTE_NODE == ety->type ||
-        RAFT_LOGTYPE_REMOVE_NODE == ety->type);
+        RAFT_LOGTYPE_DEMOTE_NODE == ety->type);
 }
 
 void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_index_t idx)
@@ -1255,11 +1252,6 @@ void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_i
                 raft_node_set_voting(node, 0);
             break;
 
-        case RAFT_LOGTYPE_REMOVE_NODE:
-            if (node)
-                raft_node_set_active(node, 0);
-            break;
-
         default:
             assert(0);
     }
@@ -1283,13 +1275,6 @@ void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const 
             {
             raft_node_t* node = raft_get_node(me_, node_id);
             raft_node_set_voting(node, 1);
-            }
-            break;
-
-        case RAFT_LOGTYPE_REMOVE_NODE:
-            {
-            raft_node_t* node = raft_get_node(me_, node_id);
-            raft_node_set_active(node, 1);
             }
             break;
 

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -85,8 +85,6 @@ def logtype2str(log_type):
         return 'normal'
     elif log_type == lib.RAFT_LOGTYPE_DEMOTE_NODE:
         return 'demote'
-    elif log_type == lib.RAFT_LOGTYPE_REMOVE_NODE:
-        return 'remove'
     elif log_type == lib.RAFT_LOGTYPE_ADD_NONVOTING_NODE:
         return 'add_nonvoting'
     elif log_type == lib.RAFT_LOGTYPE_ADD_NODE:
@@ -862,23 +860,6 @@ class RaftServer(object):
             # if we are being demoted, commit suicide on demotion being applied
             if change.node_id == lib.raft_get_nodeid(self.raft):
                 logger.info("{} shutting down because of demotion".format(self))
-                return lib.RAFT_ERR_SHUTDOWN
-
-            # the leader issues a removal of the node after its demotion is applied
-            elif lib.raft_is_leader(self.raft):
-                logger.info(f"submitting a remove node entry for {change.node_id} on node {self.id}")
-                new_ety = self.network.add_entry(
-                    lib.RAFT_LOGTYPE_REMOVE_NODE,
-                    change)
-                assert(lib.raft_entry_is_cfg_change(new_ety))
-                e = self.recv_entry(new_ety)
-                assert e == 0
-            else:
-                logger.info(f"not doing anything for demote of {change.node_id} on {self.id} as {lib.raft_get_current_leader(self.raft)} is current leader")
-
-        elif ety.type == lib.RAFT_LOGTYPE_REMOVE_NODE:
-            if change.node_id == lib.raft_get_nodeid(self.raft):
-                logger.info("{} shutting down because of removal".format(self))
                 return lib.RAFT_ERR_SHUTDOWN
 
         elif ety.type == lib.RAFT_LOGTYPE_ADD_NODE:

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -1060,9 +1060,9 @@ class RaftServer(object):
         if ety.type == lib.RAFT_LOGTYPE_NO_OP:
             return 0
 
-        change = ffi.from_handle(lib.raft_entry_getdata(ety))
-        if ety.type == lib.RAFT_LOGTYPE_REMOVE_NODE:
-            pass
+        if (ety.type == lib.RAFT_LOGTYPE_REMOVE_NODE or
+                ety.type == lib.RAFT_LOGTYPE_ADD_NONVOTING_NODE or
+                ety.type == lib.RAFT_LOGTYPE_ADD_NODE):
 
             change = ffi.from_handle(lib.raft_entry_getdata(ety))
             server = self.network.id2server(change.node_id)


### PR DESCRIPTION
Until now, removing a node was split into 2 actions, demote and remove, this didn't fit with the raft paper itself, and caused problems for removing a leader.  This removed the REMOVE_NODE log message and includes its semantics in the apply of DEMOTE.

its possible we would want to rename DEMOTE to REMOVE?