### PR TITLE
Snapshot RPC

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -197,7 +197,7 @@ typedef struct
     raft_term_t term;
 
     /** used to identify the sender node. Useful when this message is received
-     * from the nodes that are not part of the configuration yet. **/
+     * from the nodes that are not part of the configuration yet. */
     raft_node_id_t leader_id;
 
     /** id, to make it possible to associate responses with requests. */
@@ -1496,5 +1496,7 @@ raft_node_id_t raft_get_transfer_leader(raft_server_t* me_);
 
 /* cause this server to force an election on its next raft_periodic function call */
 void raft_set_timeout_now(raft_server_t* me_);
+
+raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
 
 #endif /* RAFT_H_ */

--- a/include/raft.h
+++ b/include/raft.h
@@ -17,11 +17,11 @@ typedef enum {
     RAFT_ERR_ONE_VOTING_CHANGE_ONLY=-3,
     RAFT_ERR_SHUTDOWN=-4,
     RAFT_ERR_NOMEM=-5,
-    RAFT_ERR_NEEDS_SNAPSHOT=-6,
-    RAFT_ERR_SNAPSHOT_IN_PROGRESS=-7,
-    RAFT_ERR_SNAPSHOT_ALREADY_LOADED=-8,
-    RAFT_ERR_INVALID_NODEID=-9,
-    RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS=-10,
+    RAFT_ERR_SNAPSHOT_IN_PROGRESS=-6,
+    RAFT_ERR_SNAPSHOT_ALREADY_LOADED=-7,
+    RAFT_ERR_INVALID_NODEID=-8,
+    RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS=-9,
+    RAFT_ERR_DONE=-10,
     RAFT_ERR_LAST=-100,
 } raft_error_e;
 
@@ -120,6 +120,18 @@ typedef struct raft_entry
  * applied to the FSM. */
 typedef raft_entry_t msg_entry_t;
 
+typedef struct
+{
+    /** Chunk data pointer */
+    void *data;
+
+    /** Chunk len */
+    raft_size_t len;
+
+    /** 1 if this is the last chunk */
+    int last_chunk;
+} raft_snapshot_chunk_t;
+
 /** Entry message response.
  * Indicates to client if entry was committed or not. */
 typedef struct
@@ -174,6 +186,55 @@ typedef struct
     /** true means candidate received vote */
     int vote_granted;
 } msg_requestvote_response_t;
+
+typedef struct
+{
+    /** currentTerm, for candidate to update itself */
+    raft_term_t term;
+
+    /** used to identify the sender node. Useful when this message is received
+     * from the nodes that are not part of the configuration yet. **/
+    raft_node_id_t leader_id;
+
+    /** id, to make it possible to associate responses with requests. */
+    raft_msg_id_t msg_id;
+
+    /** last included index of the snapshot */
+    raft_index_t snapshot_index;
+
+    /** last included term of the snapshot */
+    raft_term_t snapshot_term;
+
+    /** chunk offset */
+    raft_size_t offset;
+
+    /** 1 if this is the last chunk */
+    int last_chunk;
+
+    /** chunk data len */
+    raft_size_t len;
+
+    /** chunk data */
+    void *data;
+} msg_snapshot_t;
+
+typedef struct
+{
+    /** the msg_id this response refers to */
+    raft_msg_id_t msg_id;
+
+    /** currentTerm, to force other leader/candidate to step down */
+    raft_term_t term;
+
+    /** indicates last acknowledged snapshot offset by the follower */
+    raft_size_t offset;
+
+    /** 1 if request is accepted */
+    int success;
+
+     /** 1 if this is a response to the final chunk */
+    int last_chunk;
+} msg_snapshot_response_t;
 
 /** Appendentries message.
  * This message is used to tell nodes if it's safe to apply entries to the FSM.
@@ -266,21 +327,89 @@ typedef int (
     msg_appendentries_t* msg
     );
 
-/**
- * Log compaction
- * Callback for telling the user to send a snapshot.
- *
+/** Callback for sending snapshot messages.
  * @param[in] raft Raft server making this callback
  * @param[in] user_data User data that is passed from Raft server
  * @param[in] node Node's ID that needs a snapshot sent to
+ * @param[in] msg  Snapshot msg
  **/
 typedef int (
 *func_send_snapshot_f
 )   (
     raft_server_t* raft,
     void *user_data,
-    raft_node_t* node
+    raft_node_t* node,
+    msg_snapshot_t* msg
     );
