### PR TITLE
Add switch to enable/disable library logs.

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -960,6 +960,10 @@ void raft_set_election_timeout(raft_server_t* me, int msec);
  * @param[in] msec Request timeout in milliseconds */
 void raft_set_request_timeout(raft_server_t* me, int msec);
 
+/** Enable/disable library log.
+ * @param enable 0 to disable*/
+void raft_set_log_enabled(raft_server_t* me_, int enable);
+
 /** Process events that are dependent on time passing.
  * @param[in] msec_elapsed Time in milliseconds since the last call
  * @return

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -140,6 +140,8 @@ typedef struct {
     raft_index_t next_sync_index;
 
     int timeout_now;
+
+    int log_enabled;
 } raft_server_private_t;
 
 int raft_election_start(raft_server_t* me);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -56,7 +56,7 @@ static void raft_log_node(raft_server_t *me_,
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
 
-    if (me->cb.log == NULL)
+    if (!me->log_enabled || me->cb.log == NULL)
         return;
 
     char buf[1024];

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -29,6 +29,12 @@ void raft_set_request_timeout(raft_server_t* me_, int millisec)
     me->request_timeout = millisec;
 }
 
+void raft_set_log_enabled(raft_server_t* me_, int enable)
+{
+    raft_server_private_t* me = (raft_server_private_t*)me_;
+    me->log_enabled = enable;
+}
+
 raft_node_id_t raft_get_nodeid(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;


### PR DESCRIPTION
Added a function to enable/disable logging. 

Previously, we were controlling this by passing log callback pointer as null or not but it's not practical as you need to pass all callbacks together just to turn on/off logging on runtime. 