### PR TITLE
Code refactor

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -845,11 +845,11 @@ void* raft_node_get_udata(raft_node_t* me);
 void raft_node_set_udata(raft_node_t* me, void* user_data);
 
 /**
- * After sending the snapshot, library user can set next index for the node
+ * After sending the snapshot, user can set the next index for the node
  *
  * @param[in] node node
  * @param[in] idx next entry index */
-void raft_node_set_next_idx(raft_node_t* me_, raft_index_t idx);
+void raft_node_set_next_idx(raft_node_t* me, raft_index_t idx);
 
 /**
  * @param[in] idx The entry's index

--- a/include/raft.h
+++ b/include/raft.h
@@ -30,7 +30,7 @@ typedef enum {
 
 #define RAFT_REQUESTVOTE_ERR_GRANTED          1
 #define RAFT_REQUESTVOTE_ERR_NOT_GRANTED      0
-#define RAFT_REQUESTVOTE_ERR_UNKNOWN_NODE    -1
+#define RAFT_REQUESTVOTE_ERR_UNKNOWN_NODE    (-1)
 
 typedef enum {
     RAFT_STATE_NONE,
@@ -628,7 +628,7 @@ raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
 
 /** De-initialise Raft server.
  * Frees all memory */
-void raft_free(raft_server_t* me);
+void raft_destroy(raft_server_t* me_);
 
 /** De-initialise Raft server. */
 void raft_clear(raft_server_t* me);
@@ -659,8 +659,6 @@ void raft_set_callbacks(raft_server_t* me, raft_cbs_t* funcs, void* user_data);
  *  node if it was successfully added;
  *  NULL if the node already exists */
 raft_node_t* raft_add_node(raft_server_t* me, void* user_data, raft_node_id_t id, int is_self);
-
-#define raft_add_peer raft_add_node
 
 /** Add a node which does not participate in voting.
  * If a node already exists the call will fail.
@@ -847,6 +845,13 @@ void* raft_node_get_udata(raft_node_t* me);
 void raft_node_set_udata(raft_node_t* me, void* user_data);
 
 /**
+ * After sending the snapshot, library user can set next index for the node
+ *
+ * @param[in] node node
+ * @param[in] idx next entry index */
+void raft_node_set_next_idx(raft_node_t* me_, raft_index_t idx);
+
+/**
  * @param[in] idx The entry's index
  * @return entry from index */
 raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, raft_index_t idx);
@@ -854,13 +859,13 @@ raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, raft_index_t idx);
 /**
  * @param[in] node The node's ID
  * @return node pointed to by node ID */
-raft_node_t* raft_get_node(raft_server_t* me_, const raft_node_id_t id);
+raft_node_t* raft_get_node(raft_server_t* me_, raft_node_id_t id);
 
 /**
  * Used for iterating through nodes
  * @param[in] node The node's idx
  * @return node pointed to by node idx */
-raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const raft_index_t idx);
+raft_node_t* raft_get_node_from_idx(raft_server_t* me_, raft_index_t idx);
 
 /**
  * @return number of votes this server has received this election */
@@ -896,14 +901,14 @@ int raft_vote(raft_server_t* me_, raft_node_t* node);
  * @param[in] nodeid The server to vote for by nodeid
  * @return
  *  0 on success */
-int raft_vote_for_nodeid(raft_server_t* me_, const raft_node_id_t nodeid);
+int raft_vote_for_nodeid(raft_server_t* me_, raft_node_id_t nodeid);
 
 /** Set the current term.
  * This should be used to reload persistent state, ie. the current_term field.
  * @param[in] term The new current term
  * @return
  *  0 on success */
-int raft_set_current_term(raft_server_t* me, const raft_term_t term);
+int raft_set_current_term(raft_server_t* me, raft_term_t term);
 
 /** Set the commit idx.
  * This should be used to reload persistent state, ie. the commit_idx field.

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -43,7 +43,7 @@ int log_poll(log_t * me_, void** etyp);
 /** Get an array of entries from this index onwards.
  * This is used for batching.
  */
-raft_entry_t** log_get_from_idx(log_t* me_, raft_index_t idx, int *n_etys);
+raft_entry_t** log_get_from_idx(log_t* me_, raft_index_t idx, long *n_etys);
 
 raft_entry_t* log_get_at_idx(log_t* me_, raft_index_t idx);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -126,29 +126,17 @@ int raft_send_appendentries_all(raft_server_t* me_);
  * @return 1 if entry committed, 0 otherwise */
 int raft_apply_entry(raft_server_t* me_);
 
