### PR TITLE
limit size of appendentries by # of entries and total size

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -653,6 +653,7 @@ typedef struct raft_log_impl
      *
      * @param[in] idx Index of first entry to fetch.
      * @param[in] entries_n Length of entries (max. entries to fetch).
+     * @param[in] soft_max soft limit in bytes (keep adding entries till over)
      * @param[out] entries An initialized array of raft_entry_t*.
      * @return
      *  Number of entries fetched;
@@ -663,7 +664,7 @@ typedef struct raft_log_impl
      *    the returned entries.
      */
     int (*get_batch) (void *log, raft_index_t idx, int entries_n,
-            raft_entry_t **entries);
+            size_t soft_max, raft_entry_t **entries);
 
     /** Get first entry's index.
      * @return

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1257,8 +1257,11 @@ raft_entry_t** raft_get_entries_from_idx(raft_server_t* me_, raft_index_t idx, i
 
     raft_server_private_t* me = (raft_server_private_t*)me_;
     raft_index_t size = raft_get_current_idx(me_) - idx + 1;
+    if (size > 1024) {
+        size = 1024;
+    }
     raft_entry_t **e = raft_malloc(size * sizeof(raft_entry_t*));
-    int n = me->log_impl->get_batch(me->log, idx, (int) size, e);
+    int n = me->log_impl->get_batch(me->log, idx, (int) size, 1024*1024, e);
 
     if (n < 1) {
         raft_free(e);

--- a/tests/test_log_impl.c
+++ b/tests/test_log_impl.c
@@ -337,10 +337,10 @@ void TestLogImpl_get_from_idx_with_base_off_by_one(CuTest * tc)
 
     /* get off-by-one index */
     raft_entry_t *e[1];
-    CuAssertIntEquals(tc, impl->get_batch(l, 1, 1, e), 0);
+    CuAssertIntEquals(tc, impl->get_batch(l, 1, 1, 1024, e), 0);
 
     /* now get the correct index */
-    CuAssertIntEquals(tc, impl->get_batch(l, 2, 1, e), 1);
+    CuAssertIntEquals(tc, impl->get_batch(l, 2, 1, 1024, e), 1);
     CuAssertIntEquals(tc, e[0]->id, 2);
 }
 


### PR DESCRIPTION
this hard codes limits of 1024 entries and 1MB total size, but should be abstracted out

for now, its for review if this is the approach we want to take.