+
+/** Callback for loading received snapshot. User should load snapshot using
+ * raft_begin_load_snapshot() and raft_end_load_snapshot();
+ *
+ * @param[in] raft Raft server making this callback
+ * @param[in] user_data User data that is passed from Raft server
+ * @param[in] snapshot_index Received snapshot index
+ * @param[in] snapshot_term  Received snapshot term
+ * @return 0 on success */
+typedef int (
+*func_load_snapshot_f
+)   (
+    raft_server_t* raft,
+    void *user_data,
+    raft_index_t snapshot_index,
+    raft_term_t snapshot_term
+);
+
+/** Callback to get a chunk from the snapshot file. This chunk will be sent
+ * to the follower.
+ *
+ *  'chunk' struct fields should be filled with the appropriate data.
+ *  To apply backpressure, return RAFT_ERR_DONE.
+ * @param[in] raft Raft server making this callback
+ * @param[in] user_data User data that is passed from Raft server
+ * @param[in] node Chunk will be sent to this node
+ * @param[in] offset Snapshot offset we request
+ * @param[in] chunk Snapshot chunk
+ * @return 0 on success */
+typedef int (
+*func_get_snapshot_chunk_f
+)   (
+    raft_server_t* raft,
+    void *user_data,
+    raft_node_t* node,
+    raft_size_t offset,
+    raft_snapshot_chunk_t* chunk
+);
+
+/** Callback to store a snapshot chunk. This chunk is received from the leader.
+ * @param[in] raft Raft server making this callback
+ * @param[in] user_data User data that is passed from Raft server
+ * @param[in] snapshot_index Last index of the received snapshot
+ * @param[in] offset Offset of the chunk we received
+ * @param[in] chunk Snapshot chunk
+ * @return 0 on success */
+typedef int (
+*func_store_snapshot_chunk_f
+)   (
+    raft_server_t* raft,
+    void *user_data,
+    raft_index_t snapshot_index,
+    raft_size_t offset,
+    raft_snapshot_chunk_t* chunk
+);
+
+/** Callback to clear incoming snapshot file. This might be called to clean up
+ * a partial snapshot file. e.g While we are still receiving snapshot, leader
+ * takes another snapshot and starts to send it.
+ *
+ * @param[in] raft Raft server making this callback
+ * @param[in] user_data User data that is passed from Raft server
+ * @return 0 on success */
+typedef int (
+*func_clear_snapshot_f
+)   (
+    raft_server_t* raft,
+    void *user_data
+);
 
 /** Callback for detecting when non-voting nodes have obtained enough logs.
  * This triggers only when there are no pending configuration changes.
@@ -464,8 +593,22 @@ typedef struct
     /** Callback for sending appendentries messages */
     func_send_appendentries_f send_appendentries;
 
-    /** Callback for notifying user that a node needs a snapshot sent */
+    /** Callback for sending snapshot messages */
     func_send_snapshot_f send_snapshot;
