### PR TITLE
don't pipeline appendentries to unacknowledged followers

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -166,4 +166,7 @@ extern void *(*raft_calloc)(size_t nmemb, size_t size);
 extern void *(*raft_realloc)(void *ptr, size_t size);
 extern void (*raft_free)(void *ptr);
 
+void raft_node_set_responded_to_leader(raft_node_t* me_);
+void raft_node_reset_responded_to_leader(raft_node_t* me_);
+int raft_node_get_responded_to_leader(raft_node_t* me_);
 #endif /* RAFT_PRIVATE_H_ */

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -36,6 +36,7 @@ typedef struct
     /* last AE heartbeat response received */
     raft_term_t last_acked_term;
     raft_msg_id_t last_acked_msgid;
+    int responded_to_leader;
 } raft_node_private_t;
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
@@ -51,6 +52,7 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
     me->match_idx = 0;
     me->id = id;
     me->flags = RAFT_NODE_VOTING;
+    me->responded_to_leader = 1;
     return (raft_node_t*)me;
 }
 
@@ -206,4 +208,22 @@ raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->last_acked_msgid;
+}
+
+void raft_node_set_responded_to_leader(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    me->responded_to_leader = 1;
+}
+
+void raft_node_reset_responded_to_leader(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    me->responded_to_leader = 0;
+}
+
+int raft_node_get_responded_to_leader(raft_node_t* me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return me->responded_to_leader;
 }

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -2961,6 +2961,7 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
     /* become leader sets next_idx to current_idx */
     raft_become_leader(r);
     raft_node_t* node = raft_get_node(r, 2);
+    raft_node_set_responded_to_leader(node);
     CuAssertIntEquals(tc, 5, raft_node_get_next_idx(node));
     CuAssertTrue(tc, NULL != (ae = sender_poll_msg_data(sender)));
 
@@ -3015,6 +3016,7 @@ void TestRaft_leader_recv_appendentries_response_decrements_to_lower_next_idx(
     /* become leader sets next_idx to current_idx */
     raft_become_leader(r);
     raft_node_t* node = raft_get_node(r, 2);
+    raft_node_set_responded_to_leader(node);
     CuAssertIntEquals(tc, 5, raft_node_get_next_idx(node));
     CuAssertTrue(tc, NULL != (ae = sender_poll_msg_data(sender)));
 
@@ -3514,6 +3516,8 @@ void TestRaft_leader_sends_empty_appendentries_every_request_timeout(
     /* candidate to leader */
     raft_set_state(r, RAFT_STATE_CANDIDATE);
     raft_become_leader(r);
+    raft_node_set_responded_to_leader(raft_get_node(r, 2));
+    raft_node_set_responded_to_leader(raft_get_node(r, 3));
 
     /* receive appendentries messages for both nodes */
     msg_appendentries_t* ae;

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -346,9 +346,10 @@ class Network(object):
 
         # Deadlock detection
         if self.latest_applied_log_idx != 0 and self.latest_applied_log_iteration + 5000 < self.iteration:
-            logger.error("deadlock detected iteration:{0} appliedidx:{1}\n".format(
+            logger.error("deadlock detected iteration:{0} appliedidx:{1} iteration{2}\n".format(
                 self.latest_applied_log_iteration,
                 self.latest_applied_log_idx,
+                self.iteration,
                 ))
             self.diagnostic_info()
             sys.exit(1)


### PR DESCRIPTION
when we become leader, we don't know the state of the other nodes, so we set their next_idx to what would be our next_idx.

this enables us to send an empty appendentries to the other nodes on become leader where we will get a response back to their existing position

however, we then can call send_appendentries again before we get a response, so we be resetting node state on the second one in an inconsistent manner

therefore, dont send another appendentries to a followr until we get a response.

this assumes, reliable medium (i.e. if we dont get a response for the first, we wont get a response for the second or further).  so worse case scenario, the non responding node will time out and try to cause an election.