### PR TITLE
Fix: read operations will count acks correctly

### DIFF
--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -60,7 +60,7 @@ int raft_get_num_voting_nodes(raft_server_t* me_)
     raft_server_private_t* me = (raft_server_private_t*)me_;
     int i, num = 0;
     for (i = 0; i < me->num_nodes; i++)
-        if (raft_node_is_active(me->nodes[i]) && raft_node_is_voting(me->nodes[i]))
+        if (raft_node_is_voting(me->nodes[i]))
             num++;
     return num;
 }


### PR DESCRIPTION
Read operations used to miscalculate acks from the cluster. This caused even sized clusters process read operations with one less ack than required (possible linearizability violation).

e.g
Before the fix : msg_ids[3, 4, 5, 6] -> quorum was 5
After the fix : msg_ids[3, 4, 5, 6] -> quorum is 4 