### PR TITLE
Fix: Handle concurrent failures of appendentries

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -220,9 +220,6 @@ typedef struct
     /** If success, this is the highest log IDX we've received and appended to
      * our log; otherwise, this is the our currentIndex */
     raft_index_t current_idx;
-
-    /** what the leader thouught was the index of the log just before the newest_entry */
-    raft_index_t prev_log_idx;
 } msg_appendentries_response_t;
 
 typedef void* raft_server_t;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -3079,7 +3079,6 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
     aer.term = 2;
     aer.success = 0;
     aer.current_idx = 1;
-    aer.prev_log_idx = ae->prev_log_idx;
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 2, raft_node_get_next_idx(node));
 
@@ -3133,8 +3132,7 @@ void TestRaft_leader_recv_appendentries_response_decrements_to_lower_next_idx(
     memset(&aer, 0, sizeof(msg_appendentries_response_t));
     aer.term = 2;
     aer.success = 0;
-    aer.current_idx = 4;
-    aer.prev_log_idx = ae->prev_log_idx;
+    aer.current_idx = 3;
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 4, raft_node_get_next_idx(node));
 
@@ -3147,8 +3145,7 @@ void TestRaft_leader_recv_appendentries_response_decrements_to_lower_next_idx(
     memset(&aer, 0, sizeof(msg_appendentries_response_t));
     aer.term = 2;
     aer.success = 0;
-    aer.current_idx = 4;
-    aer.prev_log_idx = ae->prev_log_idx;
+    aer.current_idx = 2;
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertIntEquals(tc, 3, raft_node_get_next_idx(node));
 

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -777,7 +777,6 @@ void TestRaft_leader_sends_snapshot_if_log_was_compacted(CuTest* tc)
     aer.term = 1;
     aer.success = 0;
     aer.current_idx = 1;
-    aer.prev_log_idx = raft_node_get_next_idx(node) - 1;
 
     raft_recv_appendentries_response(r, node, &aer);
     CuAssertIntEquals(tc, 1, send_snapshot_count);


### PR DESCRIPTION
Follow-up https://github.com/RedisLabs/raft/pull/45

When an appendentry fails, leader should not blindly decrease the next index for the node. Leader should set it to whatever follower reported in the appendentries response.

Scenario : 
- Leader sends an entry [index : 3, term : 2], [prev_log_index = 0, prev_log_term = 0]
- Follower has [index 3, term 1], [prev_log_index = 0, prev_log_term = 0]
- Follower sees mismatch, deletes entry at "index 3". Sends response with "current_index = 2", requesting "index 2" from the leader. 
- So, leader doesn't need calculate next index for the node, it can just set whatever follower requested. (In this case, next index should be 2).

This change also fixes the issue : 
- Follower at index 9, creates a snapshot at index 9. 
- Leader thinks follower is still at index 7 (e.g due to lost appendentries responses)
- Leader sends appendreq starting from 7, follower rejects it as it doesn't have an entry at that index. Leader keeps decrementing next index, so leader will not find out next index is 10 for that follower. 
