### PR TITLE
fix read queue test to be more accurate

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -174,6 +174,9 @@ extern void (*raft_free)(void *ptr);
 
 /* get the max message id this server has seen from its current leader, reset to 0 on term change */
 raft_msg_id_t raft_get_max_seen_msg_id(raft_server_t* me_);
+/* */
+void raft_node_update_max_seen_msg_id(raft_node_t *me_, raft_msg_id_t msg_id);
+raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me_);
 /* get the server's (primarily for leader) current msg_id */
 raft_msg_id_t raft_get_msg_id(raft_server_t* me_);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -172,12 +172,11 @@ extern void *(*raft_calloc)(size_t nmemb, size_t size);
 extern void *(*raft_realloc)(void *ptr, size_t size);
 extern void (*raft_free)(void *ptr);
 
-/* get the max message id this server has seen from its current leader, reset to 0 on term change */
-raft_msg_id_t raft_get_max_seen_msg_id(raft_server_t* me_);
-/* */
+/* update the max_seen_msg_id for this node */
 void raft_node_update_max_seen_msg_id(raft_node_t *me_, raft_msg_id_t msg_id);
+/* get the max message id this server has seen from its the specified node */
 raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me_);
-/* get the server's (primarily for leader) current msg_id */
+/* get the server's current msg_id */
 raft_msg_id_t raft_get_msg_id(raft_server_t* me_);
 
 

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -36,6 +36,7 @@ typedef struct
     /* last AE heartbeat response received */
     raft_term_t last_acked_term;
     raft_msg_id_t last_acked_msgid;
+    raft_msg_id_t max_seen_msgid;
 } raft_node_private_t;
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
@@ -206,4 +207,18 @@ raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->last_acked_msgid;
+}
+
+void raft_node_update_max_seen_msg_id(raft_node_t *me_, raft_msg_id_t msg_id)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    if (msg_id > me->max_seen_msgid) {
+        me->max_seen_msgid = msg_id;
+    }
+}
+
+raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return me->max_seen_msgid;
 }

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -778,8 +778,8 @@ int raft_recv_appendentries(
         goto out;
     }
 
-    if (me->max_seen_msg_id < ae->msg_id) {
-        me->max_seen_msg_id = ae->msg_id;
+    if (node != NULL) {
+        raft_node_update_max_seen_msg_id(node, ae->msg_id);
     }
 
     /* update current leader because ae->term is up to date */

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -288,9 +288,3 @@ raft_msg_id_t raft_get_msg_id(raft_server_t* me_)
     raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->msg_id;
 }
-
-raft_msg_id_t raft_get_max_seen_msg_id(raft_server_t* me_)
-{
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-    return me->max_seen_msg_id;
-}

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -253,13 +253,11 @@ def get_voting_node_ids(leader):
 
 
 def verify_read(arg):
-#    logger.error(f"verify_read: {arg}")
     node_id = int(arg / 10000000)
     arg = arg % 10000000
     leader = net.servers[node_id - 1]
 
     voter_ids = get_voting_node_ids(leader)
-#    logger.error(f"voters = {voter_ids}")
     num_nodes = len(voter_ids)
 
     # primary verification logic.  we always need to count more than the required, looking to see that for voters,
@@ -274,7 +272,6 @@ def verify_read(arg):
 
         node = lib.raft_get_node(net.servers[i-1].raft, leader.id)
         msg_id = lib.raft_node_get_max_seen_msg_id(node)
-#        logger.error(f"msg_id seeen by node {i} = {msg_id}")
         if msg_id >= arg:
             count += 1
 
@@ -369,7 +366,6 @@ class Network(object):
             if lib.raft_is_leader(sv.raft):
                 msg_id = lib.raft_get_msg_id(sv.raft) + 1
                 arg = sv.id * 10000000 + msg_id
-#                logger.error(f"adding a read_request to {sv.id} at {msg_id} = msg_id, arg = {arg}")
                 lib.raft_queue_read_request(sv.raft, sv.handle_read_queue, ffi.cast("void *", arg))
 
     def id2server(self, id):


### PR DESCRIPTION
1) ecah server's set of nodes, keeps the max msg_id its seen from that node when that node has been later
1a) because of this get_max_seen now operates on a server's nodes, not on the server itself b

2) virtraft encodes the leader id into the "arg" it sends as part of the callback, so when we get the callback, we can know what leader its for and check its voters for corectness.