### PR TITLE
Delete raft_poll_entry function which is effectively noop

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1340,12 +1340,6 @@ int raft_snapshot_is_in_progress(raft_server_t *me_);
  **/
 int raft_is_apply_allowed(raft_server_t* me_);
 
-/** Remove the first log entry.
- * This should be used for compacting logs.
- * @return 0 on success
- **/
-int raft_poll_entry(raft_server_t* me_);
-
 /** Get last applied entry
  **/
 raft_entry_t *raft_get_last_applied_entry(raft_server_t *me_);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1669,20 +1669,6 @@ int raft_entry_is_cfg_change(raft_entry_t* ety)
         RAFT_LOGTYPE_REMOVE_NODE == ety->type);
 }
 
-int raft_poll_entry(raft_server_t* me_)
-{
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    /* We should never drop uncommitted entries */
-    assert(me->log_impl->first_idx(me->log) <= raft_get_commit_idx(me_));
-
-    int e = me->log_impl->poll(me->log, me->log_impl->first_idx(me->log));
-    if (e != 0)
-        return e;
-
-    return me->log_impl->sync(me->log);
-}
-
 int raft_pop_entry(raft_server_t* me_)
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -346,14 +346,6 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     CuAssertIntEquals(tc, 3, raft_get_log_count(r));
     CuAssertIntEquals(tc, 2, raft_get_num_snapshottable_logs(r));
     CuAssertIntEquals(tc, 1, raft_get_last_log_term(r));
-
-    CuAssertIntEquals(tc, 0, raft_begin_snapshot(r, 0));
-
-    int i = raft_get_first_entry_idx(r);
-    for (; i < raft_get_commit_idx(r); i++) {
-        CuAssertIntEquals(tc, 0, raft_poll_entry(r));
-    }
-
     CuAssertIntEquals(tc, 0, raft_begin_snapshot(r, 0));
     CuAssertIntEquals(tc, 0, raft_end_snapshot(r));
     CuAssertIntEquals(tc, 0, raft_get_num_snapshottable_logs(r));
@@ -377,13 +369,6 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     raft_server_private_t *r_p = (raft_server_private_t *) r;
     CuAssertIntEquals(tc, 3, r_p->log_impl->first_idx(r_p->log));
     CuAssertIntEquals(tc, 2, raft_get_num_snapshottable_logs(r));
-
-    i = raft_get_first_entry_idx(r);
-    for (; i < raft_get_commit_idx(r); i++) {
-        printf("raft_poll_entry(2): %d\n", i);
-        CuAssertIntEquals(tc, 0, raft_poll_entry(r));
-    }
-
     CuAssertIntEquals(tc, 0, raft_begin_snapshot(r, 0));
     CuAssertIntEquals(tc, 0, raft_end_snapshot(r));
     CuAssertIntEquals(tc, 0, raft_get_num_snapshottable_logs(r));
@@ -427,11 +412,6 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted2(CuTest * tc)
     CuAssertIntEquals(tc, 2, raft_get_num_snapshottable_logs(r));
 
     CuAssertIntEquals(tc, 0, raft_begin_snapshot(r, 0));
-
-    int i = raft_get_first_entry_idx(r);
-    for (; i <= raft_get_commit_idx(r); i++)
-        CuAssertIntEquals(tc, 0, raft_poll_entry(r));
-
     CuAssertIntEquals(tc, 0, raft_end_snapshot(r));
     CuAssertIntEquals(tc, 0, raft_get_num_snapshottable_logs(r));
     CuAssertIntEquals(tc, 1, raft_get_log_count(r));


### PR DESCRIPTION
Delete `raft_poll_entry()` function which is effectively noop

Log compaction is done inside `raft_end_snapshot()`. `raft_poll_entry()` is not necessary and it doesn't work already. It passes first log index to `poll()` callback. `poll()` callback is supposed to delete entries before the passed index. So, this function will ask deleting entries before the first log entry. It does not make sense.

Fixes: https://github.com/RedisLabs/raft/issues/78