+
+    /** Callback for loading snapshot. This will be called when we complete
+     * receiving snapshot from the leader */
+    func_load_snapshot_f load_snapshot;
+
+    /** Callback to get a chunk of the snapshot file */
+    func_get_snapshot_chunk_f get_snapshot_chunk;
+
+    /** Callback to store a chunk of the snapshot */
+    func_store_snapshot_chunk_f store_snapshot_chunk;
+
+    /** Callback to dismiss temporary file which is used for incoming
+     * snapshot chunks */
+    func_clear_snapshot_f clear_snapshot;
 
     /** Callback for finite state machine application
      * Return 0 on success.
@@ -777,7 +920,6 @@ int raft_periodic(raft_server_t* me, int msec_elapsed);
  * @param[out] r The resulting response
  * @return
  *  0 on success
- *  RAFT_ERR_NEEDS_SNAPSHOT
  *  */
 int raft_recv_appendentries(raft_server_t* me,
                             raft_node_t* node,
@@ -794,6 +936,28 @@ int raft_recv_appendentries(raft_server_t* me,
 int raft_recv_appendentries_response(raft_server_t* me,
                                      raft_node_t* node,
                                      msg_appendentries_response_t* r);
+
+/** Receive a snapshot message.
+ * @param[in] node The node who sent us this message
+ * @param[in] req The snapshot message
+ * @param[out] resp The resulting response
+ * @return
+ *  0 on success  */
+int raft_recv_snapshot(raft_server_t* me_,
+                       raft_node_t* node,
+                       msg_snapshot_t *req,
+                       msg_snapshot_response_t *resp);
+
+/** Receive a response from a snapshot message we sent.
+ * @param[in] node The node who sent us this message
+ * @param[in] r The snapshot response message
+ * @return
+ *  0 on success;
+ *  -1 on error;
+ *  RAFT_ERR_NOT_LEADER server is not the leader */
+int raft_recv_snapshot_response(raft_server_t* me_,
+                                raft_node_t* node,
+                                msg_snapshot_response_t *r);
 
 /** Receive a requestvote message.
  * @param[in] node The node who sent us this message

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -105,6 +105,12 @@ typedef struct {
     raft_index_t saved_snapshot_last_idx;
     raft_term_t saved_snapshot_last_term;
 
+    /* Last included index of the incoming snapshot */
+    raft_index_t snapshot_recv_idx;
+
+    /* Current offset of the incoming snapshot */
+    raft_size_t snapshot_recv_offset;
+
     /* Read requests that await a network round trip to confirm
      * we're still the leader.
      */
@@ -187,5 +193,9 @@ raft_msg_id_t raft_get_msg_id(raft_server_t* me_);
 
 /* attempt to abort the leadership transfer */
 void raft_reset_transfer_leader(raft_server_t* me_, int timed_out);
+
+raft_size_t raft_node_get_snapshot_offset(raft_node_t *me_);
+
+void raft_node_set_snapshot_offset(raft_node_t *me_, raft_size_t snapshot_offset);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -99,11 +99,9 @@ typedef struct {
     raft_index_t snapshot_last_idx;
     raft_term_t snapshot_last_term;
 
-    /* Previous index/term values stored during snapshot,
-     * which are restored if the operation is cancelled.
-     */
-    raft_index_t saved_snapshot_last_idx;
-    raft_term_t saved_snapshot_last_term;
+    /* Next index/term values stored during snapshot */
+    raft_index_t next_snapshot_last_idx;
+    raft_term_t next_snapshot_last_term;
 
     /* Last included index of the incoming snapshot */
     raft_index_t snapshot_recv_idx;
@@ -171,8 +169,6 @@ void raft_node_set_has_sufficient_logs(raft_node_t* me_);
 int raft_is_single_node_voting_cluster(raft_server_t *me_);
 
 int raft_votes_is_majority(int nnodes, int nvotes);
-
-raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
 
 void raft_node_set_last_ack(raft_node_t* me_, raft_msg_id_t msgid, raft_term_t term);
 

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -21,6 +21,11 @@ typedef long int raft_term_t;
 typedef long int raft_index_t;
 
 /**
+ * Size type. This should be at least 64 bits.
+ */
+typedef unsigned long raft_size_t;
+
+/**
  * Unique node identifier.
  */
 typedef int raft_node_id_t;

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -23,7 +23,7 @@ typedef long int raft_index_t;
 /**
  * Size type. This should be at least 64 bits.
  */
-typedef unsigned long raft_size_t;
+typedef unsigned long long raft_size_t;
 
 /**
  * Unique node identifier.

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -33,6 +33,9 @@ typedef struct
 
     raft_node_id_t id;
 
+    /* Next snapshot offset to send to this node */
+    raft_size_t snapshot_offset;
+
     /* last AE heartbeat response received */
     raft_term_t last_acked_term;
     raft_msg_id_t last_acked_msgid;
@@ -221,4 +224,16 @@ raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me_)
 {
     raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->max_seen_msgid;
+}
+
+raft_size_t raft_node_get_snapshot_offset(raft_node_t *me_)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    return me->snapshot_offset;
+}
+
+void raft_node_set_snapshot_offset(raft_node_t *me_, raft_size_t snapshot_offset)
+{
+    raft_node_private_t* me = (raft_node_private_t*)me_;
+    me->snapshot_offset = snapshot_offset;
 }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -270,8 +270,8 @@ void raft_set_snapshot_metadata(raft_server_t *me_, raft_term_t term, raft_index
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     me->last_applied_idx = idx;
-    me->saved_snapshot_last_term = me->snapshot_last_term;
-    me->saved_snapshot_last_idx = me->snapshot_last_idx;
+    me->next_snapshot_last_term = me->snapshot_last_term;
+    me->next_snapshot_last_idx = me->snapshot_last_idx;
     me->snapshot_last_term = term;
     me->snapshot_last_idx = idx;
 }

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -921,9 +921,9 @@ void TestRaft_clear_snapshot_on_leader_change(CuTest * tc)
         .snapshot_index = 1,
         .snapshot_term = 1,
         .msg_id = 1,
-        .data = "tmp",
-        .len = strlen("tmp"),
-        .last_chunk = 0,
+        .chunk.data = "tmp",
+        .chunk.len = strlen("tmp"),
+        .chunk.last_chunk = 0,
     };
 
     msg_snapshot_response_t resp = {0};
@@ -961,10 +961,10 @@ void TestRaft_reject_wrong_offset(CuTest * tc)
         .snapshot_index = 1,
         .snapshot_term = 1,
         .msg_id = 1,
-        .data = "tmp",
-        .offset = 0,
-        .len = 50,
-        .last_chunk = 0,
+        .chunk.data = "tmp",
+        .chunk.offset = 0,
+        .chunk.len = 50,
+        .chunk.last_chunk = 0,
     };
 
     msg_snapshot_response_t resp = {0};
@@ -972,7 +972,7 @@ void TestRaft_reject_wrong_offset(CuTest * tc)
     raft_recv_snapshot(r, NULL, &msg, &resp);
     CuAssertIntEquals(tc, 1, data.store_chunk);
 
