### PR TITLE
add an is_active_voter() function and fix/document all usages

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -166,6 +166,8 @@ raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
 
 int raft_node_is_active(raft_node_t* me_);
 
+int raft_node_is_active_voter(raft_node_t* me_);
+
 void raft_node_set_voting_committed(raft_node_t* me_, int voting);
 
 void raft_node_set_addition_committed(raft_node_t* me_, int committed);

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -129,7 +129,12 @@ void raft_node_set_voting(raft_node_t* me_, int voting)
 int raft_node_is_voting(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
-    return (me->flags & RAFT_NODE_VOTING && !(me->flags & RAFT_NODE_INACTIVE));
+    return me->flags & RAFT_NODE_VOTING;
+}
+
+int raft_node_is_active_voter(raft_node_t* me_)
+{
+    return raft_node_is_active(me_) && raft_node_is_voting(me_);
 }
 
 int raft_node_has_sufficient_logs(raft_node_t* me_)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -274,7 +274,7 @@ int raft_periodic(raft_server_t* me_, int msec_since_last_period)
          * happen when we get a client request */
         !raft_snapshot_is_in_progress(me_))
     {
-        if (1 < raft_get_num_voting_nodes(me_) && raft_node_is_active_voter(raft_get_my_node(me_))) // don't start election if not an active voter
+        if (1 < raft_get_num_voting_nodes(me_) && raft_node_is_voter(raft_get_my_node(me_))) // don't start election if not a voter (but can be inactive)
         {
             int e = raft_election_start(me_);
             if (0 != e)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -274,7 +274,7 @@ int raft_periodic(raft_server_t* me_, int msec_since_last_period)
          * happen when we get a client request */
         !raft_snapshot_is_in_progress(me_))
     {
-        if (1 < raft_get_num_voting_nodes(me_) && raft_node_is_voter(raft_get_my_node(me_))) // don't start election if not a voter (but can be inactive)
+        if (1 < raft_get_num_voting_nodes(me_) && raft_node_is_voting(raft_get_my_node(me_))) // don't start election if not a voter (but can be inactive)
         {
             int e = raft_election_start(me_);
             if (0 != e)

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -60,8 +60,9 @@ int raft_get_num_voting_nodes(raft_server_t* me_)
     raft_server_private_t* me = (raft_server_private_t*)me_;
     int i, num = 0;
     for (i = 0; i < me->num_nodes; i++)
-        if (raft_node_is_active(me->nodes[i]) && raft_node_is_voting(me->nodes[i]))
+        if (raft_node_is_active_voter(me->nodes[i])) {
             num++;
+        }
     return num;
 }
 
@@ -279,5 +280,5 @@ int raft_is_single_node_voting_cluster(raft_server_t *me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
 
-    return (1 == raft_get_num_voting_nodes(me_) && raft_node_is_voting(me->node));
+    return (1 == raft_get_num_voting_nodes(me_) && raft_node_is_active_voter(me->node));
 }


### PR DESCRIPTION
we changed raft_node_is_voting() to check if the node was active, this is problematic as some usages only cared if the voting flag was set

we introduce a new function raft_node_is_active_voter() that does the above change and revert raft_node_is_voting() to old behavior

in addition, a lot of documentation on its uages to make clear why one was chosen