### PR TITLE
add an append_entry and remove_entry callback

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -603,6 +603,18 @@ typedef int (
         raft_node_t* node
     );
 
+/** Callback on each individual entry append
+ * FIXME: FILL IN
+  */
+typedef int (
+*func_appendentry_f
+)   (
+        raft_server_t* raft,
+        void *user_data,
+        raft_entry_t* ety,
+        raft_index_t idx
+    );
+
 typedef struct
 {
     /** Callback for sending request vote messages */
@@ -665,6 +677,12 @@ typedef struct
 
     /** Callback for sending TimeoutNow RPC messages to nodes */
     func_send_timeoutnow_f send_timeoutnow;
+
+    /** Callback for processing private append entries on append **/
+    func_appendentry_f append_entry;
+
+    /** Callback for processing the removal of an appended entry from the log */
+    func_appendentry_f remove_entry;
 } raft_cbs_t;
 
 /** A generic notification callback used to allow Raft to notify caller

--- a/include/raft.h
+++ b/include/raft.h
@@ -23,6 +23,7 @@ typedef enum {
     RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS=-9,
     RAFT_ERR_DONE=-10,
     RAFT_ERR_STALE_TERM=-11,
+    RAFT_ERR_RETRY=-12,
     RAFT_ERR_LAST=-100,
 } raft_error_e;
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1278,7 +1278,7 @@ int raft_apply_entry(raft_server_t* me_)
 
     if (me->cb.applylog)
     {
-        int e = me->cb.applylog(me_, me->udata, ety, me->last_applied_idx);
+        int e = me->cb.applylog(me_, me->udata, ety, me->last_applied_idx + 1);
         switch (e) {
             case RAFT_ERR_SHUTDOWN:
                 raft_entry_release(ety);

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -437,7 +437,7 @@ void TestRaft_user_applylog_error_propogates_to_periodic(
 
     /* let time lapse */
     CuAssertIntEquals(tc, RAFT_ERR_SHUTDOWN, raft_periodic(r, 1));
-    CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
+    CuAssertIntEquals(tc, 0, raft_get_last_applied_idx(r));
 }
 
 void TestRaft_server_apply_entry_increments_last_applied_idx(CuTest* tc)

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -1002,7 +1002,7 @@ class RaftServer(object):
                     except Exception as e:
                         ety1 = lib.raft_get_entry_from_idx(self.raft, idx)
                         ety2 = lib.raft_get_entry_from_idx(server.raft, idx)
-                        logger.error('ids', ety1.id, ety2.id)
+                        logger.error('ids: {0} {1}'.format(ety1.id, ety2.id))
                         logger.error('{0}vs{1} idx:{2} terms:{3} {4} ids:{5} {6}'.format(
                             self, server,
                             idx,


### PR DESCRIPTION
currently, only libraft can process state on append/remove of log entries (and only does it for cfg entries).  This adds callbacks so the client code can implement its own, in its own private state.