### PR TITLE
Adapt CMake for coverage changes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ endmacro()
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
+set(BUILD_SHARED_LIBS ON)
 
 enable_testing()
 
@@ -70,20 +71,26 @@ add_dependencies(lib_coverage check)
 # ------------------------------ Python Tests ---------------------------------#
 add_custom_target(test_fuzzer)
 add_custom_command(TARGET test_fuzzer
-                    COMMAND python ${CMAKE_SOURCE_DIR}/tests/log_fuzzer.py
+                   COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python ${CMAKE_SOURCE_DIR}/tests/log_fuzzer.py
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_dependencies(test_fuzzer raft_cffi)
 
 add_custom_target(test_virtraft)
 add_custom_command(TARGET test_virtraft
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMAND python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND python3 tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 $(VIRTRAFT_OPTS))
+        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 $(VIRTRAFT_OPTS))
+add_dependencies(test_virtraft raft_cffi)
 
+add_custom_target(raft_cffi)
+add_custom_command(TARGET raft_cffi
+                   COMMAND python3 ${CMAKE_SOURCE_DIR}/tests/raft_cffi_builder.py --libdir ${CMAKE_BINARY_DIR} --includedir ${CMAKE_SOURCE_DIR}/include
+                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 # ----------------------------- Python Tests End ----------------------------- #
 
 
@@ -91,7 +98,7 @@ add_custom_command(TARGET test_virtraft
 add_custom_target(tests_full)
 add_dependencies(tests_full check test_fuzzer test_virtraft)
 
-add_library(raft STATIC
+add_library(raft
         src/raft_log.c
         src/raft_server.c
         src/raft_node.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ add_custom_target(check ${CMAKE_COMMAND}
 
 # --------------------------- Code Coverage Start ---------------------------- #
 if (${CMAKE_BUILD_TYPE} MATCHES "Coverage")
+    set(BUILD_SHARED_LIBS ON)
     add_compile_options(-fprofile-arcs -ftest-coverage)
     link_libraries(gcov)
 endif ()
@@ -100,7 +101,7 @@ add_custom_command(TARGET raft_cffi
 add_custom_target(tests_full)
 add_dependencies(tests_full check test_fuzzer test_virtraft)
 
-add_library(raft SHARED
+add_library(raft
         src/raft_log.c
         src/raft_server.c
         src/raft_node.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ endmacro()
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
-set(BUILD_SHARED_LIBS ON)
 
 enable_testing()
 
@@ -64,32 +63,35 @@ add_custom_command(
         COMMAND lcov --list coverage.info --rc lcov_branch_coverage=1 --rc lcov_excl_br_line='assert'
 )
 
-add_dependencies(lib_coverage check)
+add_dependencies(lib_coverage check test_fuzzer test_virtraft)
 # ---------------------------- Code Coverage End ----------------------------- #
 
 
 # ------------------------------ Python Tests ---------------------------------#
+
+set(LIBPATH PYTHONPATH=${CMAKE_BINARY_DIR}/tests LD_LIBRARY_PATH=${CMAKE_BINARY_DIR})
+
 add_custom_target(test_fuzzer)
 add_custom_command(TARGET test_fuzzer
-                   COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python ${CMAKE_SOURCE_DIR}/tests/log_fuzzer.py
-                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+                   COMMAND ${LIBPATH} python ${CMAKE_SOURCE_DIR}/tests/log_fuzzer.py
+                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_dependencies(test_fuzzer raft_cffi)
 
 add_custom_target(test_virtraft)
 add_custom_command(TARGET test_virtraft
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 $(VIRTRAFT_OPTS)
-        COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR} python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 $(VIRTRAFT_OPTS))
+        COMMAND ${LIBPATH} python3 ${CMAKE_SOURCE_DIR}/tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND ${LIBPATH} python3 ${CMAKE_SOURCE_DIR}/tests/virtraft2.py --servers 7 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND ${LIBPATH} python3 ${CMAKE_SOURCE_DIR}/tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 2 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND ${LIBPATH} python3 ${CMAKE_SOURCE_DIR}/tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 3 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND ${LIBPATH} python3 ${CMAKE_SOURCE_DIR}/tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 4 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND ${LIBPATH} python3 ${CMAKE_SOURCE_DIR}/tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 $(VIRTRAFT_OPTS)
+        COMMAND ${LIBPATH} python3 ${CMAKE_SOURCE_DIR}/tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 $(VIRTRAFT_OPTS))
 add_dependencies(test_virtraft raft_cffi)
 
 add_custom_target(raft_cffi)
 add_custom_command(TARGET raft_cffi
-                   COMMAND python3 ${CMAKE_SOURCE_DIR}/tests/raft_cffi_builder.py --libdir ${CMAKE_BINARY_DIR} --includedir ${CMAKE_SOURCE_DIR}/include
+                   COMMAND python3 ${CMAKE_SOURCE_DIR}/tests/raft_cffi_builder.py --libdir ${CMAKE_BINARY_DIR} --includedir ${CMAKE_SOURCE_DIR}/include --tmpdir ${CMAKE_BINARY_DIR}/
                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 # ----------------------------- Python Tests End ----------------------------- #
 
@@ -98,7 +100,7 @@ add_custom_command(TARGET raft_cffi
 add_custom_target(tests_full)
 add_dependencies(tests_full check test_fuzzer test_virtraft)
 
-add_library(raft
+add_library(raft SHARED
         src/raft_log.c
         src/raft_server.c
         src/raft_node.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ add_custom_target(check ${CMAKE_COMMAND}
 
 # --------------------------- Code Coverage Start ---------------------------- #
 if (${CMAKE_BUILD_TYPE} MATCHES "Coverage")
-    set(BUILD_SHARED_LIBS ON)
     add_compile_options(-fprofile-arcs -ftest-coverage)
     link_libraries(gcov)
 endif ()
@@ -92,7 +91,7 @@ add_dependencies(test_virtraft raft_cffi)
 
 add_custom_target(raft_cffi)
 add_custom_command(TARGET raft_cffi
-                   COMMAND python3 ${CMAKE_SOURCE_DIR}/tests/raft_cffi_builder.py --libdir ${CMAKE_BINARY_DIR} --includedir ${CMAKE_SOURCE_DIR}/include --tmpdir ${CMAKE_BINARY_DIR}/
+                   COMMAND python3 ${CMAKE_SOURCE_DIR}/tests/raft_cffi_builder.py --libname raft_shared --libdir ${CMAKE_BINARY_DIR} --includedir ${CMAKE_SOURCE_DIR}/include --tmpdir ${CMAKE_BINARY_DIR}/
                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 # ----------------------------- Python Tests End ----------------------------- #
 
@@ -101,14 +100,20 @@ add_custom_command(TARGET raft_cffi
 add_custom_target(tests_full)
 add_dependencies(tests_full check test_fuzzer test_virtraft)
 
-add_library(raft
+set(RAFT_SOURCE_FILES
         src/raft_log.c
         src/raft_server.c
         src/raft_node.c
         src/raft_server_properties.c)
 
-target_compile_options(raft PRIVATE -fPIC -g)
+add_library(raft STATIC ${RAFT_SOURCE_FILES})
+target_compile_options(raft PRIVATE -g)
 target_include_directories(raft PRIVATE include)
+
+add_library(raft_shared SHARED ${RAFT_SOURCE_FILES})
+target_include_directories(raft_shared PRIVATE include)
+set_property(TARGET raft_shared PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_options(raft PRIVATE -g)
 
 define_test(test_log)
 define_test(test_log_impl)

--- a/tests/raft_cffi_builder.py
+++ b/tests/raft_cffi_builder.py
@@ -1,5 +1,6 @@
-import cffi
+import argparse
 import subprocess
+import cffi
 
 def load(fname):
     return '\n'.join(
@@ -7,6 +8,11 @@ def load(fname):
             ["gcc", "-E", fname]).decode('utf-8').split('\n')])
 
 if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--libdir', type=str, default='.')
+    parser.add_argument('--includedir', type=str, default='include')
+    args = parser.parse_args()
 
     ffibuilder = cffi.FFI()
     ffibuilder.set_source(
@@ -37,9 +43,9 @@ if __name__ == '__main__':
             }
         """,
         libraries=["raft"],
-        include_dirs=["include"],
+        include_dirs=[args.includedir],
         extra_compile_args=["-UNDEBUG"],
-        extra_link_args=["-L."]
+        extra_link_args=["-L{}".format(args.libdir)]
         )
 
 

--- a/tests/raft_cffi_builder.py
+++ b/tests/raft_cffi_builder.py
@@ -12,6 +12,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--libdir', type=str, default='.')
     parser.add_argument('--includedir', type=str, default='include')
+    parser.add_argument('--tmpdir', type=str, default='.')
     args = parser.parse_args()
 
     ffibuilder = cffi.FFI()
@@ -58,4 +59,4 @@ if __name__ == '__main__':
     ffibuilder.cdef('void *raft_entry_getdata(raft_entry_t *);')
     ffibuilder.cdef('raft_entry_t **raft_entry_array_deepcopy(raft_entry_t **src, int len);')
 
-    ffibuilder.compile(verbose=True)
+    ffibuilder.compile(tmpdir=args.tmpdir, verbose=True)

--- a/tests/raft_cffi_builder.py
+++ b/tests/raft_cffi_builder.py
@@ -11,6 +11,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--libdir', type=str, default='.')
+    parser.add_argument('--libname', type=str, default='raft')
     parser.add_argument('--includedir', type=str, default='include')
     parser.add_argument('--tmpdir', type=str, default='.')
     args = parser.parse_args()
@@ -43,7 +44,7 @@ if __name__ == '__main__':
                 return t;
             }
         """,
-        libraries=["raft"],
+        libraries=[args.libname],
         include_dirs=[args.includedir],
         extra_compile_args=["-UNDEBUG"],
         extra_link_args=["-L{}".format(args.libdir)]


### PR DESCRIPTION
* Build libraft.so to support tests.
* CMake target to create raft_cffi module.
* CMake changes to handle LD_LIBRARY_PATH for libraft.so to be found.
* raft_cffi_builder changes to support arbitrary include and library
  paths.