### PR TITLE
fix recording of voter change idx entry

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1123,10 +1123,6 @@ int raft_recv_entry(raft_server_t* me_,
     r->idx = raft_get_current_idx(me_);
     r->term = me->current_term;
 
-    /* FIXME: is this required if raft_append_entry does this too? */
-    if (raft_entry_is_voting_cfg_change(ety))
-        me->voting_cfg_change_log_idx = raft_get_current_idx(me_);
-
     return 0;
 }
 
@@ -1173,7 +1169,7 @@ int raft_append_entry(raft_server_t* me_, raft_entry_t* ety)
         return e;
 
     if (raft_entry_is_voting_cfg_change(ety))
-        me->voting_cfg_change_log_idx = raft_get_current_idx(me_) - 1;
+        me->voting_cfg_change_log_idx = raft_get_current_idx(me_);
 
     if (raft_entry_is_cfg_change(ety)) {
         raft_handle_append_cfg_change(me_, ety, raft_get_current_idx(me_));


### PR DESCRIPTION
this was recorded in 2 places, inconsistently, when it only neededed to be recorded once.

it was in raft_recv_entry() as

    if (raft_entry_is_voting_cfg_change(ety))
        me->voting_cfg_change_log_idx = raft_get_current_idx(me_);

and in

raft_append_entry() as

```
me->voting_cfg_change_log_idx = raft_get_current_idx(me_) - 1;
```

it only should be in raft_append_entry() becaues raft_recv_entry() is only from the leader, but its value was wrong, while raft_recv_entry() was correct.  This is also why it generally worked, if no leader election happened, it always had correct value, but if a new leader was elected that would have to commit this entry, it be wrong.

or at least this is what I believe and haven't been able to duplicate the issue since I made the change