-/**
- * Appends entry using the current term.
- * Note: we make the assumption that current term is up-to-date
- * @return 0 if unsuccessful */
-int raft_append_entry(raft_server_t* me_, raft_entry_t* c);
-
 void raft_set_last_applied_idx(raft_server_t* me, raft_index_t idx);
 
 void raft_set_state(raft_server_t* me_, int state);
-
-int raft_get_state(raft_server_t* me_);
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id);
 
 void raft_node_free(raft_node_t* me_);
 
-void raft_node_set_next_idx(raft_node_t* node, raft_index_t nextIdx);
+void raft_node_set_match_idx(raft_node_t* node, raft_index_t idx);
 
-void raft_node_set_match_idx(raft_node_t* node, raft_index_t matchIdx);
-
-raft_index_t raft_node_get_match_idx(raft_node_t* me_);
-
-void raft_node_vote_for_me(raft_node_t* me_, const int vote);
+void raft_node_vote_for_me(raft_node_t* me_, int vote);
 
 int raft_node_has_vote_for_me(raft_node_t* me_);
 
@@ -156,32 +144,18 @@ void raft_node_set_has_sufficient_logs(raft_node_t* me_);
 
 int raft_is_single_node_voting_cluster(raft_server_t *me_);
 
-int raft_votes_is_majority(const int nnodes, const int nvotes);
-
-void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, const raft_index_t idx);
-
-void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const raft_index_t idx);
+int raft_votes_is_majority(int nnodes, int nvotes);
 
 raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
-
-int raft_node_is_active(raft_node_t* me_);
-
-void raft_node_set_voting_committed(raft_node_t* me_, int voting);
-
-void raft_node_set_addition_committed(raft_node_t* me_, int committed);
 
 void raft_node_set_last_ack(raft_node_t* me_, raft_msg_id_t msgid, raft_term_t term);
 
 raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me_);
 
-raft_term_t raft_node_get_last_acked_term(raft_node_t* me_);
-
-void raft_process_read_queue(raft_server_t* me_);
-
 /* Heap functions */
-extern void *(*__raft_malloc)(size_t size);
-extern void *(*__raft_calloc)(size_t nmemb, size_t size);
-extern void *(*__raft_realloc)(void *ptr, size_t size);
-extern void (*__raft_free)(void *ptr);
+extern void *(*raft_malloc)(size_t size);
+extern void *(*raft_calloc)(size_t nmemb, size_t size);
+extern void *(*raft_realloc)(void *ptr, size_t size);
+extern void (*raft_free)(void *ptr);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -165,7 +165,7 @@ int log_append_entry(log_t* me_, raft_entry_t* ety)
     return 0;
 }
 
-raft_entry_t** log_get_from_idx(log_t* me_, raft_index_t idx, int *n_etys)
+raft_entry_t** log_get_from_idx(log_t* me_, raft_index_t idx, long *n_etys)
 {
     log_private_t* me = (log_private_t*)me_;
     raft_index_t i;
@@ -183,14 +183,12 @@ raft_entry_t** log_get_from_idx(log_t* me_, raft_index_t idx, int *n_etys)
 
     i = (me->front + idx - me->base) % me->size;
 
-    long logs_till_end_of_log;
-
+    /* log entries until the end of the log */
     if (i < me->back)
-        logs_till_end_of_log = me->back - i;
+        *n_etys = me->back - i;
     else
-        logs_till_end_of_log = me->size - i;
+        *n_etys = me->size - i;
 
-    *n_etys = (int) logs_till_end_of_log;
     return &me->entries[i];
 }
 
@@ -376,7 +374,7 @@ static raft_entry_t *__log_get(void *log, raft_index_t idx)
 
 static int __log_get_batch(void *log, raft_index_t idx, int entries_n, raft_entry_t **entries)
 {
-    int n, i;
+    long n, i;
     raft_entry_t **r = log_get_from_idx(log, idx, &n);
 
     if (!r || n < 1) {
@@ -390,7 +388,7 @@ static int __log_get_batch(void *log, raft_index_t idx, int entries_n, raft_entr
         entries[i] = r[i];
         raft_entry_hold(entries[i]);
     }
-    return n;
+    return (int) n;
 }
 
 static int __log_pop(void *log, raft_index_t from_idx, func_entry_notify_f cb, void *cb_arg)

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -8,9 +8,7 @@
  * @author Willem Thiart himself@willemthiart.com
  */
 
-#include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 #include <assert.h>
 
 #include "raft.h"
@@ -55,7 +53,7 @@ static int __ensurecapacity(log_private_t * me)
     if (me->count < me->size)
         return 0;
 
-    temp = (raft_entry_t**)__raft_calloc(1, sizeof(raft_entry_t *) * me->size * 2);
+    temp = raft_calloc(1, sizeof(raft_entry_t *) * me->size * 2);
     if (!temp)
         return RAFT_ERR_NOMEM;
 
@@ -67,7 +65,7 @@ static int __ensurecapacity(log_private_t * me)
     }
 
     /* clean up old entries */
