### PR TITLE
redo/tweak transfer leader in libraft

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -184,5 +184,7 @@ raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me_);
 /* get the server's current msg_id */
 raft_msg_id_t raft_get_msg_id(raft_server_t* me_);
 
+/* attempt to abort the leadership transfer */
+void raft_reset_transfer_leader(raft_server_t* me_, int timed_out);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -289,18 +289,6 @@ raft_msg_id_t raft_get_msg_id(raft_server_t* me_)
     return me->msg_id;
 }
 
-/* Stop trying to transfer leader to a targeted node
- * internally used because either we have timed out our attempt or because we are no longer the leader
- * possible to be used by a client as well.
- */
-void raft_reset_transfer_leader(raft_server_t* me_)
-{
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-
-    me->node_transferring_leader_to = RAFT_NODE_ID_NONE;
-    me->transfer_leader_time = 0;
-}
-
 /* return the targeted node_id if we are in the middle of attempting a leadership transfer
  * return RAFT_NODE_ID_NONE if no leadership transfer is in progress
  */


### PR DESCRIPTION
this started off as a small tweak and grew a bit

1) new callback for transfer leader result, along with its own enum of states

2) change/remove raft_reset_transfer_leader() calls

only call in places where there's a new leader or timeout (i.e. failed to transfer within period).

so, we only reset in 3 places 1) recv_appendentries 2) raft_periodic (timeout) 3) raft_become_leader

2a) raft_become_leader also got refactored a little to only issue the normal cb.notify_state_event() callback after it has set its state to be leader (as before, it could fail after the callback was issued)

2b) in raft_periodic the raft_reset_transfer_leader() is pulled out the "if LEADER" block, as will lose leader when a vote is issued to it, we still want it to timeout if leadership isn't gained

3) raft_reset_transfer_leader() does the logic for determining success/failure now, but becaue timeout is its own result which can't be determined by just looking at leader/desired, add a new flag to it to note timeout state

4) a bunch of new tests