-    msg.offset = 80;
+    msg.chunk.offset = 80;
     raft_recv_snapshot(r, NULL, &msg, &resp);
 
     CuAssertIntEquals(tc, 0, resp.success);
@@ -1002,10 +1002,10 @@ void TestRaft_set_last_chunk_on_duplicate(CuTest * tc)
         .snapshot_index = 5,
         .snapshot_term = 1,
         .msg_id = 1,
-        .data = "tmp",
-        .offset = 0,
-        .len = 50,
-        .last_chunk = 1,
+        .chunk.data = "tmp",
+        .chunk.offset = 0,
+        .chunk.len = 50,
+        .chunk.last_chunk = 1,
     };
 
     msg_snapshot_response_t resp = {0};
@@ -1020,9 +1020,9 @@ void TestRaft_set_last_chunk_on_duplicate(CuTest * tc)
         .snapshot_index = 4,
         .snapshot_term = 1,
         .msg_id = 1,
-        .offset = 0,
-        .len = 50,
-        .last_chunk = 0,
+        .chunk.offset = 0,
+        .chunk.len = 50,
+        .chunk.last_chunk = 0,
     };
 
     raft_recv_snapshot(r, NULL, &msg2, &resp);

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -69,11 +69,120 @@ static int __raft_send_appendentries_capture(raft_server_t* raft,
 
 static int __raft_send_snapshot_increment(raft_server_t* raft,
         void* udata,
-        raft_node_t* node)
+        raft_node_t* node,
+        msg_snapshot_t *msg)
 {
     int *counter = udata;
 
     (*counter)++;
+    return 0;
+}
+
+static int __raft_get_snapshot_chunk(raft_server_t* raft,
+    void *user_data,
+    raft_node_t* node,
+    raft_size_t offset,
+    raft_snapshot_chunk_t* chunk)
+{
+    if (offset > 0) {
+        return RAFT_ERR_DONE;
+    }
+
+    chunk->data = "test";
+    chunk->len = strlen("test");
+    chunk->last_chunk = 1;
+
+    return 0;
+}
+
+static int __raft_store_snapshot_chunk(raft_server_t* raft,
+    void *user_data,
+    raft_index_t snapshot_index,
+    raft_size_t offset,
+    raft_snapshot_chunk_t* chunk)
+{
+    return 0;
+}
+
+static int __raft_clear_snapshot(raft_server_t* raft,
+    void *user_data)
+{
+    return 0;
+}
+
+struct test_data
+{
+    int send;
+    int get_chunk;
+    int store_chunk;
+    int clear;
+    int load;
+};
+
+static int test_send_snapshot_increment(raft_server_t* raft,
+                                          void* udata,
+                                          raft_node_t* node,
+                                          msg_snapshot_t *msg)
+{
+    struct test_data *t = udata;
+
+    t->send++;
+    return 0;
+}
+
+static int test_get_snapshot_chunk(raft_server_t* raft,
+                                     void *user_data,
+                                     raft_node_t* node,
+                                     raft_size_t offset,
+                                     raft_snapshot_chunk_t* chunk)
+{
+    struct test_data *t = user_data;
+
+    t->get_chunk++;
+
+    if (offset > 0) {
+        return RAFT_ERR_DONE;
+    }
+
+    chunk->data = "test";
+    chunk->len = strlen("test");
+    chunk->last_chunk = 1;
+
+    return 0;
+}
+
+static int test_store_snapshot_chunk(raft_server_t* raft,
+                                       void *user_data,
+                                       raft_index_t snapshot_index,
+                                       raft_size_t offset,
+                                       raft_snapshot_chunk_t* chunk)
+{
+    struct test_data *t = user_data;
+
+    t->store_chunk++;
+    return 0;
+}
+
+static int test_clear_snapshot(raft_server_t* raft,
+                                 void *user_data)
+{
+    struct test_data *t = user_data;
+    t->clear++;
+
+    return 0;
+}
+
+static int test_load_snapshot(raft_server_t* raft,
+                               void *user_data,
+                              raft_index_t snapshot_index,
+                              raft_term_t snapshot_term)
+{
+    struct test_data *t = user_data;
+    t->load++;
+
+    raft_begin_load_snapshot(raft, snapshot_term, snapshot_index);
+    raft_end_load_snapshot(raft);
+
     return 0;
 }
 