-    __raft_free(me->entries);
+    raft_free(me->entries);
 
     me->size *= 2;
     me->entries = temp;
@@ -89,14 +87,14 @@ int log_load_from_snapshot(log_t *me_, raft_index_t idx, raft_term_t term)
 
 log_t* log_alloc(raft_index_t initial_size)
 {
-    log_private_t* me = (log_private_t*)__raft_calloc(1, sizeof(log_private_t));
+    log_private_t* me = raft_calloc(1, sizeof(log_private_t));
     if (!me)
         return NULL;
     me->size = initial_size;
     log_clear((log_t*)me);
-    me->entries = (raft_entry_t**)__raft_calloc(1, sizeof(raft_entry_t *) * me->size);
+    me->entries = raft_calloc(1, sizeof(raft_entry_t *) * me->size);
     if (!me->entries) {
-        __raft_free(me);
+        raft_free(me);
         return NULL;
     }
     return (log_t*)me;
@@ -185,14 +183,14 @@ raft_entry_t** log_get_from_idx(log_t* me_, raft_index_t idx, int *n_etys)
 
     i = (me->front + idx - me->base) % me->size;
 
-    int logs_till_end_of_log;
+    long logs_till_end_of_log;
 
     if (i < me->back)
         logs_till_end_of_log = me->back - i;
     else
         logs_till_end_of_log = me->size - i;
 
-    *n_etys = logs_till_end_of_log;
+    *n_etys = (int) logs_till_end_of_log;
     return &me->entries[i];
 }
 
@@ -312,8 +310,8 @@ void log_free(log_t * me_)
 {
     log_private_t* me = (log_private_t*)me_;
 
-    __raft_free(me->entries);
-    __raft_free(me);
+    raft_free(me->entries);
+    raft_free(me);
 }
 
 raft_index_t log_get_current_idx(log_t* me_)

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -9,9 +9,7 @@
  * @version 0.1
  */
 
-#include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 #include <assert.h>
 
 #include "raft.h"
@@ -43,9 +41,11 @@ typedef struct
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
 {
     raft_node_private_t* me;
-    me = (raft_node_private_t*)__raft_calloc(1, sizeof(raft_node_private_t));
+
+    me = raft_calloc(1, sizeof(raft_node_private_t));
     if (!me)
         return NULL;
+
     me->udata = udata;
     me->next_idx = 1;
     me->match_idx = 0;
@@ -56,7 +56,7 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
 
 void raft_node_free(raft_node_t* me_)
 {
-    __raft_free(me_);
+    raft_free(me_);
 }
 
 raft_index_t raft_node_get_next_idx(raft_node_t* me_)
@@ -65,11 +65,11 @@ raft_index_t raft_node_get_next_idx(raft_node_t* me_)
     return me->next_idx;
 }
 
-void raft_node_set_next_idx(raft_node_t* me_, raft_index_t nextIdx)
+void raft_node_set_next_idx(raft_node_t* me_, raft_index_t idx)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     /* log index begins at 1 */
-    me->next_idx = nextIdx < 1 ? 1 : nextIdx;
+    me->next_idx = idx < 1 ? 1 : idx;
 }
 
 raft_index_t raft_node_get_match_idx(raft_node_t* me_)
@@ -78,10 +78,10 @@ raft_index_t raft_node_get_match_idx(raft_node_t* me_)
     return me->match_idx;
 }
 
-void raft_node_set_match_idx(raft_node_t* me_, raft_index_t matchIdx)
+void raft_node_set_match_idx(raft_node_t* me_, raft_index_t idx)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
-    me->match_idx = matchIdx;
+    me->match_idx = idx;
 }
 
 void* raft_node_get_udata(raft_node_t* me_)
