### PR TITLE
ignore raft_send_appendentries error in appendentries_all

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -143,7 +143,7 @@ int raft_send_requestvote(raft_server_t* me, raft_node_t* node);
 
 int raft_send_appendentries(raft_server_t* me, raft_node_t* node);
 
-int raft_send_appendentries_all(raft_server_t* me_);
+void raft_send_appendentries_all(raft_server_t* me_);
 
 /**
  * Apply entry at lastApplied + 1. Entry becomes 'committed'.

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1584,11 +1584,10 @@ int raft_send_appendentries(raft_server_t* me_, raft_node_t* node)
     return res;
 }
 
-int raft_send_appendentries_all(raft_server_t* me_)
+void raft_send_appendentries_all(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     int i, e;
-    int ret = 0;
 
     me->timeout_elapsed = 0;
     for (i = 0; i < me->num_nodes; i++)
@@ -1598,12 +1597,10 @@ int raft_send_appendentries_all(raft_server_t* me_)
 
         e = raft_send_appendentries(me_, me->nodes[i]);
         if (0 != e) {
-            /* ignore error */
+            /* ignore error, future log message here? */
             ;
         }
     }
-
-    return ret;
 }
 
 int raft_get_nvotes_for_me(raft_server_t* me_)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1597,8 +1597,10 @@ int raft_send_appendentries_all(raft_server_t* me_)
             continue;
 
         e = raft_send_appendentries(me_, me->nodes[i]);
-        if (0 != e)
-            ret = e;
+        if (0 != e) {
+            /* ignore error */
+            ;
+        }
     }
 
     return ret;


### PR DESCRIPTION
we need to ignore the error so we make progress to other nodes.  none of the callers of raft_send_appendentries_all check for an error

From: https://github.com/RedisLabs/raft/issues/49