### PR TITLE
support "read_queue_id" testing in virtraft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,19 @@ tests_full:
 .PHONY: test_virtraft
 test_virtraft:
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 
 .PHONY: amalgamation
 amalgamation:

--- a/include/raft.h
+++ b/include/raft.h
@@ -164,7 +164,7 @@ typedef struct
 typedef struct
 {
     /** id, to make it possible to associate responses with requests. */
-    raft_msg_id_t msg_id;
+    raft_read_queue_id_t read_queue_id;
 
     /** currentTerm, to force other leader/candidate to step down */
     raft_term_t term;
@@ -193,8 +193,8 @@ typedef struct
  * This message could force a leader/candidate to become a follower. */
 typedef struct
 {
-    /** the msg_id this response refers to */
-    unsigned long msg_id;
+    /** the read_queue_id this response refers to */
+    unsigned long read_queue_id;
 
     /** currentTerm, to force other leader/candidate to step down */
     raft_term_t term;
@@ -1217,4 +1217,5 @@ void raft_queue_read_request(raft_server_t* me_, func_read_request_callback_f cb
  */
 void raft_process_read_queue(raft_server_t* me_);
 
+raft_node_id_t * raft_get_voting_node_ids(raft_server_t* me_);
 #endif /* RAFT_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -25,7 +25,7 @@ typedef struct raft_read_request {
     raft_index_t read_idx;
     raft_term_t read_term;
 
-    raft_msg_id_t msg_id;
+    raft_read_queue_id_t read_queue_id;
     func_read_request_callback_f cb;
     void *cb_arg;
 
@@ -102,7 +102,7 @@ typedef struct {
     /* Read requests that await a network round trip to confirm
      * we're still the leader.
      */
-    raft_msg_id_t msg_id;
+    raft_read_queue_id_t read_queue_id;
     raft_read_request_t *read_queue_head;
     raft_read_request_t *read_queue_tail;
 } raft_server_private_t;
@@ -126,17 +126,9 @@ int raft_send_appendentries_all(raft_server_t* me_);
  * @return 1 if entry committed, 0 otherwise */
 int raft_apply_entry(raft_server_t* me_);
 
-/**
- * Appends entry using the current term.
- * Note: we make the assumption that current term is up-to-date
- * @return 0 if unsuccessful */
-int raft_append_entry(raft_server_t* me_, raft_entry_t* c);
-
 void raft_set_last_applied_idx(raft_server_t* me, raft_index_t idx);
 
 void raft_set_state(raft_server_t* me_, int state);
-
-int raft_get_state(raft_server_t* me_);
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id);
 
@@ -145,8 +137,6 @@ void raft_node_free(raft_node_t* me_);
 void raft_node_set_next_idx(raft_node_t* node, raft_index_t nextIdx);
 
 void raft_node_set_match_idx(raft_node_t* node, raft_index_t matchIdx);
-
-raft_index_t raft_node_get_match_idx(raft_node_t* me_);
 
 void raft_node_vote_for_me(raft_node_t* me_, const int vote);
 
@@ -158,30 +148,25 @@ int raft_is_single_node_voting_cluster(raft_server_t *me_);
 
 int raft_votes_is_majority(const int nnodes, const int nvotes);
 
-void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, const raft_index_t idx);
-
 void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const raft_index_t idx);
 
 raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
 
-int raft_node_is_active(raft_node_t* me_);
+void raft_node_set_last_ack(raft_node_t* me_, raft_read_queue_id_t msgid, raft_term_t term);
 
-void raft_node_set_voting_committed(raft_node_t* me_, int voting);
-
-void raft_node_set_addition_committed(raft_node_t* me_, int committed);
-
-void raft_node_set_last_ack(raft_node_t* me_, raft_msg_id_t msgid, raft_term_t term);
-
-raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me_);
+raft_read_queue_id_t raft_node_get_last_acked_read_queue_id(raft_node_t* me_);
 
 raft_term_t raft_node_get_last_acked_term(raft_node_t* me_);
-
-void raft_process_read_queue(raft_server_t* me_);
 
 /* Heap functions */
 extern void *(*__raft_malloc)(size_t size);
 extern void *(*__raft_calloc)(size_t nmemb, size_t size);
 extern void *(*__raft_realloc)(void *ptr, size_t size);
 extern void (*__raft_free)(void *ptr);
+
+/* get the read_queue_id
+ * this will either be the last sent, or the last valid one recieved from leader
+ */
+raft_read_queue_id_t raft_get_read_queue_id(raft_server_t* me_);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -26,8 +26,8 @@ typedef long int raft_index_t;
 typedef int raft_node_id_t;
 
 /**
- * Unique message identifier.
+ * Unique identifier to synchronize reads
  */
