### PR TITLE
Separating configuration and cluster operations (RPC handling, starting elections and replication)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,14 +211,14 @@ When we receive an entry log from the client it's possible we might not be a lea
 
 If we aren't currently the leader of the raft cluster, we MUST send a redirect error message to the client. This is so that the client can connect directly to the leader in future connections. This enables future requests to be faster (ie. no redirects are required after the first redirect until the leader changes).
 
-We use the ``raft_get_current_leader`` function to check who is the current leader.
+We use the ``raft_get_leader_id`` function to check who is the current leader.
 
 *Example of ticketd sending a 301 HTTP redirect response:*
 
 .. code-block:: c
 
     /* redirect to leader if needed */
-    raft_node_t* leader = raft_get_current_leader_node(sv->raft);
+    raft_node_t* leader = raft_get_leader_node(sv->raft);
     if (!leader)
     {
         return h2oh_respond_with_error(req, 503, "Leader unavailable");

--- a/include/raft.h
+++ b/include/raft.h
@@ -159,7 +159,8 @@ typedef struct
  * This message could force a leader/candidate to become a follower. */
 typedef struct
 {
-    /** sender node id **/
+    /** used to identify the sender node. Useful when this message is received
+     * from the nodes that are not part of the configuration yet. **/
     raft_node_id_t leader_id;
 
     /** id, to make it possible to associate responses with requests. */
@@ -876,13 +877,13 @@ int raft_get_voted_for(raft_server_t* me);
 
 /** Get what this node thinks the node ID of the leader is.
  * @return node of what this node thinks is the valid leader;
- *   -1 if the leader is unknown */
-raft_node_id_t raft_get_leader_id(raft_server_t*me_);
+ *   -1 if there is no leader */
+raft_node_id_t raft_get_leader_id(raft_server_t* me);
 
 /** Get what this node thinks the node of the leader is.
  * @return node of what this node thinks is the valid leader;
- *   NULL if the leader is unknown */
-raft_node_t*raft_get_leader_node(raft_server_t* me);
+ *   NULL if there is no leader */
+raft_node_t* raft_get_leader_node(raft_server_t* me);
 
 /**
  * @return callback user data */

--- a/include/raft.h
+++ b/include/raft.h
@@ -28,10 +28,6 @@ typedef enum {
     RAFT_MEMBERSHIP_REMOVE,
 } raft_membership_e;
 
-#define RAFT_REQUESTVOTE_ERR_GRANTED          1
-#define RAFT_REQUESTVOTE_ERR_NOT_GRANTED      0
-#define RAFT_REQUESTVOTE_ERR_UNKNOWN_NODE    (-1)
-
 typedef enum {
     RAFT_STATE_NONE,
     RAFT_STATE_FOLLOWER,
@@ -163,6 +159,9 @@ typedef struct
  * This message could force a leader/candidate to become a follower. */
 typedef struct
 {
+    /** sender node id **/
+    raft_node_id_t leader_id;
+
     /** id, to make it possible to associate responses with requests. */
     raft_msg_id_t msg_id;
 
@@ -878,12 +877,12 @@ int raft_get_voted_for(raft_server_t* me);
 /** Get what this node thinks the node ID of the leader is.
  * @return node of what this node thinks is the valid leader;
  *   -1 if the leader is unknown */
-raft_node_id_t raft_get_current_leader(raft_server_t* me);
+raft_node_id_t raft_get_leader_id(raft_server_t*me_);
 
 /** Get what this node thinks the node of the leader is.
  * @return node of what this node thinks is the valid leader;
  *   NULL if the leader is unknown */
-raft_node_t* raft_get_current_leader_node(raft_server_t* me);
+raft_node_t*raft_get_leader_node(raft_server_t* me);
 
 /**
  * @return callback user data */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -74,9 +74,9 @@ typedef struct {
     /* latest quorum id for the previous quorum_timeout round */
     raft_msg_id_t last_acked_msg_id;
 
-    /* what this node thinks is the node ID of the current leader, or -1 if
+    /* what this node thinks is the node ID of the current leader, or NULL if
      * there isn't a known current leader. */
-    raft_node_id_t leader;
+    raft_node_t* leader;
 
     /* callbacks */
     raft_cbs_t cb;
@@ -84,7 +84,14 @@ typedef struct {
 
     /* my node ID */
     raft_node_t* node;
-    raft_node_t* unknown_leader;
+
+    /*
+     * If the leader node is not part of the configuration yet, we'll use this
+     * node object for it. e.g : Current node is joining to a cluster. It didn't
+     * get the latest configuration yet, so, leader node is not the part of the
+     * current node's configuration.
+     */
+    raft_node_t* unknown_node;
 
     /* the log which has a voting cfg change, otherwise -1 */
     raft_index_t voting_cfg_change_log_idx;

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -74,9 +74,9 @@ typedef struct {
     /* latest quorum id for the previous quorum_timeout round */
     raft_msg_id_t last_acked_msg_id;
 
-    /* what this node thinks is the node ID of the current leader, or NULL if
+    /* what this node thinks is the node ID of the current leader, or -1 if
      * there isn't a known current leader. */
-    raft_node_t* current_leader;
+    raft_node_id_t leader;
 
     /* callbacks */
     raft_cbs_t cb;
@@ -84,6 +84,7 @@ typedef struct {
 
     /* my node ID */
     raft_node_t* node;
+    raft_node_t* unknown_leader;
 
     /* the log which has a voting cfg change, otherwise -1 */
     raft_index_t voting_cfg_change_log_idx;
@@ -143,6 +144,8 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id);
 void raft_node_free(raft_node_t* me_);
 
 void raft_node_set_match_idx(raft_node_t* node, raft_index_t idx);
+
+void raft_node_update_id(raft_node_t* me_, raft_node_id_t id);
 
 void raft_node_vote_for_me(raft_node_t* me_, int vote);
 

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -184,13 +184,12 @@ void raft_node_update_id(raft_node_t* me_, raft_node_id_t id)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
 
-    if (me->id == id) {
-        return;
+    if (me->id != id) {
+        // Clear user data if we are changing the id
+        me->udata = NULL;
     }
 
     me->id = id;
-    me->udata = NULL;
-    me->flags = 0;
 }
 
 void raft_node_set_addition_committed(raft_node_t* me_, int committed)

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -185,7 +185,10 @@ void raft_node_update_id(raft_node_t* me_, raft_node_id_t id)
     raft_node_private_t* me = (raft_node_private_t*)me_;
 
     if (me->id != id) {
-        // Clear user data if we are changing the id
+        /*
+         * Clear user data if we are changing the id. Users may set user data
+         * for unknown nodes by reaching to the node object.
+         */
         me->udata = NULL;
     }
 

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -180,6 +180,19 @@ raft_node_id_t raft_node_get_id(raft_node_t* me_)
     return me != NULL ? me->id : -1;
 }
 
+void raft_node_update_id(raft_node_t* me_, raft_node_id_t id)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+
+    if (me->id == id) {
+        return;
+    }
+
+    me->id = id;
+    me->udata = NULL;
+    me->flags = 0;
+}
+
 void raft_node_set_addition_committed(raft_node_t* me_, int committed)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -749,6 +749,10 @@ int raft_recv_appendentries(raft_server_t* me_,
     }
 
     if (node == NULL) {
+        /**
+         * We've accepted the request but we don't have this node in the
+         * configuration. Assign its id to the dummy unknown node object.
+         */
         raft_node_update_id(me->unknown_node, ae->leader_id);
         node = me->unknown_node;
     }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -137,7 +137,7 @@ void raft_set_state(raft_server_t* me_, int state)
     raft_server_private_t* me = (raft_server_private_t*)me_;
     /* if became the leader, then update the current leader entry */
     if (state == RAFT_STATE_LEADER) {
-        me->leader = raft_node_get_id(me->node);
+        me->leader = me->node;
     }
 
     me->state = state;
@@ -175,32 +175,19 @@ raft_node_t* raft_get_my_node(raft_server_t *me_)
 raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const raft_index_t idx)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
-
     return me->nodes[idx];
 }
 
 raft_node_id_t raft_get_leader_id(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
-    return me->leader;
+    return raft_node_get_id(me->leader);
 }
 
 raft_node_t* raft_get_leader_node(raft_server_t* me_)
 {
-    raft_server_private_t* me = (void*) me_;
-
-    if (me->leader == -1) {
-        return NULL;
-    }
-
-    raft_node_t* node = raft_get_node(me_, me->leader);
-    if (node == NULL) {
-        if (me->leader == raft_node_get_id(me->unknown_leader)) {
-            node = me->unknown_leader;
-        }
-    }
-
-    return node;
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    return me->leader;
 }
 
 void* raft_get_udata(raft_server_t* me_)

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -136,8 +136,10 @@ void raft_set_state(raft_server_t* me_, int state)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     /* if became the leader, then update the current leader entry */
-    if (state == RAFT_STATE_LEADER)
-        me->current_leader = me->node;
+    if (state == RAFT_STATE_LEADER) {
+        me->leader = raft_node_get_id(me->node);
+    }
+
     me->state = state;
 }
 
@@ -173,21 +175,32 @@ raft_node_t* raft_get_my_node(raft_server_t *me_)
 raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const raft_index_t idx)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
+
     return me->nodes[idx];
 }
 