@@ -490,7 +599,10 @@ void TestRaft_follower_load_from_snapshot_fails_if_log_is_newer(CuTest * tc)
 void TestRaft_leader_sends_snapshot_when_node_next_index_was_compacted(CuTest* tc)
 {
     raft_cbs_t funcs = {
-        .send_snapshot = __raft_send_snapshot_increment
+        .send_snapshot = __raft_send_snapshot_increment,
+        .clear_snapshot = __raft_clear_snapshot,
+        .store_snapshot_chunk = __raft_store_snapshot_chunk,
+        .get_snapshot_chunk = __raft_get_snapshot_chunk
     };
 
     int increment = 0;
@@ -524,7 +636,7 @@ void TestRaft_leader_sends_snapshot_when_node_next_index_was_compacted(CuTest* t
 
     /* verify snapshot is sent */
     int rc = raft_send_appendentries(r, node);
-    CuAssertIntEquals(tc, RAFT_ERR_NEEDS_SNAPSHOT, rc);
+    CuAssertIntEquals(tc, 0, rc);
     CuAssertIntEquals(tc, 1, increment);
 
     /* update callbacks, verify correct appendreq is sent after the snapshot */
@@ -732,7 +844,10 @@ void TestRaft_leader_sends_snapshot_if_log_was_compacted(CuTest* tc)
 {
     raft_cbs_t funcs = {
         .send_snapshot = __raft_send_snapshot_increment,
-        .send_appendentries = __raft_send_appendentries
+        .send_appendentries = __raft_send_appendentries,
+        .clear_snapshot = __raft_clear_snapshot,
+        .store_snapshot_chunk = __raft_store_snapshot_chunk,
+        .get_snapshot_chunk = __raft_get_snapshot_chunk
     };
 
     int send_snapshot_count = 0;
@@ -784,6 +899,138 @@ void TestRaft_leader_sends_snapshot_if_log_was_compacted(CuTest* tc)
     CuAssertIntEquals(tc, 1, send_snapshot_count);
 }
 
+void TestRaft_clear_snapshot_on_leader_change(CuTest * tc)
+{
+    raft_cbs_t funcs = {
+        .send_snapshot = test_send_snapshot_increment,
+        .send_appendentries = __raft_send_appendentries,
+        .clear_snapshot = test_clear_snapshot,
+        .load_snapshot = test_load_snapshot,
+        .store_snapshot_chunk = test_store_snapshot_chunk,
+        .get_snapshot_chunk = test_get_snapshot_chunk
+    };
+
+    struct test_data data = {0};
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, &data);
+    raft_add_node(r, NULL, 1, 1);
+
+    msg_snapshot_t msg = {
+        .leader_id = 2,
+        .snapshot_index = 1,
+        .snapshot_term = 1,
+        .msg_id = 1,
+        .data = "tmp",
+        .len = strlen("tmp"),
+        .last_chunk = 0,
+    };
+
+    msg_snapshot_response_t resp = {0};
+
+    raft_recv_snapshot(r, NULL, &msg, &resp);
+    CuAssertIntEquals(tc, 1, data.store_chunk);
+
+    msg.msg_id = 2;
+    msg.leader_id = 3;
+
+    raft_recv_snapshot(r, NULL, &msg, &resp);
+    CuAssertIntEquals(tc, 1, data.clear);
+    CuAssertIntEquals(tc, 2, data.store_chunk);
+}
+
+void TestRaft_reject_wrong_offset(CuTest * tc)
+{
+    raft_cbs_t funcs = {
+        .send_snapshot = test_send_snapshot_increment,
+        .send_appendentries = __raft_send_appendentries,
+        .clear_snapshot = test_clear_snapshot,
+        .load_snapshot = test_load_snapshot,
+        .store_snapshot_chunk = test_store_snapshot_chunk,
+        .get_snapshot_chunk = test_get_snapshot_chunk
+    };
+
+    struct test_data data = {0};
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, &data);
+    raft_add_node(r, NULL, 1, 1);
+
+    msg_snapshot_t msg = {
+        .leader_id = 2,
+        .snapshot_index = 1,
+        .snapshot_term = 1,
+        .msg_id = 1,
+        .data = "tmp",
+        .offset = 0,
+        .len = 50,
+        .last_chunk = 0,
+    };
+
+    msg_snapshot_response_t resp = {0};
+
+    raft_recv_snapshot(r, NULL, &msg, &resp);
+    CuAssertIntEquals(tc, 1, data.store_chunk);
+
+    msg.offset = 80;
+    raft_recv_snapshot(r, NULL, &msg, &resp);
+
+    CuAssertIntEquals(tc, 0, resp.success);
+    CuAssertIntEquals(tc, 50, resp.offset);
+}
+
+void TestRaft_set_last_chunk_on_duplicate(CuTest * tc)
+{
+    raft_cbs_t funcs = {
+        .send_snapshot = test_send_snapshot_increment,
+        .send_appendentries = __raft_send_appendentries,
+        .clear_snapshot = test_clear_snapshot,
+        .load_snapshot = test_load_snapshot,
+        .store_snapshot_chunk = test_store_snapshot_chunk,
+        .get_snapshot_chunk = test_get_snapshot_chunk
+    };
+
+    struct test_data data = {0};
+
+    void *r = raft_new();
+    raft_set_callbacks(r, &funcs, &data);
+    raft_add_node(r, NULL, 1, 1);
+
+    msg_snapshot_t msg = {
+        .term = 1,
+        .leader_id = 2,
+        .snapshot_index = 5,
+        .snapshot_term = 1,
+        .msg_id = 1,
+        .data = "tmp",
+        .offset = 0,
+        .len = 50,
+        .last_chunk = 1,
+    };
+
+    msg_snapshot_response_t resp = {0};
+
+    raft_recv_snapshot(r, NULL, &msg, &resp);
+    CuAssertIntEquals(tc, 1, data.store_chunk);
+    CuAssertIntEquals(tc, 1, data.load);
+
+    msg_snapshot_t msg2 = {
+        .term = 1,
+        .leader_id = 2,
+        .snapshot_index = 4,
+        .snapshot_term = 1,
+        .msg_id = 1,
+        .offset = 0,
+        .len = 50,
+        .last_chunk = 0,
+    };
+
+    raft_recv_snapshot(r, NULL, &msg2, &resp);
+
+    CuAssertIntEquals(tc, 1, resp.success);
+    CuAssertIntEquals(tc, 1, resp.last_chunk);
+}
+
 int main(void)
 {
     CuString *output = CuStringNew();
@@ -808,6 +1055,9 @@ int main(void)
     SUITE_ADD_TEST(suite, TestRaft_leader_sends_appendentries_with_correct_prev_log_idx_when_snapshotted);
     SUITE_ADD_TEST(suite, TestRaft_cancel_snapshot_restores_state);
     SUITE_ADD_TEST(suite, TestRaft_leader_sends_snapshot_if_log_was_compacted);
+    SUITE_ADD_TEST(suite, TestRaft_clear_snapshot_on_leader_change);
+    SUITE_ADD_TEST(suite, TestRaft_reject_wrong_offset);
+    SUITE_ADD_TEST(suite, TestRaft_set_last_chunk_on_duplicate);
 
     CuSuiteRun(suite);
     CuSuiteDetails(suite, output);

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -77,6 +77,7 @@ NODE_CONNECTING = 1
 NODE_CONNECTED = 2
 NODE_DISCONNECTING = 3
 
+SNAPSHOT_SIZE = 512 * 1023
 
 class ServerDoesNotExist(Exception):
     pass
@@ -125,9 +126,11 @@ def err2str(err):
         lib.RAFT_ERR_ONE_VOTING_CHANGE_ONLY: 'RAFT_ERR_ONE_VOTING_CHANGE_ONLY',
         lib.RAFT_ERR_SHUTDOWN: 'RAFT_ERR_SHUTDOWN',
         lib.RAFT_ERR_NOMEM: 'RAFT_ERR_NOMEM',
-        lib.RAFT_ERR_NEEDS_SNAPSHOT: 'RAFT_ERR_NEEDS_SNAPSHOT',
         lib.RAFT_ERR_SNAPSHOT_IN_PROGRESS: 'RAFT_ERR_SNAPSHOT_IN_PROGRESS',
         lib.RAFT_ERR_SNAPSHOT_ALREADY_LOADED: 'RAFT_ERR_SNAPSHOT_ALREADY_LOADED',
+        lib.RAFT_INVALID_NODEID: 'RAFT_INVALID_NODEID',
+        lib.RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS: 'RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS',
+        lib.RAFT_ERR_DONE: 'RAFT_ERR_DONE',
         lib.RAFT_ERR_LAST: 'RAFT_ERR_LAST',
     }[err]
 
