### PR TITLE
Define separate callback function for node id retrieval

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -354,6 +354,25 @@ typedef int (
     void *user_data,
     raft_entry_t *entry,
     raft_index_t entry_idx
+);
+
+/** Callback for determining which node this configuration log entry
+ * affects. This call only applies to configuration change log entries.
+ * @return the node ID of the node
+ *
+ * @param[in] raft The Raft server making this callback
+ * @param[in] user_data User data that is passed from Raft server
+ * @param[in] entry The entry that the event is happening to.
+ * @param[in] entry_idx The entries index in the log
+*  @return the node ID of the node
+ * */
+typedef int (
+*func_get_node_id_f
+)   (
+    raft_server_t* raft,
+    void *user_data,
+    raft_entry_t *entry,
+    raft_index_t entry_idx
     );
 
 /** Callback for being notified of membership changes.
@@ -421,7 +440,7 @@ typedef struct
     /** Callback for determining which node this configuration log entry
      * affects. This call only applies to configuration change log entries.
      * @return the node ID of the node */
-    func_logentry_event_f log_get_node_id;
+    func_get_node_id_f get_node_id;
 
     /** Callback for detecting when a non-voting node has sufficient logs. */
     func_node_has_sufficient_logs_f node_has_sufficient_logs;

--- a/include/raft.h
+++ b/include/raft.h
@@ -366,7 +366,7 @@ typedef int (
  * @param[in] entry_idx The entries index in the log
 *  @return the node ID of the node
  * */
-typedef int (
+typedef raft_node_id_t (
 *func_get_node_id_f
 )   (
     raft_server_t* raft,

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -266,11 +266,11 @@ void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_i
     if (!raft_entry_is_cfg_change(ety))
         return;
 
-    if (!me->cb.log_get_node_id)
+    if (!me->cb.get_node_id)
         return;
 
     void* udata = raft_get_udata(me_);
-    raft_node_id_t node_id = me->cb.log_get_node_id(me_, udata, ety, idx);
+    raft_node_id_t node_id = me->cb.get_node_id(me_, udata, ety, idx);
     raft_node_t* node = raft_get_node(me_, node_id);
     int is_self = node_id == raft_get_nodeid(me_);
 
@@ -315,11 +315,11 @@ void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const 
     if (!raft_entry_is_cfg_change(ety))
         return;
 
-    if (!me->cb.log_get_node_id)
+    if (!me->cb.get_node_id)
         return;
 
     void* udata = raft_get_udata(me_);
-    raft_node_id_t node_id = me->cb.log_get_node_id(me_, udata, ety, idx);
+    raft_node_id_t node_id = me->cb.get_node_id(me_, udata, ety, idx);
     raft_node_t* node = raft_get_node(me_, node_id);
 
     switch (ety->type)
@@ -1161,7 +1161,7 @@ int raft_apply_entry(raft_server_t* me_)
     if (!raft_entry_is_cfg_change(ety))
         goto exit;
 
-    raft_node_id_t node_id = me->cb.log_get_node_id(me_, raft_get_udata(me_), ety, log_idx);
+    raft_node_id_t node_id = me->cb.get_node_id(me_, raft_get_udata(me_), ety, log_idx);
     raft_node_t* node = raft_get_node(me_, node_id);
 
     switch (ety->type) {

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -31,7 +31,7 @@ static void __LOG_APPEND_ENTRIES_SEQ_ID(void *l, int count, int id, raft_term_t 
     }
 }
 
-static int __logentry_get_node_id(
+static int __get_node_id(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
@@ -76,8 +76,7 @@ static int __log_pop_failing(
 }
 
 raft_cbs_t funcs = {
-    .log_get_node_id = __logentry_get_node_id
-};
+    .get_node_id = __get_node_id};
 
 raft_log_cbs_t log_funcs = {
     .log_pop = __log_pop
@@ -147,7 +146,7 @@ void TestLog_delete(CuTest * tc)
     void* queue = llqueue_new();
     void *r = raft_new();
     raft_cbs_t funcs = {
-        .log_get_node_id = __logentry_get_node_id
+        .get_node_id = __get_node_id
     };
     raft_log_cbs_t log_funcs = {
         .log_pop = __log_pop
@@ -182,8 +181,7 @@ void TestLog_delete_onwards(CuTest * tc)
     void* queue = llqueue_new();
     void *r = raft_new();
     raft_cbs_t funcs = {
-        .log_get_node_id = __logentry_get_node_id
-    };
+        .get_node_id = __get_node_id};
     raft_log_cbs_t log_funcs = {
         .log_pop = __log_pop
     };
@@ -212,8 +210,7 @@ void TestLog_delete_handles_log_pop_failure(CuTest * tc)
     void* queue = llqueue_new();
     void *r = raft_new();
     raft_cbs_t funcs = {
-        .log_get_node_id = __logentry_get_node_id
-    };
+        .get_node_id = __get_node_id};
     raft_log_cbs_t log_funcs = {
         .log_pop = __log_pop_failing
     };
@@ -237,8 +234,7 @@ void TestLog_delete_fails_for_idx_zero(CuTest * tc)
     void* queue = llqueue_new();
     void *r = raft_new();
     raft_cbs_t funcs = {
-        .log_get_node_id = __logentry_get_node_id
-    };
+        .get_node_id = __get_node_id};
     raft_log_cbs_t log_funcs = {
         .log_pop = __log_pop
     };
@@ -258,8 +254,7 @@ void TestLog_poll(CuTest * tc)
     void* queue = llqueue_new();
     void *r = raft_new();
     raft_cbs_t funcs = {
-        .log_get_node_id = __logentry_get_node_id
-    };
+        .get_node_id = __get_node_id};
     raft_log_cbs_t log_funcs = {
         .log_pop = __log_pop
     };
@@ -450,8 +445,7 @@ void TestLog_delete_after_polling_from_double_append(CuTest * tc)
     void* queue = llqueue_new();
     void *r = raft_new();
     raft_cbs_t funcs = {
-        .log_get_node_id = __logentry_get_node_id
-    };
+        .get_node_id = __get_node_id};
     raft_log_cbs_t log_funcs = {
         .log_pop = __log_pop
     };
@@ -487,8 +481,7 @@ void TestLog_get_from_idx_with_base_off_by_one(CuTest * tc)
     void* queue = llqueue_new();
     void *r = raft_new();
     raft_cbs_t funcs = {
-        .log_get_node_id = __logentry_get_node_id
-    };
+        .get_node_id = __get_node_id};
     raft_log_cbs_t log_funcs = {
         .log_pop = __log_pop
     };

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -31,7 +31,7 @@ static void __LOG_APPEND_ENTRIES_SEQ_ID(void *l, int count, int id, raft_term_t 
     }
 }
 