@@ -206,10 +206,4 @@ raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->last_acked_msgid;
-}
-
-raft_term_t raft_node_get_last_acked_term(raft_node_t* me_)
-{
-    raft_node_private_t* me = (raft_node_private_t*)me_;
-    return me->last_acked_term;
 }

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -18,7 +18,6 @@
 #include <stdarg.h>
 
 #include "raft.h"
-#include "raft_log.h"
 #include "raft_private.h"
 
 #ifndef min
@@ -29,20 +28,20 @@
 #define max(a, b) ((a) < (b) ? (b) : (a))
 #endif
 
-void *(*__raft_malloc)(size_t) = malloc;
-void *(*__raft_calloc)(size_t, size_t) = calloc;
-void *(*__raft_realloc)(void *, size_t) = realloc;
-void (*__raft_free)(void *) = free;
+void *(*raft_malloc)(size_t) = malloc;
+void *(*raft_calloc)(size_t, size_t) = calloc;
+void *(*raft_realloc)(void *, size_t) = realloc;
+void (*raft_free)(void *) = free;
 
 void raft_set_heap_functions(void *(*_malloc)(size_t),
                              void *(*_calloc)(size_t, size_t),
                              void *(*_realloc)(void *, size_t),
                              void (*_free)(void *))
 {
-    __raft_malloc = _malloc;
-    __raft_calloc = _calloc;
-    __raft_realloc = _realloc;
-    __raft_free = _free;
+    raft_malloc = _malloc;
+    raft_calloc = _calloc;
+    raft_realloc = _realloc;
+    raft_free = _free;
 }
 
 static void raft_log(raft_server_t *me_, raft_node_t* node, const char *fmt, ...)
@@ -76,8 +75,7 @@ void raft_randomize_election_timeout(raft_server_t* me_)
 
 raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
 {
-    raft_server_private_t* me =
-        (raft_server_private_t*)__raft_calloc(1, sizeof(raft_server_private_t));
+    raft_server_private_t* me = raft_calloc(1, sizeof(raft_server_private_t));
     if (!me)
         return NULL;
     me->current_term = 0;
@@ -89,7 +87,7 @@ raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
     me->log_impl = log_impl;
     me->log = me->log_impl->init(me, log_arg);
     if (!me->log) {
-        __raft_free(me);
+        raft_free(me);
         return NULL;
     }
     me->voting_cfg_change_log_idx = -1;
@@ -101,8 +99,6 @@ raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
 
     return (raft_server_t*)me;
 }
-
-extern raft_log_impl_t log_internal_impl;
 
 raft_server_t* raft_new(void)
 {
@@ -117,12 +113,12 @@ void raft_set_callbacks(raft_server_t* me_, raft_cbs_t* funcs, void* udata)
     me->udata = udata;
 }
 
-void raft_free(raft_server_t* me_)
+void raft_destroy(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
 
     me->log_impl->free(me->log);
-    __raft_free(me_);
+    raft_free(me_);
 }
 
 void raft_clear(raft_server_t* me_)
@@ -141,6 +137,185 @@ void raft_clear(raft_server_t* me_)
     me->num_nodes = 0;
     me->node = NULL;
     me->log_impl->reset(me->log, 1, 1);