@@ -177,8 +180,32 @@ def raft_send_appendentries(raft, udata, node, msg):
     return 0
 
 
-def raft_send_snapshot(raft, udata, node):
-    return ffi.from_handle(udata).send_snapshot(node)
+def raft_send_snapshot(raft, udata, node, msg):
+    server = ffi.from_handle(udata)
+    dst_server = ffi.from_handle(lib.raft_node_get_udata(node))
+    server.network.enqueue_msg(msg, server, dst_server)
+    return 0
+
+
+def raft_load_snapshot(raft, udata, index, term):
+    return ffi.from_handle(udata).load_snapshot(index, term)
+
+
+def raft_clear_snapshot(raft, udata):
+    return ffi.from_handle(udata).clear_snapshot()
+
+
+def raft_get_snapshot_chunk(raft, udata, node, offset, chunk):
+    server = ffi.from_handle(udata)
+    chunk.len = min(4096, len(server.snapshot_buf) - offset)
+    chunk.last_chunk = offset + chunk.len == len(server.snapshot_buf)
+    chunk.data = ffi.from_buffer("char*", server.snapshot_buf, 0) + offset
+    return lib.RAFT_ERR_DONE if chunk.len == 0 else 0
+
+
+def raft_store_snapshot_chunk(raft, udata, index, offset, chunk):
+    buf = ffi.buffer(chunk.data, chunk.len)
+    return ffi.from_handle(udata).store_snapshot(offset, buf)
 
 
 def raft_applylog(raft, udata, ety, idx):
