### PR TITLE
Delete leftover assignment in raft_set_snapshot_metadata()

### DIFF
--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -270,8 +270,6 @@ void raft_set_snapshot_metadata(raft_server_t *me_, raft_term_t term, raft_index
 {
     raft_server_private_t* me = (raft_server_private_t*)me_;
     me->last_applied_idx = idx;
-    me->next_snapshot_last_term = me->snapshot_last_term;
-    me->next_snapshot_last_idx = me->snapshot_last_idx;
     me->snapshot_last_term = term;
     me->snapshot_last_idx = idx;
 }


### PR DESCRIPTION
Fixes https://github.com/RedisLabs/raft/issues/79