-typedef unsigned long raft_msg_id_t;
+typedef unsigned long raft_read_queue_id_t;
 
 #endif  /* RAFT_DEFS_H_ */

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -37,7 +37,7 @@ typedef struct
 
     /* last AE heartbeat response received */
     raft_term_t last_acked_term;
-    raft_msg_id_t last_acked_msgid;
+    raft_read_queue_id_t last_acked_read_queue_id;
 } raft_node_private_t;
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
@@ -195,17 +195,17 @@ int raft_node_is_addition_committed(raft_node_t* me_)
     return (me->flags & RAFT_NODE_ADDITION_COMMITTED) != 0;
 }
 
-void raft_node_set_last_ack(raft_node_t* me_, raft_msg_id_t msgid, raft_term_t term)
+void raft_node_set_last_ack(raft_node_t* me_, raft_read_queue_id_t read_queue_id, raft_term_t term)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
-    me->last_acked_msgid = msgid;
+    me->last_acked_read_queue_id = read_queue_id;
     me->last_acked_term = term;
 }
 
-raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me_)
+raft_read_queue_id_t raft_node_get_last_acked_read_queue_id(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
-    return me->last_acked_msgid;
+    return me->last_acked_read_queue_id;
 }
 
 raft_term_t raft_node_get_last_acked_term(raft_node_t* me_)

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -281,3 +281,27 @@ int raft_is_single_node_voting_cluster(raft_server_t *me_)
 
     return (1 == raft_get_num_voting_nodes(me_) && raft_node_is_voting(me->node));
 }
+
+raft_read_queue_id_t raft_get_read_queue_id(raft_server_t* me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    return me->read_queue_id;
+}
+
+raft_node_id_t * raft_get_voting_node_ids(raft_server_t* me_)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    raft_node_id_t * ret = __raft_malloc(sizeof(int)*me->num_nodes);
+    if (ret == NULL) {
+        return NULL;
+    }
+
+    int i, num = 0;
+    for (i = 0; i < me->num_nodes; i++) {
+        if (raft_node_is_voting(me->nodes[i])) {
+            ret[num++] = raft_node_get_id(me->nodes[i]);
+        }
+    }
+
+    return ret;
+}

--- a/tests/raft_cffi.py
+++ b/tests/raft_cffi.py
@@ -48,6 +48,7 @@ def load(fname):
 
 ffi.cdef('void *malloc(size_t __size);')
 ffi.cdef(load('include/raft.h'))
+ffi.cdef(load('include/raft_private.h'))
 ffi.cdef(load('include/raft_log.h'))
 
 ffi.cdef('raft_entry_t *raft_entry_newdata(void *data);')

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -230,13 +230,11 @@ class ReadQueueEntry(object):
 def verify_read(arg):
     # cffi magic explanation, as didn't see this documented anywhere
     # 1. normal call
-    ret = lib.raft_get_voting_node_ids(net.leader.raft)
+    voter_ids = lib.raft_get_voting_node_ids(net.leader.raft)
     # 2. setup the pointer we were returned to be garbage collected, with libraft's free
-    ret = ffi.gc(ret, lib.__raft_free)
-    # 3. for the ability to turn pointer/array into a python list, get its length
+    voter_ids = ffi.gc(voter_ids, lib.__raft_free)
+    # 3. need to know length of array, so we don't go past it.
     num_nodes = lib.raft_get_num_voting_nodes(net.leader.raft)
-    # 4. covnvert to a python list
-    voter_ids = ffi.unpack(ret, num_nodes)
 
     # primary verification logic.  we always need to count more than the required, looking to see that for voters,
     # the read_queue_id they have recorded is equal to our greater than the arg (i.e. the read_queue id this was sent on


### PR DESCRIPTION
before in virtraft, we didn't have the ability to test the read_queue if it was behaving correctly, this adds that functionality
    
in order to get there, we did a few things
    
1) rename msg_id to read_queue_id everywhere (as its not really a message id, it determines an entry in the read queue, and that's it)
2) every raft server will update it's read_queue id from the appendentry from the leader, before it didn't do that, it just used it in the append_entry_response.
    
this is necessary, as otherwise, read_queue id's would always reset from 0 and we wouldn't have good accuracy, now they are more or less always increasing (we still could have a situation where they are out of sync, might want to add a term comparison in as well)
    
3) removed duplicate prototypes that were in raft_private.h that were also in raft.h, while this didn't cause gcc itself any problems, it caused cffi problems when raft_private.h was added to it
    
4) add a function raft_get_read_queue_id() that returns the server's current read_queue_id (remember, updated on appendentry) so that we can read its current value during testing
    
5) add a function raft_get_voting_node_ids(raft_server_t* me_) that returns an array of raft_node_id's of the servers voting nodes, used for testing
    
6) add a verify_read() function to virtraft that on each read_queue handler call, will verify that a majority of nodes read_queue_id >= to the desired value
