### PR TITLE
add a read_queue test to virtraft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,19 @@ tests_full:
 .PHONY: test_virtraft
 test_virtraft:
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 
 .PHONY: amalgamation
 amalgamation:

--- a/include/raft.h
+++ b/include/raft.h
@@ -196,7 +196,10 @@ typedef struct
 typedef struct
 {
     /** the msg_id this response refers to */
-    unsigned long msg_id;
+    raft_msg_id_t msg_id;
+
+    /** used for helping make msg_id always increasing (though not strictly) across cluster: needed for testing */
+    raft_msg_id_t node_msg_id;
 
     /** currentTerm, to force other leader/candidate to step down */
     raft_term_t term;

--- a/include/raft.h
+++ b/include/raft.h
@@ -198,9 +198,6 @@ typedef struct
     /** the msg_id this response refers to */
     raft_msg_id_t msg_id;
 
-    /** used for helping make msg_id always increasing (though not strictly) across cluster: needed for testing */
-    raft_msg_id_t node_msg_id;
-
     /** currentTerm, to force other leader/candidate to step down */
     raft_term_t term;
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -166,4 +166,14 @@ extern void *(*raft_calloc)(size_t nmemb, size_t size);
 extern void *(*raft_realloc)(void *ptr, size_t size);
 extern void (*raft_free)(void *ptr);
 
+/* get the read_queue_id
+ * this will either be the last sent, or the last valid one recieved from leader
+ */
+raft_msg_id_t raft_get_msg_id(raft_server_t* me_);
+
+/* get an array of raft_node_id_t of the known voting nodes
+ * needs to be freed by caller
+ */
+raft_node_id_t * raft_get_voting_node_ids(raft_server_t* me_);
+
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -109,6 +109,10 @@ typedef struct {
      * we're still the leader.
      */
     raft_msg_id_t msg_id;
+    /*
+     * the maximum msg_id we've seen from our current leader.  reset on term change
+     */
+    raft_msg_id_t max_seen_msg_id;
     raft_read_request_t *read_queue_head;
     raft_read_request_t *read_queue_tail;
 } raft_server_private_t;
@@ -166,14 +170,10 @@ extern void *(*raft_calloc)(size_t nmemb, size_t size);
 extern void *(*raft_realloc)(void *ptr, size_t size);
 extern void (*raft_free)(void *ptr);
 
-/* get the read_queue_id
- * this will either be the last sent, or the last valid one recieved from leader
- */
+/* get the max message id this server has seen from its current leader, reset to 0 on term change */
+raft_msg_id_t raft_get_max_seen_msg_id(raft_server_t* me_);
+/* get the server's (primarily for leader) current msg_id */
 raft_msg_id_t raft_get_msg_id(raft_server_t* me_);
 
-/* get an array of raft_node_id_t of the known voting nodes
- * needs to be freed by caller
- */
-raft_node_id_t * raft_get_voting_node_ids(raft_server_t* me_);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -608,10 +608,6 @@ int raft_recv_appendentries_response(raft_server_t* me_,
     if (!raft_is_leader(me_))
         return RAFT_ERR_NOT_LEADER;
 
-    if (r->node_msg_id > me->msg_id) {
-        me->msg_id = r->node_msg_id;
-    }
-
     if (raft_node_get_last_acked_msgid(node) > r->msg_id) {
         // this was received out of order and is now irrelevant.
         return 0;
@@ -734,8 +730,6 @@ int raft_recv_appendentries(
     }
 
     r->msg_id = ae->msg_id;
-    // enable leader to increase msg_id, if this node's msg_id is greater, to synchronize cluster for virtraft
-    r->node_msg_id = me->msg_id;
 
     r->prev_log_idx = ae->prev_log_idx;
     r->success = 0;
@@ -743,6 +737,7 @@ int raft_recv_appendentries(
     if (raft_is_candidate(me_) && me->current_term == ae->term)
     {
         raft_become_follower(me_);
+        me->max_seen_msg_id = 0;
     }
     else if (me->current_term < ae->term)
     {
@@ -750,6 +745,7 @@ int raft_recv_appendentries(
         if (0 != e)
             goto out;
         raft_become_follower(me_);
+        me->max_seen_msg_id = 0;
     }
     else if (ae->term < me->current_term)
     {
@@ -758,6 +754,10 @@ int raft_recv_appendentries(
                     "AE term %ld is less than current term %ld",
                     ae->term, me->current_term);
         goto out;
+    }
+
+    if (me->max_seen_msg_id < ae->msg_id) {
+        me->max_seen_msg_id = ae->msg_id;
     }
 
     /* update current leader because ae->term is up to date */
@@ -817,9 +817,10 @@ int raft_recv_appendentries(
 
     r->success = 1;
     r->current_idx = ae->prev_log_idx;
-    // synchronize msg_id to leader.  not really needed for raft, but needed for virtraft for msg_id to be increasing
-    // cluster wide so that can verify read_queue correctness easily.  Otherwise, it be fine for msg_id to be unique to
-    // each raft_server_t.
+    /* synchronize msg_id to leader.  not really needed for raft, but needed for virtraft for msg_id to be increasing
+     * cluster wide so that can verify read_queue correctness easily.  Otherwise, it be fine for msg_id to be unique to
+     * each raft_server_t.
+     */
     if (ae->msg_id > me->msg_id) {
         me->msg_id = ae->msg_id;
     }

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -737,7 +737,6 @@ int raft_recv_appendentries(
     if (raft_is_candidate(me_) && me->current_term == ae->term)
     {
         raft_become_follower(me_);
-        me->max_seen_msg_id = 0;
     }
     else if (me->current_term < ae->term)
     {
@@ -745,7 +744,6 @@ int raft_recv_appendentries(
         if (0 != e)
             goto out;
         raft_become_follower(me_);
-        me->max_seen_msg_id = 0;
     }
     else if (ae->term < me->current_term)
     {

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -282,3 +282,9 @@ raft_msg_id_t raft_get_msg_id(raft_server_t* me_)
     raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->msg_id;
 }
+
+raft_msg_id_t raft_get_max_seen_msg_id(raft_server_t* me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    return me->max_seen_msg_id;
+}

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -276,3 +276,27 @@ int raft_is_single_node_voting_cluster(raft_server_t *me_)
 
     return (1 == raft_get_num_voting_nodes(me_) && raft_node_is_voting(me->node));
 }
+
+raft_msg_id_t raft_get_msg_id(raft_server_t* me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    return me->msg_id;
+}
+
+raft_node_id_t * raft_get_voting_node_ids(raft_server_t* me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    raft_node_id_t * ret = raft_malloc(sizeof(int)*me->num_nodes);
+    if (ret == NULL) {
+        return NULL;
+    }
+
+    int i, num = 0;
+    for (i = 0; i < me->num_nodes; i++) {
+        if (raft_node_is_voting(me->nodes[i])) {
+            ret[num++] = raft_node_get_id(me->nodes[i]);
+        }
+    }
+
+    return ret;
+}

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -93,6 +93,7 @@ int raft_set_current_term(raft_server_t* me_, const raft_term_t term)
         }
         me->current_term = term;
         me->voted_for = voted_for;
+        me->max_seen_msg_id = 0;
     }
     return 0;
 }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -282,21 +282,3 @@ raft_msg_id_t raft_get_msg_id(raft_server_t* me_)
     raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->msg_id;
 }
-
-raft_node_id_t * raft_get_voting_node_ids(raft_server_t* me_)
-{
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-    raft_node_id_t * ret = raft_malloc(sizeof(int)*me->num_nodes);
-    if (ret == NULL) {
-        return NULL;
-    }
-
-    int i, num = 0;
-    for (i = 0; i < me->num_nodes; i++) {
-        if (raft_node_is_voting(me->nodes[i])) {
-            ret[num++] = raft_node_get_id(me->nodes[i]);
-        }
-    }
-
-    return ret;
-}

--- a/tests/raft_cffi.py
+++ b/tests/raft_cffi.py
@@ -48,6 +48,7 @@ def load(fname):
 
 ffi.cdef('void *malloc(size_t __size);')
 ffi.cdef(load('include/raft.h'))
+ffi.cdef(load('include/raft_private.h'))
 ffi.cdef(load('include/raft_log.h'))
 
 ffi.cdef('raft_entry_t *raft_entry_newdata(void *data);')

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -234,6 +234,7 @@ def find_leader():
 
     return leader
 
+
 def get_voting_node_ids(leader):
     voting_nodes_ids = []
 

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -222,6 +222,23 @@ def raft_notify_membership_event(raft, udata, node, ety, event_type):
     return ffi.from_handle(udata).notify_membership_event(node, ety, event_type)
 
 
+class ReadQueueEntry(object):
+    def __init__(self, network):
+        self.network = network
+        self.iteration = network.iteration
+
+
+def handle_read_queue(arg, can_read):
+    val = int(ffi.cast("int", arg))
+    if can_read != 0:
+        logger.debug(f"handling read_request {val}")
+        if net.last_read_iteration < val:
+            net.last_read_iteration = val
+    else:
+        logger.debug(f"ignoring read_request {val}")
+
+
+
 def raft_log(raft, node, udata, buf):
     server = ffi.from_handle(lib.raft_get_udata(raft))
     # if server.id in [1] or (node and node.id in [1]):
@@ -292,6 +309,12 @@ class Network(object):
                 assert e == 0 or e == lib.RAFT_ERR_NOT_LEADER
                 break
 
+    def push_read(self):
+        for sv in self.active_servers:
+            if lib.raft_is_leader(sv.raft):
+                logger.debug(f"adding a read_request to {sv.id}")
+                lib.raft_queue_read_request(sv.raft, sv.handle_read_queue, ffi.cast("void *", sv.network.iteration))
+
     def id2server(self, id):
         for server in self.servers:
             if server.id == id:
@@ -342,13 +365,18 @@ class Network(object):
                 server.periodic(self.random.randint(1, 100))
 
         # Deadlock detection
-        if self.latest_applied_log_idx != 0 and self.latest_applied_log_iteration + 5000 < self.iteration:
+        if self.client_rate != 0 and self.latest_applied_log_idx != 0 and self.latest_applied_log_iteration + 5000 < self.iteration:
             logger.error("deadlock detected iteration:{0} appliedidx:{1}\n".format(
                 self.latest_applied_log_iteration,
                 self.latest_applied_log_idx,
                 ))
             self.diagnostic_info()
             sys.exit(1)
+
+        if self.last_read_iteration + 5000 < self.iteration:
+            logger.error("deadlock detected in handling reads: last_read from iteration {0} current at {1}\n".format(
+                self.last_read_iteration, self.iteration,
+            ))
 
         # Count leadership changes
         assert len(self.active_servers) > 0, self.diagnostic_info()
@@ -369,6 +397,7 @@ class Network(object):
         for partition in self.partitions:
             # Partitions are in one direction
             if partition[0] is sendor and partition[1] is sendee:
+                logger.info(f"dropping message from {sendor.id} to {sendee.id}")
                 return
             # duplex partitions prevent both directions from sending traffic
             if self.duplex_partition and (
@@ -789,6 +818,7 @@ class RaftServer(object):
         self.raft_node_has_sufficient_logs = ffi.callback("int(raft_server_t* raft, void *user_data, raft_node_t* node)", raft_node_has_sufficient_logs)
         self.raft_notify_membership_event = ffi.callback("void(raft_server_t* raft, void *user_data, raft_node_t* node, raft_entry_t* ety, raft_membership_e)", raft_notify_membership_event)
         self.raft_log = ffi.callback("void(raft_server_t*, raft_node_id_t, void*, const char* buf)", raft_log)
+        self.handle_read_queue = ffi.callback("void(void *arg, int can_read)", handle_read_queue)
 
     def recv_entry(self, ety):
         # FIXME: leak
@@ -1039,7 +1069,7 @@ class RaftServer(object):
 
     def entry_append(self, ety, ety_idx):
         try:
-            assert not self.fsm_log or self.fsm_log[-1].term <= ety.term
+            assert not self.fsm_log or self.fsm_log[-1].term <= ety.term, f"node {self.id}'s term {self.fsm_log[-1].term} > to entry term {ety.term}"
         except Exception as e:
             self.abort_exception = e
             # FIXME: consider returning RAFT_ERR_SHUTDOWN
@@ -1180,6 +1210,7 @@ if __name__ == '__main__':
             logger.addHandler(fh)
             logger.propagate = False
 
+    global net
     net = Network(int(args['--seed']))
 
     net.dupe_rate = int(args['--dupe_rate'])
@@ -1204,6 +1235,8 @@ if __name__ == '__main__':
     for i in range(0, int(args['--iterations'])):
         net.iteration += 1
         try:
+            net.push_read()
+            net.poll_messages()
             net.periodic()
             net.poll_messages()
         except:

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -263,14 +263,10 @@ def verify_read(arg):
     required = int(num_nodes / 2) + 1
     count = 0
 
-    for i in voter_ids:
-        if lib.raft_is_leader(net.servers[i-1].raft) == 1:
-            leader_id = i
-
     leader_term = lib.raft_get_current_term(net.servers[leader.id-1].raft)
 
     for i in voter_ids:
-        if lib.raft_is_leader(net.servers[i-1].raft):
+        if net.servers[i-1] == leader:
             count += 1
             continue
 


### PR DESCRIPTION
every iteration we push a read_queue request and the handler and "arg" we pass to it set a variable on calling.  we can use this to make sure that the read_queue doesn't get too far from the iteration.

this is analagoues to the current deadlock test.

in the future, we will also test for correctness, that the other nodes confirm to virtraft that they have gotten the msgid that corresponds to allowing this