### PR TITLE
Set minimum supported CMake version as 3.7.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #         make && make tests_full
 
 project(raft C)
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.7.2)
 
 macro(define_test name)
     add_executable(${name}


### PR DESCRIPTION
Lower minimum required version to support older Cmake versions