### PR TITLE
Delete unused connection data

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -12,13 +12,6 @@
 
 #include "raft_types.h"
 
-enum {
-    RAFT_NODE_STATUS_DISCONNECTED,
-    RAFT_NODE_STATUS_CONNECTED,
-    RAFT_NODE_STATUS_CONNECTING,
-    RAFT_NODE_STATUS_DISCONNECTING
-};
-
 struct raft_log_impl;
 
 typedef struct raft_read_request {
@@ -87,10 +80,6 @@ typedef struct {
 
     /* the log which has a voting cfg change, otherwise -1 */
     raft_index_t voting_cfg_change_log_idx;
-
-    /* Our membership with the cluster is confirmed (ie. configuration log was
-     * committed) */
-    int connected;
 
     int snapshot_in_progress;
     int snapshot_flags;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1254,10 +1254,7 @@ int raft_apply_entry(raft_server_t* me_)
         case RAFT_LOGTYPE_ADD_NODE:
             raft_node_set_addition_committed(node, 1);
             raft_node_set_voting_committed(node, 1);
-            /* Membership Change: confirm connection with cluster */
             raft_node_set_has_sufficient_logs(node);
-            if (node_id == raft_get_nodeid(me_))
-                me->connected = RAFT_NODE_STATUS_CONNECTED;
             break;
         case RAFT_LOGTYPE_ADD_NONVOTING_NODE:
             raft_node_set_addition_committed(node, 1);

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -232,11 +232,6 @@ raft_term_t raft_get_last_log_term(raft_server_t* me_)
     return 0;
 }
 
-int raft_is_connected(raft_server_t* me_)
-{
-    return ((raft_server_private_t*)me_)->connected;
-}
-
 int raft_snapshot_is_in_progress(raft_server_t *me_)
 {
     return ((raft_server_private_t*)me_)->snapshot_in_progress;


### PR DESCRIPTION
Deleted unused connection data.

If required, to learn whether current node is a voter or not, `raft_node_is_voting()` can be called.