+}
+
+raft_node_t* raft_add_node_internal(raft_server_t* me_, raft_entry_t *ety, void* udata, raft_node_id_t id, int is_self)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+
+    /* set to voting if node already exists */
+    raft_node_t* node = raft_get_node(me_, id);
+    if (node)
+    {
+        if (!raft_node_is_voting(node))
+        {
+            raft_node_set_voting(node, 1);
+            return node;
+        }
+        else
+            /* we shouldn't add a node twice */
+            return NULL;
+    }
+
+    node = raft_node_new(udata, id);
+    if (!node)
+        return NULL;
+
+    void* p = raft_realloc(me->nodes, sizeof(void*) * (me->num_nodes + 1));
+    if (!p) {
+        raft_node_free(node);
+        return NULL;
+    }
+    me->num_nodes++;
+    me->nodes = p;
+    me->nodes[me->num_nodes - 1] = node;
+    if (is_self)
+        me->node = me->nodes[me->num_nodes - 1];
+
+    node = me->nodes[me->num_nodes - 1];
+
+    if (me->cb.notify_membership_event)
+        me->cb.notify_membership_event(me_, raft_get_udata(me_), node, ety, RAFT_MEMBERSHIP_ADD);
+
+    return node;
+}
+
+static raft_node_t* raft_add_non_voting_node_internal(raft_server_t* me_, raft_entry_t *ety, void* udata, raft_node_id_t id, int is_self)
+{
+    if (raft_get_node(me_, id))
+        return NULL;
+
+    raft_node_t* node = raft_add_node_internal(me_, ety, udata, id, is_self);
+    if (!node)
+        return NULL;
+
+    raft_node_set_voting(node, 0);
+    return node;
+}
+
+raft_node_t* raft_add_node(raft_server_t* me_, void* udata, raft_node_id_t id, int is_self)
+{
+    return raft_add_node_internal(me_, NULL, udata, id, is_self);
+}
+
+raft_node_t* raft_add_non_voting_node(raft_server_t* me_, void* udata, raft_node_id_t id, int is_self)
+{
+    return raft_add_non_voting_node_internal(me_, NULL, udata, id, is_self);
+}
+
+void raft_remove_node(raft_server_t* me_, raft_node_t* node)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+
+    if (me->cb.notify_membership_event)
+        me->cb.notify_membership_event(me_, raft_get_udata(me_), node, NULL, RAFT_MEMBERSHIP_REMOVE);
+
+    assert(node);
+
+    int i, found = 0;
+    for (i = 0; i < me->num_nodes; i++)
+    {
+        if (me->nodes[i] == node)
+        {
+            found = 1;
+            break;
+        }
+    }
+    assert(found);
+    memmove(&me->nodes[i], &me->nodes[i + 1], sizeof(*me->nodes) * (me->num_nodes - i - 1));
+    me->num_nodes--;
+
+    /* if we are removing the current leader, have to reset it, as this data is now stale */
+    raft_node_t *current_leader_node = raft_get_current_leader_node(me_);
+    if (node == current_leader_node) {
+        me->current_leader = NULL;
+    }
+
+    raft_node_free(node);
+}
+
+void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_index_t idx)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+
+    if (!raft_entry_is_cfg_change(ety))
+        return;
+
+    if (!me->cb.log_get_node_id)
+        return;
+
+    void* udata = raft_get_udata(me_);
+    raft_node_id_t node_id = me->cb.log_get_node_id(me_, udata, ety, idx);
+    raft_node_t* node = raft_get_node(me_, node_id);
+    int is_self = node_id == raft_get_nodeid(me_);
+
+    switch (ety->type)
+    {
+        case RAFT_LOGTYPE_ADD_NONVOTING_NODE:
+            if (!is_self)
+            {
+                if (node && !raft_node_is_active(node))
+                {
+                    raft_node_set_active(node, 1);
+                }
+                else if (!node)
+                {
+                    node = raft_add_non_voting_node_internal(me_, ety, NULL, node_id, is_self);
+                    assert(node);
+                }
+             }
+            break;
+
+        case RAFT_LOGTYPE_ADD_NODE:
+            node = raft_add_node_internal(me_, ety, NULL, node_id, is_self);
+            assert(node);
+            assert(raft_node_is_voting(node));
+            break;
+
+        case RAFT_LOGTYPE_REMOVE_NODE:
+            if (node) {
+                raft_node_set_active(node, 0);
+            }
+            break;
+
+        default:
+            assert(0);
+    }
+}
+
+void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const raft_index_t idx)
+{
+    raft_server_private_t* me = (raft_server_private_t*) me_;
+
+    if (!raft_entry_is_cfg_change(ety))
+        return;
+
+    if (!me->cb.log_get_node_id)
+        return;
+
+    void* udata = raft_get_udata(me_);
+    raft_node_id_t node_id = me->cb.log_get_node_id(me_, udata, ety, idx);
+    raft_node_t* node = raft_get_node(me_, node_id);
+
+    switch (ety->type)
+    {
+        case RAFT_LOGTYPE_REMOVE_NODE:
+            raft_node_set_active(node, 1);
+            break;
+
+        case RAFT_LOGTYPE_ADD_NONVOTING_NODE:
+            assert(node_id != raft_get_nodeid(me_));
+            raft_remove_node(me_, node);
+            break;
+
+        case RAFT_LOGTYPE_ADD_NODE:
+            raft_node_set_voting(node, 0);
+            break;
+
+        default:
+            assert(0);
+            break;
+    }
 }
 
 int raft_delete_entry_from_idx(raft_server_t* me_, raft_index_t idx)
