### PR TITLE
attempt at fixing become_leader to be more sane

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -185,9 +185,9 @@ int raft_become_leader(raft_server_t* me_)
     noop->term = raft_get_current_term(me_);
     noop->type = RAFT_LOGTYPE_NO_OP;
     int e = raft_recv_entry(me_, noop, &response);
+    raft_entry_release(noop);
     if (0 != e)
         return e;
-    raft_entry_release(noop);
 
     me->timeout_elapsed = 0;
     if (me->cb.notify_state_event)

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -515,7 +515,8 @@ class Network(object):
         e = server.recv_entry(ety)
         assert e == 0
 
-        lib.raft_set_commit_idx(server.raft, 1)
+        idx = lib.raft_get_current_idx(server.raft)
+        lib.raft_set_commit_idx(server.raft, idx)
         e = lib.raft_apply_all(server.raft)
         assert e == 0
 


### PR DESCRIPTION
1) change become_leader to not directly append_entry or send_appendentries() itself, but to rely on recv_entry

this requires restructuring it.

2) this exposed issues in test code where the noop that has it become leader wasn't being comitted, so the count of entries for itself and other nodes was off, had to modify this in multiple places

3) the next_idx == last_log_idx + 1 test is no longer accurate for similar reason, as now the noop is the last_log_idx so it should be next_idx for all nodes