@@ -498,14 +525,22 @@ class Network(object):
                 logger.error(msg.sendee.debug_log())
                 self.diagnostic_info()
                 sys.exit(1)
-            elif lib.RAFT_ERR_NEEDS_SNAPSHOT == e:
-                pass  # TODO: pretend as if snapshot works
             else:
                 self.enqueue_msg(response, msg.sendee, msg.sendor)
 
         elif msg_type == 'msg_appendentries_response_t *':
             node = lib.raft_get_node(msg.sendee.raft, msg.sendor.id)
             lib.raft_recv_appendentries_response(msg.sendee.raft, node, msg.data)
+
+        elif msg_type == 'msg_snapshot_t *':
+            response = ffi.new('msg_snapshot_response_t *')
+            node = lib.raft_get_node(msg.sendee.raft, msg.sendor.id)
+            lib.raft_recv_snapshot(msg.sendee.raft, node, msg.data, response)
+            self.enqueue_msg(response, msg.sendee, msg.sendor)
+
+        elif msg_type == 'msg_snapshot_response_t *':
+            node = lib.raft_get_node(msg.sendee.raft, msg.sendor.id)
+            lib.raft_recv_snapshot_response(msg.sendee.raft, node, msg.data)
 
         elif msg_type == 'msg_requestvote_t *':
             response = ffi.new('msg_requestvote_response_t*')
@@ -770,6 +805,10 @@ class RaftServer(object):
         cbs.send_requestvote = self.raft_send_requestvote
         cbs.send_appendentries = self.raft_send_appendentries
         cbs.send_snapshot = self.raft_send_snapshot
+        cbs.load_snapshot = self.raft_load_snapshot
+        cbs.clear_snapshot = self.raft_clear_snapshot
+        cbs.get_snapshot_chunk = self.raft_get_snapshot_chunk
+        cbs.store_snapshot_chunk = self.raft_store_snapshot_chunk
         cbs.applylog = self.raft_applylog
         cbs.persist_vote = self.raft_persist_vote
         cbs.persist_term = self.raft_persist_term
@@ -789,6 +828,14 @@ class RaftServer(object):
 
         self.fsm_dict = {}
         self.fsm_log = []
+
+        # Generate dummy snapshot file for each node to send to other nodes as
+        # part of snapshot delivery validation
+        r = random.Random(self.id)
+        self.snapshot_buf = bytearray(r.randbytes(SNAPSHOT_SIZE))
+
+        # Save incoming snapshot chunks to this buffer
+        self.snapshot_recv_buf = bytearray(SNAPSHOT_SIZE)
 
     def __str__(self):
         return '<Server: {0}>'.format(self.id)
@@ -868,7 +915,11 @@ class RaftServer(object):
     def load_callbacks(self):
         self.raft_send_requestvote = ffi.callback("int(raft_server_t*, void*, raft_node_t*, msg_requestvote_t*)", raft_send_requestvote)
         self.raft_send_appendentries = ffi.callback("int(raft_server_t*, void*, raft_node_t*, msg_appendentries_t*)", raft_send_appendentries)
-        self.raft_send_snapshot = ffi.callback("int(raft_server_t*, void* , raft_node_t*)", raft_send_snapshot)
+        self.raft_send_snapshot = ffi.callback("int(raft_server_t*, void* , raft_node_t*, msg_snapshot_t*)", raft_send_snapshot)
+        self.raft_load_snapshot = ffi.callback("int(raft_server_t*, void*, raft_index_t, raft_term_t)", raft_load_snapshot)
+        self.raft_clear_snapshot = ffi.callback("int(raft_server_t*, void*)", raft_clear_snapshot)
+        self.raft_get_snapshot_chunk = ffi.callback("int(raft_server_t*, void*, raft_node_t*, raft_size_t offset, raft_snapshot_chunk_t*)", raft_get_snapshot_chunk)
+        self.raft_store_snapshot_chunk = ffi.callback("int(raft_server_t*, void*, raft_index_t index, raft_size_t offset, raft_snapshot_chunk_t*)", raft_store_snapshot_chunk)
         self.raft_applylog = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_applylog)
         self.raft_persist_vote = ffi.callback("int(raft_server_t*, void*, raft_node_id_t)", raft_persist_vote)
         self.raft_persist_term = ffi.callback("int(raft_server_t*, void*, raft_term_t, raft_node_id_t)", raft_persist_term)
@@ -993,13 +1044,27 @@ class RaftServer(object):
             self.snapshot.members.append(
                 SnapshotMember(id, lib.raft_node_is_voting_committed(n)))
 
