### PR TITLE
Add support for async disk flush, backpressure and batching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ test_virtraft: $(RAFT_CFFI_TARGET)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 5 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 $(VIRTRAFT_OPTS)
 	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 --client_rate 0 $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 1 -m 3 --auto_flush $(VIRTRAFT_OPTS)
+	python3 tests/virtraft2.py --servers 5 -i 20000 --compaction_rate 50 --drop_rate 5 -P 10 --seed 6 -m 3 --auto_flush $(VIRTRAFT_OPTS)
 
 .PHONY: amalgamation
 amalgamation:

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -132,9 +132,13 @@ typedef struct {
      * manually. It will trigger sending appendreqs, applying entries etc.
      * Useful for batching, e.g after many raft_recv_entry() calls,
      * one raft_flush() call will trigger sending appendreq for the latest
-     * entries.
-     */
+     * entries. */
     int auto_flush;
+
+    /* Index of the log entry that need to be written to the disk. Only useful
+     * when auto flush is disabled. */
+    raft_index_t next_sync_index;
+
     int timeout_now;
 } raft_server_private_t;
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -120,10 +120,21 @@ typedef struct {
     raft_read_request_t *read_queue_head;
     raft_read_request_t *read_queue_tail;
 
+    /* Do we need quorum ? e.g Leader received a read request, need quorum round
+     * before processing it */
+    int need_quorum_round;
+
     raft_node_id_t node_transferring_leader_to; // the node we are targeting for leadership
     long transfer_leader_time; // how long we should wait for leadership transfer to take, before aborting
     int sent_timeout_now; // if we've already sent a leadership transfer signal
 
+    /* If this config is off (equals zero), user must call raft_flush()
+     * manually. It will trigger sending appendreqs, applying entries etc.
+     * Useful for batching, e.g after many raft_recv_entry() calls,
+     * one raft_flush() call will trigger sending appendreq for the latest
+     * entries.
+     */
+    int auto_flush;
     int timeout_now;
 } raft_server_private_t;
 

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -424,6 +424,11 @@ static raft_index_t __log_count(void *log)
     return log_count(log);
 }
 