@@ -408,10 +583,10 @@ int raft_recv_appendentries_response(raft_server_t* me_,
             int votes = raft_node_is_voting(me->node) ? 1 : 0;
             for (int i = 0; i < me->num_nodes; i++)
             {
-                raft_node_t* node = me->nodes[i];
-                if (me->node != node &&
-                    raft_node_is_voting(node) &&
-                    point <= raft_node_get_match_idx(node))
+                raft_node_t* follower = me->nodes[i];
+                if (me->node != follower &&
+                    raft_node_is_voting(follower) &&
+                    point <= raft_node_get_match_idx(follower))
                 {
                     votes++;
                 }
@@ -594,7 +769,7 @@ int raft_already_voted(raft_server_t* me_)
     return ((raft_server_private_t*)me_)->voted_for != -1;
 }
 
-static int __should_grant_vote(raft_server_t* me_, msg_requestvote_t* vr)
+static int raft_should_grant_vote(raft_server_t* me_, msg_requestvote_t* vr)
 {
     if (!raft_node_is_voting(raft_get_my_node(me_)))
         return 0;
@@ -654,7 +829,7 @@ int raft_recv_requestvote(raft_server_t* me_,
         me->current_leader = NULL;
     }
 
-    if (__should_grant_vote(me_, vr))
+    if (raft_should_grant_vote(me_, vr))
     {
         /* It shouldn't be possible for a leader or candidate to grant a vote
          * Both states would have voted for themselves */
@@ -668,7 +843,6 @@ int raft_recv_requestvote(raft_server_t* me_,
 
         /* must be in an election. */
         me->current_leader = NULL;
-
         me->timeout_elapsed = 0;
     }
     else
@@ -715,24 +889,18 @@ int raft_recv_requestvote_response(raft_server_t* me_,
           r->vote_granted == 1 ? "granted" :
           r->vote_granted == 0 ? "not granted" : "unknown");
 
-    if (!raft_is_candidate(me_))
+    if (!raft_is_candidate(me_) || raft_get_current_term(me_) > r->term)
     {
         return 0;
     }
-    else if (raft_get_current_term(me_) < r->term)
+
+    if (raft_get_current_term(me_) < r->term)
     {
         int e = raft_set_current_term(me_, r->term);
         if (0 != e)
             return e;
         raft_become_follower(me_);
         me->current_leader = NULL;
-        return 0;
-    }
-    else if (raft_get_current_term(me_) != r->term)
-    {
-        /* The node who voted for us would have obtained our term.
-         * Therefore this is an old message we should ignore.
-         * This happens if the network is pretty choppy. */
         return 0;
     }
 
@@ -948,12 +1116,12 @@ raft_entry_t** raft_get_entries_from_idx(raft_server_t* me_, raft_index_t idx, i
     }
 
     raft_server_private_t* me = (raft_server_private_t*)me_;
-    int size = raft_get_current_idx(me_) - idx + 1;
-    raft_entry_t **e = __raft_malloc(size * sizeof(raft_entry_t*));
-    int n = me->log_impl->get_batch(me->log, idx, size, e);
+    raft_index_t size = raft_get_current_idx(me_) - idx + 1;
+    raft_entry_t **e = raft_malloc(size * sizeof(raft_entry_t*));
+    int n = me->log_impl->get_batch(me->log, idx, (int) size, e);
 
     if (n < 1) {
-        __raft_free(e);
+        raft_free(e);
         *n_etys = 0;
         return NULL;
     }
@@ -1022,7 +1190,7 @@ int raft_send_appendentries(raft_server_t* me_, raft_node_t* node)
 
     int res = me->cb.send_appendentries(me_, me->udata, node, &ae);
     raft_entry_release_list(ae.entries, ae.n_entries);
-    __raft_free(ae.entries);
+    raft_free(ae.entries);
 
     return res;
 }
@@ -1045,100 +1213,6 @@ int raft_send_appendentries_all(raft_server_t* me_)
     }
 
     return ret;
-}
-
-raft_node_t* raft_add_node_internal(raft_server_t* me_, raft_entry_t *ety, void* udata, raft_node_id_t id, int is_self)
-{
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    /* set to voting if node already exists */
-    raft_node_t* node = raft_get_node(me_, id);
-    if (node)
-    {
-        if (!raft_node_is_voting(node))
-        {
-            raft_node_set_voting(node, 1);
-            return node;
-        }
-        else
-            /* we shouldn't add a node twice */
-            return NULL;
-    }
-
-    node = raft_node_new(udata, id);
-    if (!node)
-        return NULL;
-    void* p = __raft_realloc(me->nodes, sizeof(void*) * (me->num_nodes + 1));
-    if (!p) {
-        raft_node_free(node);
-        return NULL;
-    }
-    me->num_nodes++;
-    me->nodes = p;
-    me->nodes[me->num_nodes - 1] = node;
-    if (is_self)
-        me->node = me->nodes[me->num_nodes - 1];
-
-    node = me->nodes[me->num_nodes - 1];
-
-    if (me->cb.notify_membership_event)
-        me->cb.notify_membership_event(me_, raft_get_udata(me_), node, ety, RAFT_MEMBERSHIP_ADD);
-
-    return node;
-}
-
-raft_node_t* raft_add_node(raft_server_t* me_, void* udata, raft_node_id_t id, int is_self)
-{
-    return raft_add_node_internal(me_, NULL, udata, id, is_self);
-}
-
-static raft_node_t* raft_add_non_voting_node_internal(raft_server_t* me_, raft_entry_t *ety, void* udata, raft_node_id_t id, int is_self)
-{
-    if (raft_get_node(me_, id))
-        return NULL;
-
-    raft_node_t* node = raft_add_node_internal(me_, ety, udata, id, is_self);
-    if (!node)
-        return NULL;
-
-    raft_node_set_voting(node, 0);
-    return node;
-}
-
-raft_node_t* raft_add_non_voting_node(raft_server_t* me_, void* udata, raft_node_id_t id, int is_self)
-{
-    return raft_add_non_voting_node_internal(me_, NULL, udata, id, is_self);
-}
-
-void raft_remove_node(raft_server_t* me_, raft_node_t* node)
-{
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    if (me->cb.notify_membership_event)
-        me->cb.notify_membership_event(me_, raft_get_udata(me_), node, NULL, RAFT_MEMBERSHIP_REMOVE);
-
-    assert(node);
-
-    int i, found = 0;
-    for (i = 0; i < me->num_nodes; i++)
-    {
-        if (me->nodes[i] == node)
-        {
-            found = 1;
-            break;
-        }
-    }
-    assert(found);
-    memmove(&me->nodes[i], &me->nodes[i + 1], sizeof(*me->nodes) * (me->num_nodes - i - 1));
-    me->num_nodes--;
-
-    /* if we are removing the current leader, have to reset it, as this data is now stale */
-    raft_node_t *current_leader_node = raft_get_current_leader_node(me_);
-    if (node == current_leader_node) {
-        me->current_leader = NULL;
-    }
-
-    raft_node_free(node);
 }
 
 int raft_get_nvotes_for_me(raft_server_t* me_)
