### PR TITLE
Do not prevent election when snapshot is in progress

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -643,10 +643,7 @@ int raft_periodic(raft_server_t* me_, int msec_since_last_period)
             raft_update_quorum_meta(me_, quorum_id);
 	    }
     }
-    else if ((me->election_timeout_rand <= me->timeout_elapsed || me->timeout_now) &&
-        /* Don't become the leader when building snapshots or bad things will
-         * happen when we get a client request */
-        !raft_snapshot_is_in_progress(me_))
+    else if ((me->election_timeout_rand <= me->timeout_elapsed || me->timeout_now))
     {
         int e = raft_election_start(me_);
         if (0 != e)


### PR DESCRIPTION
Do not prevent election when snapshot is in progress.

This condition hurts availability. I'm not sure what was the intention but I don't see any point to support this "mode". If concern is applying an entry when snapshot is in progress, there is `raft_is_apply_allowed()` function that prevents it already. 