-static int __get_node_id(
+static raft_node_id_t __get_node_id(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,

--- a/tests/test_log_impl.c
+++ b/tests/test_log_impl.c
@@ -11,7 +11,7 @@
 #include "raft.h"
 #include "helpers.h"
 
-static int __logentry_get_node_id(
+static int __get_node_id(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,
@@ -131,8 +131,7 @@ void TestLogImpl_pop(CuTest * tc)
 
     void *r = raft_new();
     raft_cbs_t funcs = {
-        .log_get_node_id = __logentry_get_node_id
-    };
+        .get_node_id = __get_node_id};
 
     raft_set_callbacks(r, &funcs, NULL);
 

--- a/tests/test_log_impl.c
+++ b/tests/test_log_impl.c
@@ -11,7 +11,7 @@
 #include "raft.h"
 #include "helpers.h"
 
-static int __get_node_id(
+static raft_node_id_t __get_node_id(
     raft_server_t* raft,
     void *udata,
     raft_entry_t *ety,

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -70,7 +70,7 @@ static int __raft_send_appendentries(raft_server_t* raft,
     return 0;
 }
 
-static int __raft_get_node_id(raft_server_t* raft,
+static raft_node_id_t __raft_get_node_id(raft_server_t* raft,
         void *udata,
         raft_entry_t *entry,
         raft_index_t entry_idx)

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -70,7 +70,7 @@ static int __raft_send_appendentries(raft_server_t* raft,
     return 0;
 }
 
-static int __raft_log_get_node_id(raft_server_t* raft,
+static int __raft_get_node_id(raft_server_t* raft,
         void *udata,
         raft_entry_t *entry,
         raft_index_t entry_idx)
@@ -3635,7 +3635,7 @@ void TestRaft_leader_recv_entry_add_nonvoting_node_remove_and_revert(CuTest *tc)
             .applylog = __raft_applylog,
             .persist_term = __raft_persist_term,
             .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
-            .log_get_node_id = __raft_log_get_node_id
+            .get_node_id = __raft_get_node_id
     };
     raft_log_cbs_t log_funcs = {
             .log_offer = __raft_log_offer
@@ -3683,8 +3683,7 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_after_v
         .applylog = __raft_applylog,
         .persist_term = __raft_persist_term,
         .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
-        .log_get_node_id = __raft_log_get_node_id
-    };
+        .get_node_id = __raft_get_node_id};
     raft_log_cbs_t log_funcs = {
         .log_offer = __raft_log_offer
     };
@@ -4018,8 +4017,7 @@ void TestRaft_recv_appendreq_from_unknown_node(CuTest * tc)
 void TestRaft_unknown_node_can_become_leader(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .log_get_node_id = __raft_log_get_node_id
-    };
+        .get_node_id = __raft_get_node_id};
 
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
@@ -4109,8 +4107,7 @@ void TestRaft_unknown_node_can_become_leader(CuTest * tc)
 void TestRaft_removed_node_starts_election(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .log_get_node_id = __raft_log_get_node_id
-    };
+        .get_node_id = __raft_get_node_id};
 
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -208,7 +208,7 @@ def raft_logentry_pop(raft, udata, ety, ety_idx):
     return ffi.from_handle(udata).entry_pop(ety, ety_idx)
 
 
-def raft_logentry_get_node_id(raft, udata, ety, ety_idx):
+def raft_get_node_id(raft, udata, ety, ety_idx):
     change_entry = ffi.from_handle(lib.raft_entry_getdata(ety))
     assert isinstance(change_entry, ChangeRaftEntry)
     return change_entry.node_id
@@ -772,7 +772,7 @@ class RaftServer(object):
         cbs.applylog = self.raft_applylog
         cbs.persist_vote = self.raft_persist_vote
         cbs.persist_term = self.raft_persist_term
-        cbs.log_get_node_id = self.raft_logentry_get_node_id
+        cbs.get_node_id = self.raft_get_node_id
         cbs.node_has_sufficient_logs = self.raft_node_has_sufficient_logs
         cbs.notify_membership_event = self.raft_notify_membership_event
         cbs.log = self.raft_log
@@ -871,7 +871,7 @@ class RaftServer(object):
         self.raft_logentry_offer = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_logentry_offer)
         self.raft_logentry_poll = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_logentry_poll)
         self.raft_logentry_pop = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_logentry_pop)
-        self.raft_logentry_get_node_id = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_logentry_get_node_id)
+        self.raft_get_node_id = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_get_node_id)
         self.raft_node_has_sufficient_logs = ffi.callback("int(raft_server_t* raft, void *user_data, raft_node_t* node)", raft_node_has_sufficient_logs)
         self.raft_notify_membership_event = ffi.callback("void(raft_server_t* raft, void *user_data, raft_node_t* node, raft_entry_t* ety, raft_membership_e)", raft_notify_membership_event)
         self.raft_log = ffi.callback("void(raft_server_t*, raft_node_id_t, void*, const char* buf)", raft_log)


### PR DESCRIPTION
Previously : 
```c 
func_logentry_event_f log_get_node_id;
 ```
I find this confusing, getting node id doesn't fit that callback type. Defined another one. 