-    def load_snapshot(self, snapshot, other):
+    def clear_snapshot(self):
+        self.snapshot_recv_buf = bytearray(SNAPSHOT_SIZE)
+        return 0
+
+    def store_snapshot(self, offset, data):
+        for i in range(0, len(data)):
+            self.snapshot_recv_buf[offset + i] = bytes(data)[i]
+
+        return 0
+
+    def load_snapshot(self, index, term):
         logger.debug('{} loading snapshot'.format(self))
-        e = lib.raft_begin_load_snapshot(
-            self.raft,
-            snapshot.last_term,
-            snapshot.last_idx,
-        )
+
+        leader = find_leader()
+        leader_snapshot = leader.snapshot_buf
+
+        # Validate received snapshot against the leader's snapshot
+        for i in range(len(self.snapshot_buf)):
+            assert self.snapshot_recv_buf[i] == leader_snapshot[i]
+
+        e = lib.raft_begin_load_snapshot(self.raft, index, term)
         logger.debug(f"return value from raft_begin_load_snapshot = {e}")
         if e == -1:
             return 0
@@ -1010,17 +1075,11 @@ class RaftServer(object):
         else:
             assert False
 
-        # Send appendentries response for this snapshot
-        response = ffi.new('msg_appendentries_response_t*')
-        response.success = 1
-        response.current_idx = snapshot.last_idx
-        response.term = lib.raft_get_current_term(self.raft)
-        self.network.enqueue_msg(response, self, other)
-
+        snapshot_info = leader.snapshot
         node_id = lib.raft_get_nodeid(self.raft)
 
         # set membership configuration according to snapshot
-        for member in snapshot.members:
+        for member in snapshot_info.members:
             if -1 == member.id:
                 continue
 
@@ -1056,37 +1115,18 @@ class RaftServer(object):
         assert(lib.raft_get_log_count(self.raft) == 0)
 
         self.do_membership_snapshot()
-        self.snapshot.image = dict(snapshot.image)
-        self.snapshot.last_term = snapshot.last_term
-        self.snapshot.last_idx = snapshot.last_idx
+        self.snapshot.image = dict(snapshot_info.image)
+        self.snapshot.last_term = snapshot_info.last_term
+        self.snapshot.last_idx = snapshot_info.last_idx
 
         assert(lib.raft_get_my_node(self.raft))
         # assert(sv->snapshot_fsm);
 
-        self.fsm_dict = dict(snapshot.image)
+        self.fsm_dict = dict(snapshot_info.image)
+        self.snapshot_recv_buf = bytearray(SNAPSHOT_SIZE)
 
         # logger.warning('{} loaded snapshot t:{} idx:{}'.format(
         #     self, snapshot.last_term, snapshot.last_idx))
-
-    def send_snapshot(self, node):
-        assert not lib.raft_snapshot_is_in_progress(self.raft)
-
-        # FIXME: Why would this happen?
-        if not hasattr(self, 'snapshot'):
-            return 0
-
-        node_sv = ffi.from_handle(lib.raft_node_get_udata(node))
-
-        # TODO: Why would this happen?
-        # seems odd that we would send something to a node that didn't exist
-        if not node_sv:
-            return 0
-
-        # NOTE:
-        # In a real server we would have to send the snapshot file to the
-        # other node. Here we have the convenience of the transfer being
-        # "immediate".
-        node_sv.load_snapshot(self.snapshot, self)
         return 0
 
     def persist_vote(self, voted_for):

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -77,7 +77,7 @@ NODE_CONNECTING = 1
 NODE_CONNECTED = 2
 NODE_DISCONNECTING = 3
 
-SNAPSHOT_SIZE = 512 * 1023
+SNAPSHOT_SIZE = 41 * 1023
 
 class ServerDoesNotExist(Exception):
     pass
@@ -1084,7 +1084,7 @@ class RaftServer(object):
         for i in range(len(self.snapshot_buf)):
             assert self.snapshot_buf[i] == leader_snapshot[i]
 
-        e = lib.raft_begin_load_snapshot(self.raft, index, term)
+        e = lib.raft_begin_load_snapshot(self.raft, term, index)
         logger.debug(f"return value from raft_begin_load_snapshot = {e}")
         if e == -1:
             return 0


### PR DESCRIPTION
- Added snapshot RPC.  **msg_snapshot** and **msg_snapshot_response**.
- New callbacks : 
    - **load_snapshot** : After we receive a snapshot fully, this callback will be called to ask user to load snapshot.
    - **get_snapshot_chunk** : We request a chunk from the user to send to the follower.
    - **store_snapshot_chunk** : We ask user to store incoming chunk to the storage.
    - **clear_snapshot** : Dismiss existing (partial) snapshot file. e.g Required when leader switches to a more recent snapshot before we get all the chunks.

- Test: Made virtraft to have a dummy snapshot file on memory for each node. When snapshot is completed, received snapshot is compared to leader's snapshot to validate snapshot integrity.