@@ -1224,99 +1298,6 @@ int raft_entry_is_cfg_change(raft_entry_t* ety)
         RAFT_LOGTYPE_REMOVE_NODE == ety->type);
 }
 
-void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_index_t idx)
-{
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    if (!raft_entry_is_cfg_change(ety))
-        return;
-
-    if (!me->cb.log_get_node_id)
-        return;
-
-    raft_node_id_t node_id = me->cb.log_get_node_id(me_, raft_get_udata(me_), ety, idx);
-    raft_node_t* node = raft_get_node(me_, node_id);
-    int is_self = node_id == raft_get_nodeid(me_);
-
-    switch (ety->type)
-    {
-        case RAFT_LOGTYPE_ADD_NONVOTING_NODE:
-            if (!is_self)
-            {
-                if (node && !raft_node_is_active(node))
-                {
-                    raft_node_set_active(node, 1);
-                }
-                else if (!node)
-                {
-                    node = raft_add_non_voting_node_internal(me_, ety, NULL, node_id, is_self);
-                    assert(node);
-                }
-            }
-            break;
-
-        case RAFT_LOGTYPE_ADD_NODE:
-            node = raft_add_node_internal(me_, ety, NULL, node_id, is_self);
-            assert(node);
-            assert(raft_node_is_voting(node));
-            break;
-
-        case RAFT_LOGTYPE_REMOVE_NODE:
-            if (node) {
-                raft_node_set_active(node, 0);
-            }
-
-            break;
-
-        default:
-            assert(0);
-    }
-}
-
-void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const raft_index_t idx)
-{
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    if (!raft_entry_is_cfg_change(ety))
-        return;
-
-    if (!me->cb.log_get_node_id)
-        return;
-
-    raft_node_id_t node_id = me->cb.log_get_node_id(me_, raft_get_udata(me_), ety, idx);
-
-    switch (ety->type)
-    {
-        case RAFT_LOGTYPE_REMOVE_NODE:
-            {
-            raft_node_t* node = raft_get_node(me_, node_id);
-            raft_node_set_active(node, 1);
-            }
-            break;
-
-        case RAFT_LOGTYPE_ADD_NONVOTING_NODE:
-            {
-            int is_self = node_id == raft_get_nodeid(me_);
-            raft_node_t* node = raft_get_node(me_, node_id);
-            raft_remove_node(me_, node);
-            if (is_self)
-                assert(0);
-            }
-            break;
-
-        case RAFT_LOGTYPE_ADD_NODE:
-            {
-            raft_node_t* node = raft_get_node(me_, node_id);
-            raft_node_set_voting(node, 0);
-            }
-            break;
-
-        default:
-            assert(0);
-            break;
-    }
-}
-
 int raft_poll_entry(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
@@ -1369,7 +1350,7 @@ int raft_begin_snapshot(raft_server_t *me_, int flags)
         return -1;
 
     raft_index_t snapshot_target = raft_get_commit_idx(me_);
-    if (!snapshot_target || snapshot_target == 0)
+    if (!snapshot_target)
         return -1;
 
     raft_entry_t* ety = raft_get_entry_from_idx(me_, snapshot_target);
@@ -1551,7 +1532,7 @@ void *raft_get_log(raft_server_t *me_)
 
 raft_entry_t *raft_entry_new(unsigned int data_len)
 {
-    raft_entry_t *ety = __raft_calloc(1, sizeof(raft_entry_t) + data_len);
+    raft_entry_t *ety = raft_calloc(1, sizeof(raft_entry_t) + data_len);
     ety->data_len = data_len;
     ety->refs = 1;
 
@@ -1573,7 +1554,7 @@ void raft_entry_release(raft_entry_t *ety)
         if (ety->free_func) {
             ety->free_func(ety);
         } else {
-            __raft_free(ety);
+            raft_free(ety);
         }
     }
 }
