### PR TITLE
enable clients of libraft to enable delaying of send_appendentries

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -456,6 +456,16 @@ typedef int (
         raft_node_t* node
     );
 
+/** Callback for determing if we should delay sending appendentries requests
+ * @param[in] raft The Raft server making this callback
+ * @return 0 if we shouldn't delay, 1 if we should
+ */
+typedef int (
+*func_delay_send_appendentries_f
+)   (
+        raft_server_t *raft
+    );
+
 typedef struct
 {
     /** Callback for sending request vote messages */
@@ -504,6 +514,10 @@ typedef struct
 
     /** Callback for sending TimeoutNow RPC messages to nodes */
     func_send_timeoutnow_f send_timeoutnow;
+
+    /** Callback for enabling delaying sending of appendentries in raft_recv_entry
+     * This callback is optional */
+    func_delay_send_appendentries_f delay_send_appendentries;
 } raft_cbs_t;
 
 /** A generic notification callback used to allow Raft to notify caller

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1110,8 +1110,11 @@ int raft_recv_entry(raft_server_t* me_,
          * Don't send the entry to peers who are behind, to prevent them from
          * becoming congested. */
         raft_index_t next_idx = raft_node_get_next_idx(node);
-        if (next_idx == raft_get_current_idx(me_))
-            raft_send_appendentries(me_, node);
+        if (next_idx == raft_get_current_idx(me_)) {
+            if (!me->cb.delay_send_appendentries || !me->cb.delay_send_appendentries(me_)) {
+                raft_send_appendentries(me_, node);
+            }
+        }
     }
 
     /* if we are the only voter, commit now, as no appendentries_response will occur */


### PR DESCRIPTION
if they have a queue of items, don't have to send an rpc for each, can wait till queue is emptied and send them all at once.

optional for clients to implement, if they don't behaves as now, send an appendentry rpc on each recv_entry