+static int __log_sync(void *log)
+{
+    return 0;
+}
+
 const raft_log_impl_t raft_log_internal_impl = {
     .init = __log_init,
     .free = __log_free,
@@ -435,5 +440,6 @@ const raft_log_impl_t raft_log_internal_impl = {
     .get_batch = __log_get_batch,
     .first_idx = __log_first_idx,
     .current_idx = __log_current_idx,
-    .count = __log_count
+    .count = __log_count,
+    .sync = __log_sync
 };

--- a/tests/helpers.h
+++ b/tests/helpers.h
@@ -36,7 +36,7 @@ static void __RAFT_APPEND_ENTRY(void *r, int id, raft_term_t term, const char *d
 {
     raft_entry_t *e = __MAKE_ENTRY(id, term, data);
     raft_append_entry(r, e);
-    raft_set_persisted_index(r, raft_get_current_idx(r));
+    raft_node_set_match_idx(raft_get_my_node(r), raft_get_current_idx(r));
 }
 
 static void __RAFT_APPEND_ENTRIES_SEQ_ID(void *r, int count, int id, raft_term_t term, const char *data)

--- a/tests/helpers.h
+++ b/tests/helpers.h
@@ -36,6 +36,7 @@ static void __RAFT_APPEND_ENTRY(void *r, int id, raft_term_t term, const char *d
 {
     raft_entry_t *e = __MAKE_ENTRY(id, term, data);
     raft_append_entry(r, e);
+    raft_set_persisted_index(r, raft_get_current_idx(r));
 }
 
 static void __RAFT_APPEND_ENTRIES_SEQ_ID(void *r, int count, int id, raft_term_t term, const char *data)

--- a/tests/test_log_impl.c
+++ b/tests/test_log_impl.c
@@ -9,6 +9,7 @@
 #include "linked_list_queue.h"
 
 #include "raft.h"
+#include "raft_private.h"
 #include "helpers.h"
 
 static raft_node_id_t __get_node_id(

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -465,12 +465,10 @@ class Network(object):
                 server.periodic(self.random.randint(1, 100))
 
             if not self.auto_flush:
-                # Pretend like async operation for persisting entries are
-                # completed and call raft_flush() often to trigger sending
-                # appendentries.
-                idx = lib.raft_get_current_idx(server.raft)
-                assert lib.raft_set_persisted_index(server.raft, idx) == 0
-                assert lib.raft_flush(server.raft) == 0
+                # Pretend like async disk write operation is completed. Also,
+                # call raft_flush() often to trigger sending appendentries.
+                idx = lib.raft_get_index_to_sync(server.raft)
+                assert lib.raft_flush(server.raft, idx) == 0
 
         # Deadlock detection
         if self.client_rate != 0 and self.latest_applied_log_idx != 0 and self.latest_applied_log_iteration + 5000 < self.iteration:

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -22,6 +22,7 @@ Usage:
   virtraft --servers SERVERS [-d RATE] [-D RATE] [-c RATE] [-C RATE] [-m RATE]
                              [-P RATE] [-s SEED] [-i ITERS] [-p] [--tsv] [--rqm MULTI]
                              [-q] [-v] [-l LEVEL] [-j] [-L LOGFILE] [--duplex_partition]
+                             [--auto_flush]
   virtraft --version
   virtraft --help
 
@@ -49,6 +50,7 @@ Options:
   -V --version               Display version.
   -h --help                  Prints a short usage summary.
   --duplex_partition         On partition, prevent traffic from flowing in both directions
+  --auto_flush               Use libraft with auto_flush option
 
 Examples:
 
@@ -311,6 +313,9 @@ def verify_read(arg):
             continue
 
         node = lib.raft_get_node(net.servers[i-1].raft, leader.id)
+        if node == ffi.NULL:
+            continue
+
         msg_id = lib.raft_node_get_max_seen_msg_id(node)
         if msg_id >= arg:
             count += 1
@@ -363,6 +368,7 @@ class Network(object):
         self.partitions = set()
         self.no_random_period = False
         self.duplex_partition = False
+        self.auto_flush = False
         self.last_seen_read_queue_msg_id = -1
         self.rqm = 10000000000
 
@@ -457,6 +463,14 @@ class Network(object):
                 server.periodic(100)
             else:
                 server.periodic(self.random.randint(1, 100))
+
+            if not self.auto_flush:
+                # Pretend like async operation for persisting entries are
+                # completed and call raft_flush() often to trigger sending
+                # appendentries.
+                idx = lib.raft_get_current_idx(server.raft)
+                assert lib.raft_set_persisted_index(server.raft, idx) == 0
+                assert lib.raft_flush(server.raft) == 0
 
         # Deadlock detection
         if self.client_rate != 0 and self.latest_applied_log_idx != 0 and self.latest_applied_log_iteration + 5000 < self.iteration:
@@ -767,7 +781,6 @@ class Network(object):
         logger.info(f"trying to remove follower: node {lib.raft_get_nodeid(server.raft)}")
 
         # Wake up new node
-        assert NODE_CONNECTED == server.connection_status
         server.set_connection_status(NODE_DISCONNECTING)
 
     def diagnostic_info(self):
@@ -838,6 +851,7 @@ class RaftServer(object):
         lib.raft_set_callbacks(self.raft, cbs, self.udata)
         lib.log_set_callbacks(lib.raft_get_log(self.raft), log_cbs, self.raft)
         lib.raft_set_election_timeout(self.raft, 500)
+        lib.raft_set_auto_flush(self.raft, network.auto_flush)
 
         self.fsm_dict = {}
         self.fsm_log = []
@@ -1353,6 +1367,7 @@ if __name__ == '__main__':
     net.no_random_period = 1 == int(args['--no_random_period'])
     net.duplex_partition = 1 == int(args['--duplex_partition'])
     net.rqm = int(args['--rqm'])
+    net.auto_flush = 1 == int(args['--auto_flush'])
 
     net.num_of_servers = int(args['--servers'])
 


### PR DESCRIPTION
Adding support for batching and async disk write operations to achieve better performance numbers.

To increase performance, we need batching while writing entries to the disk and sending appendentries to the followers. As disk write operations are quite slow, writing many entries at once will provide better performance. Also, creating an appendentries message for each entry is inefficient, we can create a single appendentries message for multiple entries. User can manually control when to write to the disk and when to create appendentries messages. As an example, assume user is reading messages from the network in an event loop. For each iteration, after network messages are read, we can trigger disk write for the entries received in that iteration. In parallel to that, we can send new appendentries messages for this entry batch. 

This PR introduces auto flush mode which is controlled by `raft_set_auto_flush()`. Default is `auto_flush = on`, this mode preserves current behavior of the library. Once it's disabled, enables user to do batching and offload disk write operation to another thread : 

1-  Leader node can now flush log entries to the disk in another thread. Leader must call `raft_get_index_to_sync()` and complete disk write operation for the entries in another thread. After operation is completed, `raft_flush(sync_index)` should be called to update persisted entry index.

2- `raft_flush()` function will also update the commit index, apply entries and send appendentries messages. It helps with batching: After calling `raft_recv_entry()` or `raft_queue_read_request()` many times, calling `raft_flush()` once will create single appendentries message for the new batch of entries. 

3 - Followers still operate in synchronous way. `sync()` callback is added to the `log_cbs_t` to verify log entries are persisted to the disk. Followers just need to write entries in the append entries message to the disk, call `sync()` once and send the appendentries response. As leader sends entries in batches, followers don't need to do anything special. 

4- Added `backpressure()` callback to decide whether we want to send another appendentries message to the node. Basically, it prevents creating too many messages in flight if we don't get response from the previous ones and helps with batching until we can send more messages to a node. 

A typical implementation for this mode would look like : 

```c
  void server_loop() {
     while (1) {
         HandleNetworkOperations();
 
          for (int i = 0; i < new_readreq_count; i++)
              raft_queue_read_request(raft, read_requests[i]);
 
          for (int i = 0; i < new_requests_count; i++)
              raft_recv_entry(raft, new_requests[i]);
 
          raft_index_t current_idx = raft_get_index_to_sync(raft);
          if (current_idx != 0) {
               TriggerAsyncWriteForIndex(current_idx);
          }
 
         raft_index_t sync_index = GetLastCompletedSyncIndex();
 
         // This call will send new appendentries messages if necessary
         raft_flush(sync_index);
     }
  }

```