### PR TITLE
Improve codecov workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,5 @@ jobs:
     - name: Run tests
       run:
         make tests_full
-    - name: Set up codecov
-      run: |
-        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-        shasum -a 256 -c codecov.SHA256SUM
-    - name: Upload data to codecov
-      env:
-        HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
-      if: env.HAS_CODECOV_TOKEN == 'true'
-      run: ./codecov -t ${CODECOV_TOKEN}
+    - name: Upload to codecov
+      uses: codecov/codecode-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
       run:
         make tests_full
     - name: Upload to codecov
-      uses: codecov/codecode-action@v2
+      uses: codecov/codecov-action@v2

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -25,4 +25,4 @@ jobs:
       run:
         make tests_full
     - name: Upload to codecov
-      uses: codecov/codecode-action@v2
+      uses: codecov/codecov-action@v2

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -24,17 +24,5 @@ jobs:
     - name: Run tests
       run:
         make tests_full
-    - name: Set up codecov
-      run: |
-        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-        curl -Os https://uploader.codecov.io/latest/linux/codecov
-        chmod +x codecov
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-        shasum -a 256 -c codecov.SHA256SUM
-    - name: Upload data to codecov
-      env:
-        HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
-      if: env.HAS_CODECOV_TOKEN == 'true'
-      run: ./codecov -t ${CODECOV_TOKEN}
+    - name: Upload to codecov
+      uses: codecov/codecode-action@v2


### PR DESCRIPTION
A public repository does not require a token, so we get the benefit of being able to run coverage on PRs as well.
