### PR TITLE
Check if the node is leader inside raft_get_index_to_sync()

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1550,7 +1550,7 @@ raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
  * another thread. Also, users should call raft_flush() often to update
  * persisted log index and to send new appendentries messages.
  *
- * Example :
+ * Example:
  *
  * void server_loop() {
  *    while (1) {
@@ -1586,6 +1586,10 @@ int raft_set_auto_flush(raft_server_t* me, int flush);
  *
  * This function is only useful when auto flush is disabled. Same index will be
  * reported once.
+ *
+ * If the node is not the leader, it returns zero. For followers, disk flush is
+ * synchronous. sync() callback is called when an appendentries message
+ * received. So, this function does not makes sense if the node is a follower.
  *
  * @param[in] raft The Raft server
  * @return entry index need to be written to the disk.

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -2159,10 +2159,11 @@ static int raft_update_commit_idx(raft_server_t* me_)
 raft_index_t raft_get_index_to_sync(raft_server_t *me_)
 {
     raft_server_private_t* me = (raft_server_private_t*) me_;
-
     raft_index_t idx = raft_get_current_idx(me_);
-    if (me->next_sync_index > idx)
+
+    if (!raft_is_leader(me_) || idx < me->next_sync_index) {
         return 0;
+    }
 
     me->next_sync_index = idx + 1;
     return idx;


### PR DESCRIPTION
- Disk flush is synchronous for followers, `sync()` callback is called immediately when an appendentries message is received.
- `raft_get_index_to_sync()` is part of async API for disk flush when the node is the leader.  Added state check inside this function, to verify node is leader. Users don't need to check state explicitly anymore.