@@ -1630,7 +1611,7 @@ void raft_queue_read_request(raft_server_t* me_, func_read_request_callback_f cb
 {
     raft_server_private_t* me = (raft_server_private_t*) me_;
 
-    raft_read_request_t *req = __raft_malloc(sizeof(raft_read_request_t));
+    raft_read_request_t *req = raft_malloc(sizeof(raft_read_request_t));
 
     req->read_idx = raft_get_current_idx(me_);
     req->read_term = raft_get_current_term(me_);
@@ -1664,7 +1645,7 @@ static void pop_read_queue(raft_server_private_t *me, int can_read)
         me->read_queue_tail = NULL;
     }
 
-    __raft_free(p);
+    raft_free(p);
 }
 
 void raft_process_read_queue(raft_server_t* me_)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -19,11 +19,15 @@
 #include "raft_private.h"
 
 #ifndef min
-#define min(a, b) ((a) < (b) ? (a) : (b))
+    #define min(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
 #ifndef max
-#define max(a, b) ((a) < (b) ? (b) : (a))
+    #define max(a, b) ((a) < (b) ? (b) : (a))
+#endif
+
+#ifndef __GNUC__
+    #define __attribute__(a)
 #endif
 
 void *(*raft_malloc)(size_t) = malloc;

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -7,16 +7,10 @@
  * @author Willem Thiart himself@willemthiart.com
  */
 
-#include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 #include <assert.h>
 
-/* for varags */
-#include <stdarg.h>
-
 #include "raft.h"
-#include "raft_log.h"
 #include "raft_private.h"
 
 void raft_set_election_timeout(raft_server_t* me_, int millisec)

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -511,7 +511,7 @@ void TestLog_get_from_idx_with_base_off_by_one(CuTest * tc)
     CuAssertIntEquals(tc, 1, log_count(l));
 
     /* get off-by-one index */
-    int n_etys;
+    long n_etys;
     CuAssertPtrEquals(tc, log_get_from_idx(l, 1, &n_etys), NULL);
     CuAssertIntEquals(tc, n_etys, 0);
 


### PR DESCRIPTION
A bit of code refactor, to list a few things : 

- Added `raft_node_set_next_idx()` to the API which can be used by the application after loading the snapshot.
- Removed duplicate declarations for functions in raft_private.h and raft.h
- Removed leftover code pieces
- Removed unnecessary malloc casts.
- Fixed some Clang-tidy warnings:
   - Fixed type conversations 
   - Removed const declarations in function prototypes for basic data types.
   - Removed unused imports
   - Renamed symbols starting with "__". It is reserved by the C implementation.