-raft_node_id_t raft_get_current_leader(raft_server_t* me_)
+raft_node_id_t raft_get_leader_id(raft_server_t* me_)
 {
-    raft_server_private_t* me = (void*)me_;
-    if (me->current_leader)
-        return raft_node_get_id(me->current_leader);
-    return -1;
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    return me->leader;
 }
 
-raft_node_t* raft_get_current_leader_node(raft_server_t* me_)
+raft_node_t* raft_get_leader_node(raft_server_t* me_)
 {
-    raft_server_private_t* me = (void*)me_;
-    return me->current_leader;
+    raft_server_private_t* me = (void*) me_;
+
+    if (me->leader == -1) {
+        return NULL;
+    }
+
+    raft_node_t* node = raft_get_node(me_, me->leader);
+    if (node == NULL) {
+        if (me->leader == raft_node_get_id(me->unknown_leader)) {
+            node = me->unknown_leader;
+        }
+    }
+
+    return node;
 }
 
 void* raft_get_udata(raft_server_t* me_)

--- a/tests/test_log_impl.c
+++ b/tests/test_log_impl.c
@@ -1,9 +1,7 @@
-#include <stdbool.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdint.h>
+
 #include "CuTest.h"
 
 #include "linked_list_queue.h"

--- a/tests/test_node.c
+++ b/tests/test_node.c
@@ -1,13 +1,7 @@
-#include <stdbool.h>
-#include <assert.h>
-#include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
-#include <stdint.h>
 #include "CuTest.h"
 
 #include "raft.h"
