### PR TITLE
Make leader transfer faster

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -40,10 +40,10 @@ typedef enum {
 } raft_state_e;
 
 typedef enum {
-    RAFT_STATE_LEADERSHIP_TRANSFER_TIMEOUT,
-    RAFT_STATE_LEADERSHIP_TRANSFER_UNEXPECTED_LEADER,
-    RAFT_STATE_LEADERSHIP_TRANSFER_EXPECTED_LEADER,
-} raft_transfer_state_e;
+    RAFT_LEADER_TRANSFER_TIMEOUT,
+    RAFT_LEADER_TRANSFER_UNEXPECTED_LEADER,
+    RAFT_LEADER_TRANSFER_EXPECTED_LEADER,
+} raft_leader_transfer_e;
 
 /** Allow entries to apply while taking a snapshot */
 #define RAFT_SNAPSHOT_NONBLOCKING_APPLY     1
@@ -169,9 +169,6 @@ typedef struct
 
     /** term of candidate's last log entry */
     raft_term_t last_log_term;
-
-    /** tell nodes that they should allow a vote, even with a healthy leader */
-    int transfer_leader;
 } msg_requestvote_t;
 
 /** Vote request response message.
@@ -581,15 +578,15 @@ typedef void (
  *
  * @param[in] raft The Raft server making this callback
  * @param[in] user_data User data that is passed from Raft server
- * @param[in] state the leadership transfer result
+ * @param[in] result the leadership transfer result
  */
 typedef void (
-        *func_transfer_event_f
+*func_transfer_event_f
 )   (
-        raft_server_t* raft,
-        void *user_data,
-        raft_transfer_state_e state
-);
+    raft_server_t* raft,
+    void *user_data,
+    raft_leader_transfer_e result
+    );
 
 /** Callback for sending TimeoutNow RPC messages
  * @param[in] raft The Raft server making this callback
@@ -599,8 +596,8 @@ typedef void (
 typedef int (
 *func_send_timeoutnow_f
 )   (
-        raft_server_t* raft,
-        raft_node_t* node
+    raft_server_t* raft,
+    raft_node_t* node
     );
 
 /** Callback to skip sending msg_appendentries to the node
@@ -1532,8 +1529,8 @@ int raft_transfer_leader(raft_server_t* me_, raft_node_id_t node_id, long timeou
 /* get the targeted node_id if a leadership transfer is in progress, or RAFT_NODE_ID_NONE if not */
 raft_node_id_t raft_get_transfer_leader(raft_server_t* me_);
 
-/* cause this server to force an election on its next raft_periodic function call */
-void raft_set_timeout_now(raft_server_t* me_);
+/* cause this server to force an election. */
+int raft_timeout_now(raft_server_t* me_);
 
 raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -139,10 +139,9 @@ typedef struct {
      * when auto flush is disabled. */
     raft_index_t next_sync_index;
 
-    int timeout_now;
 } raft_server_private_t;
 
-int raft_election_start(raft_server_t* me);
+int raft_election_start(raft_server_t* me, int skip_precandidate);
 
 int raft_become_candidate(raft_server_t* me);
 

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -299,10 +299,3 @@ raft_node_id_t raft_get_transfer_leader(raft_server_t* me_)
     return me->node_transferring_leader_to;
 }
 
-/* Forces the raft server to invoke an election on the next raft_periodic function call */
-void raft_set_timeout_now(raft_server_t* me_)
-{
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-
-    me->timeout_now = 1;
-}


### PR DESCRIPTION
This is an attempt to fix failed leader transfer issue we've seen in CI. Not sure if this is the case but still I can imagine a scenario where it can fail. 

- Target node receives "timeout now" message and it starts pre-candidate round. 
- Term is still same at this point.
- If prior leader sends a heartbeat, target node has to accept it and revert back to follower as the term matches. 

Second problem is, we wait until periodic() call to start an election. This extends transfer time, might be undesirable. 

This PR makes two changes to fix these issues:

When target node receives "timeout now" message:
 - Target node starts election immediately without waiting periodic() call.
 - Target node skips pre-candidate round and becomes candidate immediately to increment term. This way, prior leader's appendentries messages will be rejected. Also, it means one less "round-trip time" to complete transfer. 

As we skip pre-candidate round and start the election immediately, leader transfer will be completed in one round-trip time (candidate round). Probably, this is the fastest way to do it. From clients point of view, they'll experience less downtime when leader is transferred. 

Other notes: 
- Renamed leader transfer enum to distinguish with state enum.
- Deleted `transfer_leader` field from reqvote msg. When a node receives a prevote request, it checks if there is a valid leader and reject the request according to. With this PR, leader transfer will only use reqvote (not prevote), so, `transfer_leader` field is not necessary anymore.