-#include "raft_log.h"
 #include "raft_private.h"
 
 void TestRaft_is_voting_by_default(CuTest * tc)

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -1960,7 +1960,7 @@ void TestRaft_follower_recv_appendentries_resets_election_timeout(
 
     raft_set_election_timeout(r, 1000);
     raft_add_node(r, NULL, 1, 1);
-    raft_add_node(r, NULL, 2, 1);
+    raft_add_node(r, NULL, 2, 0);
 
     raft_periodic(r, 900);
 

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -355,7 +355,7 @@ class Network(object):
 
         # Count leadership changes
         assert len(self.active_servers) > 0, self.diagnostic_info()
-        leader_node = lib.raft_get_current_leader_node(self.active_servers[0].raft)
+        leader_node = lib.raft_get_leader_node(self.active_servers[0].raft)
         if leader_node:
             leader = ffi.from_handle(lib.raft_node_get_udata(leader_node))
             if self.leader is not leader:
@@ -1140,7 +1140,7 @@ class RaftServer(object):
             "snapshot": lib.raft_get_snapshot_last_idx(self.raft),
             "removed": getattr(self, 'removed', False),
             "partitioned": partitioned_from,
-            "leader": lib.raft_get_current_leader(self.raft),
+            "leader": lib.raft_get_leader_id(self.raft),
         }
 
 


### PR DESCRIPTION
**Description :** 

- A node should vote for another node which is not part of the current configuration. 
- A node should accept append entries requests from the nodes that are not part of the configuration. 
- A node should start an election even it's not part of the cluster configuration
- A node should replicate removal entry of itself and stay as the leader until it's committed

**Related parts from Raft dissertation :** 

>  • In Raft, it is the caller’s configuration that is used in reaching consensus, both for voting and for
log replication:

> • A server accepts AppendEntries requests from a leader that is not part of the server’s latest
     configuration. Otherwise, a new server could never be added to the cluster (it would never
     accept any log entries preceding the configuration entry that adds the server).

> • A server also grants its vote to a candidate that is not part of the server’s latest configuration (if
     the candidate has a sufficiently up-to-date log and a current term). This vote may occasionally
     be needed to keep the cluster available. For example, consider adding a fourth server to a
     three-server cluster. If one server were to fail, the new server’s vote would be needed to form
     a majority and elect a leader.

>  • Thus, servers process incoming RPC requests without consulting their current configurations.

>  • This approach leads to two implications about decision-making that are not particularly harmful
but may be surprising. First, there will be a period of time (while it is committing Cnew) when a
leader can manage a cluster that does not include itself; it replicates log entries but does not count
itself in majorities. Second, a server that is not part of its own latest configuration should still start
new elections, as it might still be needed until the Cnew entry is committed (as in Figure 4.6). It does
not count its own vote in elections unless it is part of its latest configuration.


**Implementation :**

1 - Voting for unknown nodes
   - `msg_requestvote_t` has already `raft_node_id_t candidate_id;` field. In case `raft_recv_requestvote()` is called with a NULL node object (for a node which is not part of the configuration), we can just use `candidate_id` and vote for it.

2 - Accepting append requests from the unknown node : 
   - Added `raft_node_id_t leader_id` to the `msg_appendentries_t `. In case we don't have a node object for the node (for a node which is not part of the configuration), we'll use `leader_id` to identify the node. 
   - If we accept that append request, we'll assign `leader_id` to the internal `unknown_node` node object to provide dummy node 
      object for that unknown node. So, users can still call `raft_node_t* raft_get_current_leader();` etc.

3 - Refactor & fixes
   - Made possible to start an election and become leader for a server without being part of the cluster configuration. 
   - Removed checks which validates requests according to the current configuration before sending a response (it shouldn't, it's caller's responsibility)
   - Refactor & style
