### PR TITLE
Delete private_t typedefs

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -288,7 +288,7 @@ typedef struct
 } msg_appendentries_response_t;
 
 typedef void* raft_server_t;
-typedef void* raft_node_t;
+typedef struct raft_node raft_node_t;
 
 /** Callback for sending request vote messages.
  * @param[in] raft The Raft server making this callback

--- a/include/raft.h
+++ b/include/raft.h
@@ -287,7 +287,7 @@ typedef struct
     raft_index_t current_idx;
 } msg_appendentries_response_t;
 
-typedef void* raft_server_t;
+typedef struct raft_server raft_server_t;
 typedef struct raft_node raft_node_t;
 
 /** Callback for sending request vote messages.

--- a/include/raft.h
+++ b/include/raft.h
@@ -903,7 +903,7 @@ raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
 
 /** De-initialise Raft server.
  * Frees all memory */
-void raft_destroy(raft_server_t* me_);
+void raft_destroy(raft_server_t* me);
 
 /** De-initialise Raft server. */
 void raft_clear(raft_server_t* me);
@@ -941,11 +941,11 @@ raft_node_t* raft_add_node(raft_server_t* me, void* user_data, raft_node_id_t id
  * @return
  *  node if it was successfully added;
  *  NULL if the node already exists */
-raft_node_t* raft_add_non_voting_node(raft_server_t* me_, void* udata, raft_node_id_t id, int is_self);
+raft_node_t* raft_add_non_voting_node(raft_server_t* me, void* udata, raft_node_id_t id, int is_self);
 
 /** Remove node.
  * @param node The node to be removed. */
-void raft_remove_node(raft_server_t* me_, raft_node_t* node);
+void raft_remove_node(raft_server_t* me, raft_node_t* node);
 
 /** Set election timeout.
  * The amount of time that needs to elapse before we assume the leader is down
@@ -959,7 +959,7 @@ void raft_set_request_timeout(raft_server_t* me, int msec);
 
 /** Enable/disable library log.
  * @param enable 0 to disable*/
-void raft_set_log_enabled(raft_server_t* me_, int enable);
+void raft_set_log_enabled(raft_server_t* me, int enable);
 
 /** Process events that are dependent on time passing.
  * @param[in] msec_elapsed Time in milliseconds since the last call
@@ -1004,7 +1004,7 @@ int raft_recv_appendentries_response(raft_server_t* me,
  * @param[out] resp The resulting response
  * @return
  *  0 on success  */
-int raft_recv_snapshot(raft_server_t* me_,
+int raft_recv_snapshot(raft_server_t* me,
                        raft_node_t* node,
                        msg_snapshot_t *req,
                        msg_snapshot_response_t *resp);
@@ -1016,7 +1016,7 @@ int raft_recv_snapshot(raft_server_t* me_,
  *  0 on success;
  *  -1 on error;
  *  RAFT_ERR_NOT_LEADER server is not the leader */
-int raft_recv_snapshot_response(raft_server_t* me_,
+int raft_recv_snapshot_response(raft_server_t* me,
                                 raft_node_t* node,
                                 msg_snapshot_response_t *r);
 
@@ -1074,7 +1074,7 @@ int raft_get_nodeid(raft_server_t* me);
 
 /**
  * @return the server's node */
-raft_node_t* raft_get_my_node(raft_server_t *me_);
+raft_node_t* raft_get_my_node(raft_server_t *me);
 
 /**
  * @return currently configured election timeout in milliseconds */
@@ -1086,7 +1086,7 @@ int raft_get_num_nodes(raft_server_t* me);
 
 /**
  * @return number of voting nodes that this server has */
-int raft_get_num_voting_nodes(raft_server_t* me_);
+int raft_get_num_voting_nodes(raft_server_t* me);
 
 /**
  * @return number of items within log */
@@ -1102,7 +1102,7 @@ raft_index_t raft_get_current_idx(raft_server_t* me);
 
 /**
  * @return commit index */
-raft_index_t raft_get_commit_idx(raft_server_t* me_);
+raft_index_t raft_get_commit_idx(raft_server_t* me);
 
 /**
  * @return 1 if follower; 0 otherwise */
@@ -1163,13 +1163,13 @@ raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, raft_index_t idx);
 /**
  * @param[in] node The node's ID
  * @return node pointed to by node ID */
-raft_node_t* raft_get_node(raft_server_t* me_, raft_node_id_t id);
+raft_node_t* raft_get_node(raft_server_t* me, raft_node_id_t id);
 
 /**
  * Used for iterating through nodes
  * @param[in] node The node's idx
  * @return node pointed to by node idx */
-raft_node_t* raft_get_node_from_idx(raft_server_t* me_, raft_index_t idx);
+raft_node_t* raft_get_node_from_idx(raft_server_t* me, raft_index_t idx);
 
 /**
  * @return number of votes this server has received this election */
@@ -1182,13 +1182,13 @@ int raft_get_voted_for(raft_server_t* me);
 /** Get what this node thinks the node ID of the leader is.
  * @return node of what this node thinks is the valid leader;
  *   RAFT_NODE_ID_NONE if there is no leader */
-raft_node_id_t raft_get_leader_id(raft_server_t* me_);
+raft_node_id_t raft_get_leader_id(raft_server_t* me);
 
 /** Get what this node thinks the node of the leader is.
  * @return node of what this node thinks is the valid leader;
  *   NULL if there is no leader or
  *        if the leader is not part of the local configuration yet */
-raft_node_t* raft_get_leader_node(raft_server_t* me_);
+raft_node_t* raft_get_leader_node(raft_server_t* me);
 
 /**
  * @return callback user data */
@@ -1199,14 +1199,14 @@ void* raft_get_udata(raft_server_t* me);
  * @param[in] node The server to vote for
  * @return
  *  0 on success */
-int raft_vote(raft_server_t* me_, raft_node_t* node);
+int raft_vote(raft_server_t* me, raft_node_t* node);
 
 /** Vote for a server.
  * This should be used to reload persistent state, ie. the voted-for field.
  * @param[in] nodeid The server to vote for by nodeid
  * @return
  *  0 on success */
-int raft_vote_for_nodeid(raft_server_t* me_, raft_node_id_t nodeid);
+int raft_vote_for_nodeid(raft_server_t* me, raft_node_id_t nodeid);
 
 /** Set the current term.
  * This should be used to reload persistent state, ie. the current_term field.
@@ -1238,20 +1238,20 @@ int raft_pop_entry(raft_server_t* me);
 
 /** Confirm if a msg_entry_response has been committed.
  * @param[in] r The response we want to check */
-int raft_msg_entry_response_committed(raft_server_t* me_,
+int raft_msg_entry_response_committed(raft_server_t* me,
                                       const msg_entry_response_t* r);
 
 /** Get node's ID.
  * @return ID of node */
-raft_node_id_t raft_node_get_id(raft_node_t* me_);
+raft_node_id_t raft_node_get_id(raft_node_t* me);
 
 /** Tell if we are a leader, candidate or follower.
  * @return get state of type raft_state_e. */
-int raft_get_state(raft_server_t* me_);
+int raft_get_state(raft_server_t* me);
 
 /** Get the most recent log's term
  * @return the last log term */
-raft_term_t raft_get_last_log_term(raft_server_t* me_);
+raft_term_t raft_get_last_log_term(raft_server_t* me);
 
 /** Turn a node into a voting node.
  * Voting nodes can take part in elections and in-regards to committing entries,
@@ -1260,17 +1260,17 @@ void raft_node_set_voting(raft_node_t* node, int voting);
 
 /** Tell if a node is a voting node or not.
  * @return 1 if this is a voting node. Otherwise 0. */
-int raft_node_is_voting(raft_node_t* me_);
+int raft_node_is_voting(raft_node_t* me);
 
 /** Check if a node has sufficient logs to be able to join the cluster.
  **/
-int raft_node_has_sufficient_logs(raft_node_t* me_);
+int raft_node_has_sufficient_logs(raft_node_t* me);
 
 /** Apply all entries up to the commit index
  * @return
  *  0 on success;
  *  RAFT_ERR_SHUTDOWN when server MUST shutdown */
-int raft_apply_all(raft_server_t* me_);
+int raft_apply_all(raft_server_t* me);
 
 /** Become leader
  * WARNING: this is a dangerous function call. It could lead to your cluster
@@ -1304,7 +1304,7 @@ int raft_entry_is_cfg_change(raft_entry_t* ety);
  * @return 0 on success
  *
  **/
-int raft_begin_snapshot(raft_server_t *me_, int flags);
+int raft_begin_snapshot(raft_server_t *me, int flags);
 
 /** Stop snapshotting.
  *
@@ -1320,7 +1320,7 @@ int raft_begin_snapshot(raft_server_t *me_, int flags);
  *  0 on success
  *  -1 on failure
  **/
-int raft_end_snapshot(raft_server_t *me_);
+int raft_end_snapshot(raft_server_t *me);
 
 /** Cancel snapshotting.
  *
@@ -1330,22 +1330,22 @@ int raft_end_snapshot(raft_server_t *me_);
  * The user MUST be sure the original snapshot is left untouched and remains
  * usable.
  */
-int raft_cancel_snapshot(raft_server_t *me_);
+int raft_cancel_snapshot(raft_server_t *me);
 
 /** Check is a snapshot is in progress
  **/
-int raft_snapshot_is_in_progress(raft_server_t *me_);
+int raft_snapshot_is_in_progress(raft_server_t *me);
 
 /** Check if entries can be applied now (no snapshot in progress, or
  * RAFT_SNAPSHOT_NONBLOCKING_APPLY specified).
  **/
-int raft_is_apply_allowed(raft_server_t* me_);
+int raft_is_apply_allowed(raft_server_t* me);
 
 /** Get last applied entry
  **/
-raft_entry_t *raft_get_last_applied_entry(raft_server_t *me_);
+raft_entry_t *raft_get_last_applied_entry(raft_server_t *me);
 
-raft_index_t raft_get_first_entry_idx(raft_server_t* me_);
+raft_index_t raft_get_first_entry_idx(raft_server_t* me);
 
 /** Start loading snapshot
  *
@@ -1363,7 +1363,7 @@ raft_index_t raft_get_first_entry_idx(raft_server_t* me_);
  *  -1 on failure
  *  RAFT_ERR_SNAPSHOT_ALREADY_LOADED
  **/
-int raft_begin_load_snapshot(raft_server_t *me_,
+int raft_begin_load_snapshot(raft_server_t *me,
                        raft_term_t last_included_term,
 		       raft_index_t last_included_index);
 
@@ -1373,19 +1373,19 @@ int raft_begin_load_snapshot(raft_server_t *me_,
  *  0 on success
  *  -1 on failure
  **/
-int raft_end_load_snapshot(raft_server_t *me_);
+int raft_end_load_snapshot(raft_server_t *me);
 
-raft_index_t raft_get_snapshot_last_idx(raft_server_t *me_);
+raft_index_t raft_get_snapshot_last_idx(raft_server_t *me);
 
-raft_term_t raft_get_snapshot_last_term(raft_server_t *me_);
+raft_term_t raft_get_snapshot_last_term(raft_server_t *me);
 
-void raft_set_snapshot_metadata(raft_server_t *me_, raft_term_t term, raft_index_t idx);
+void raft_set_snapshot_metadata(raft_server_t *me, raft_term_t term, raft_index_t idx);
 
 /** Check if a node is active.
  * Active nodes could become voting nodes.
  * This should be used for creating the membership snapshot.
  **/
-int raft_node_is_active(raft_node_t* me_);
+int raft_node_is_active(raft_node_t* me);
 
 /** Make the node active.
  *
@@ -1394,17 +1394,17 @@ int raft_node_is_active(raft_node_t* me_);
  *
  * @param[in] active Set a node as active if this is 1
  **/
-void raft_node_set_active(raft_node_t* me_, int active);
+void raft_node_set_active(raft_node_t* me, int active);
 
 /** Check if a node's voting status has been committed.
  * This should be used for creating the membership snapshot.
  **/
-int raft_node_is_voting_committed(raft_node_t* me_);
+int raft_node_is_voting_committed(raft_node_t* me);
 
 /** Check if a node's membership to the cluster has been committed.
  * This should be used for creating the membership snapshot.
  **/
-int raft_node_is_addition_committed(raft_node_t* me_);
+int raft_node_is_addition_committed(raft_node_t* me);
 
 /**
  * Register custom heap management functions, to be used if an alternative
@@ -1418,21 +1418,21 @@ void raft_set_heap_functions(void *(*_malloc)(size_t),
 /** Confirm that a node's voting status is final
  * @param[in] node The node
  * @param[in] voting Whether this node's voting status is committed or not */
-void raft_node_set_voting_committed(raft_node_t* me_, int voting);
+void raft_node_set_voting_committed(raft_node_t* me, int voting);
 
 /** Confirm that a node's voting status is final
  * @param[in] node The node
  * @param[in] committed Whether this node's membership is committed or not */
-void raft_node_set_addition_committed(raft_node_t* me_, int committed);
+void raft_node_set_addition_committed(raft_node_t* me, int committed);
 
 /** Check if a voting change is in progress
  * @param[in] raft The Raft server
  * @return 1 if a voting change is in progress */
-int raft_voting_change_is_in_progress(raft_server_t* me_);
+int raft_voting_change_is_in_progress(raft_server_t* me);
 
 /** Get the log implementation handle in use.
  */
-void *raft_get_log(raft_server_t* me_);
+void *raft_get_log(raft_server_t* me);
 
 /** Backward compatible callbacks for log events, implemented by the
  * default in-memory log implementation.
@@ -1509,28 +1509,28 @@ void raft_entry_release_list(raft_entry_t **ety_list, size_t len);
  */
 extern const raft_log_impl_t raft_log_internal_impl;
 
-void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_index_t idx);
+void raft_handle_append_cfg_change(raft_server_t* me, raft_entry_t* ety, raft_index_t idx);
 
-int raft_queue_read_request(raft_server_t* me_, func_read_request_callback_f cb, void *cb_arg);
+int raft_queue_read_request(raft_server_t* me, func_read_request_callback_f cb, void *cb_arg);
 
 /** Attempt to process read queue.
  */
-void raft_process_read_queue(raft_server_t* me_);
+void raft_process_read_queue(raft_server_t* me);
 
 /*
  * invoke a leadership transfer to targeted node
  * node_id = targeted node
  * timeout = timeout in ms before this transfer is aborted.  if 0, use default election timeout
  */
-int raft_transfer_leader(raft_server_t* me_, raft_node_id_t node_id, long timeout);
+int raft_transfer_leader(raft_server_t* me, raft_node_id_t node_id, long timeout);
 
 /* get the targeted node_id if a leadership transfer is in progress, or RAFT_NODE_ID_NONE if not */
-raft_node_id_t raft_get_transfer_leader(raft_server_t* me_);
+raft_node_id_t raft_get_transfer_leader(raft_server_t* me);
 
 /* cause this server to force an election. */
-int raft_timeout_now(raft_server_t* me_);
+int raft_timeout_now(raft_server_t* me);
 
-raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me_);
+raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
 
 /** Disable auto flush mode. Default is enabled.
  *

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -5,9 +5,9 @@
 
 typedef struct raft_log raft_log_t;
 
-raft_log_t*raft_log_new(void);
+raft_log_t* raft_log_new(void);
 
-raft_log_t*raft_log_alloc(raft_index_t initial_size);
+raft_log_t* raft_log_alloc(raft_index_t initial_size);
 
 void raft_log_set_callbacks(raft_log_t* me, raft_log_cbs_t* funcs, void* raft);
 
@@ -15,7 +15,7 @@ void raft_log_free(raft_log_t* me);
 
 void raft_log_clear(raft_log_t* me);
 
-void log_clear_entries(raft_log_t* me);
+void raft_log_clear_entries(raft_log_t* me);
 
 /**
  * Add entry to log.

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -3,58 +3,58 @@
 
 #include "raft_types.h"
 
-typedef void* log_t;
+typedef struct raft_log raft_log_t;
 
-log_t* log_new(void);
+raft_log_t*raft_log_new(void);
 
-log_t* log_alloc(raft_index_t initial_size);
+raft_log_t*raft_log_alloc(raft_index_t initial_size);
 
-void log_set_callbacks(log_t* me_, raft_log_cbs_t* funcs, void* raft);
+void raft_log_set_callbacks(raft_log_t* me, raft_log_cbs_t* funcs, void* raft);
 
-void log_free(log_t* me_);
+void raft_log_free(raft_log_t* me);
 
-void log_clear(log_t* me_);
+void raft_log_clear(raft_log_t* me);
 
-void log_clear_entries(log_t* me_);
+void log_clear_entries(raft_log_t* me);
 
 /**
  * Add entry to log.
  * Don't add entry if we've already added this entry (based off ID)
  * Don't add entries with ID=0
  * @return 0 if unsuccessful; 1 otherwise */
-int log_append_entry(log_t* me_, raft_entry_t* c);
+int raft_log_append_entry(raft_log_t* me, raft_entry_t* c);
 
 /**
  * @return number of entries held within log */
-raft_index_t log_count(log_t* me_);
+raft_index_t raft_log_count(raft_log_t* me);
 
 /**
  * Delete all logs from this log onwards */
-int log_delete(log_t* me_, raft_index_t idx);
+int raft_log_delete(raft_log_t* me, raft_index_t idx);
 
 /**
  * Empty the queue. */
-void log_empty(log_t * me_);
+void raft_log_empty(raft_log_t * me);
 
 /**
  * Remove oldest entry. Set *etyp to oldest entry on success. */
-int log_poll(log_t * me_, void** etyp);
+int raft_log_poll(raft_log_t * me, raft_entry_t **etyp);
 
 /** Get an array of entries from this index onwards.
  * This is used for batching.
  */
-raft_entry_t** log_get_from_idx(log_t* me_, raft_index_t idx, long *n_etys);
+raft_entry_t** raft_log_get_from_idx(raft_log_t* me, raft_index_t idx, long *n_etys);
 
-raft_entry_t* log_get_at_idx(log_t* me_, raft_index_t idx);
+raft_entry_t* raft_log_get_at_idx(raft_log_t* me, raft_index_t idx);
 
 /**
  * @return youngest entry */
-raft_entry_t *log_peektail(log_t * me_);
+raft_entry_t *raft_log_peektail(raft_log_t * me);
 
-raft_index_t log_get_current_idx(log_t* me_);
+raft_index_t raft_log_get_current_idx(raft_log_t* me);
 
-int log_load_from_snapshot(log_t *me_, raft_index_t idx, raft_term_t term);
+int raft_log_load_from_snapshot(raft_log_t *me, raft_index_t idx, raft_term_t term);
 
-raft_index_t log_get_base(log_t* me_);
+raft_index_t raft_log_get_base(raft_log_t* me);
 
 #endif /* RAFT_LOG_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -137,9 +137,9 @@ int raft_become_candidate(raft_server_t* me);
 
 int raft_become_precandidate(raft_server_t* me);
 
-void raft_randomize_election_timeout(raft_server_t* me_);
+void raft_randomize_election_timeout(raft_server_t* me);
 
-void raft_update_quorum_meta(raft_server_t* me_, raft_msg_id_t id);
+void raft_update_quorum_meta(raft_server_t* me, raft_msg_id_t id);
 
 /**
  * @return 0 on error */
@@ -147,36 +147,36 @@ int raft_send_requestvote(raft_server_t* me, raft_node_t* node);
 
 int raft_send_appendentries(raft_server_t* me, raft_node_t* node);
 
-int raft_send_appendentries_all(raft_server_t* me_);
+int raft_send_appendentries_all(raft_server_t* me);
 
 /**
  * Apply entry at lastApplied + 1. Entry becomes 'committed'.
  * @return 1 if entry committed, 0 otherwise */
-int raft_apply_entry(raft_server_t* me_);
+int raft_apply_entry(raft_server_t* me);
 
 void raft_set_last_applied_idx(raft_server_t* me, raft_index_t idx);
 
-void raft_set_state(raft_server_t* me_, int state);
+void raft_set_state(raft_server_t* me, int state);
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id);
 
-void raft_node_free(raft_node_t* me_);
+void raft_node_free(raft_node_t* me);
 
 void raft_node_set_match_idx(raft_node_t* node, raft_index_t idx);
 
-void raft_node_vote_for_me(raft_node_t* me_, int vote);
+void raft_node_vote_for_me(raft_node_t* me, int vote);
 
-int raft_node_has_vote_for_me(raft_node_t* me_);
+int raft_node_has_vote_for_me(raft_node_t* me);
 
-void raft_node_set_has_sufficient_logs(raft_node_t* me_);
+void raft_node_set_has_sufficient_logs(raft_node_t* me);
 
-int raft_is_single_node_voting_cluster(raft_server_t *me_);
+int raft_is_single_node_voting_cluster(raft_server_t *me);
 
 int raft_votes_is_majority(int nnodes, int nvotes);
 
-void raft_node_set_last_ack(raft_node_t* me_, raft_msg_id_t msgid, raft_term_t term);
+void raft_node_set_last_ack(raft_node_t* me, raft_msg_id_t msgid, raft_term_t term);
 
-raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me_);
+raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me);
 
 /* Heap functions */
 extern void *(*raft_malloc)(size_t size);
@@ -185,17 +185,17 @@ extern void *(*raft_realloc)(void *ptr, size_t size);
 extern void (*raft_free)(void *ptr);
 
 /* update the max_seen_msg_id for this node */
-void raft_node_update_max_seen_msg_id(raft_node_t *me_, raft_msg_id_t msg_id);
+void raft_node_update_max_seen_msg_id(raft_node_t *me, raft_msg_id_t msg_id);
 /* get the max message id this server has seen from its the specified node */
-raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me_);
+raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me);
 /* get the server's current msg_id */
-raft_msg_id_t raft_get_msg_id(raft_server_t* me_);
+raft_msg_id_t raft_get_msg_id(raft_server_t* me);
 
 /* attempt to abort the leadership transfer */
-void raft_reset_transfer_leader(raft_server_t* me_, int timed_out);
+void raft_reset_transfer_leader(raft_server_t* me, int timed_out);
 
-raft_size_t raft_node_get_snapshot_offset(raft_node_t *me_);
+raft_size_t raft_node_get_snapshot_offset(raft_node_t *me);
 
-void raft_node_set_snapshot_offset(raft_node_t *me_, raft_size_t snapshot_offset);
+void raft_node_set_snapshot_offset(raft_node_t *me, raft_size_t snapshot_offset);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -25,7 +25,7 @@ typedef struct raft_read_request {
     struct raft_read_request *next;
 } raft_read_request_t;
 
-typedef struct {
+struct raft_server {
     /* Persistent state: */
 
     /* the server's best guess of what the current term is
@@ -129,7 +129,7 @@ typedef struct {
     raft_index_t next_sync_index;
 
     int log_enabled;
-} raft_server_private_t;
+};
 
 int raft_election_start(raft_server_t* me, int skip_precandidate);
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -54,7 +54,7 @@ typedef struct {
     /* amount of time left till timeout */
     int timeout_elapsed;
 
-    raft_node_t* nodes;
+    raft_node_t** nodes;
     int num_nodes;
 
     int election_timeout;

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -17,7 +17,7 @@
 
 #define INITIAL_CAPACITY 10
 
-typedef struct
+struct raft_log
 {
     /* size of array */
     raft_index_t size;
@@ -37,15 +37,15 @@ typedef struct
     raft_log_cbs_t cb;
 
     void* raft;
-} log_private_t;
+};
 
-static int mod(raft_index_t a, raft_index_t b)
+static raft_index_t mod(raft_index_t a, raft_index_t b)
 {
-    int r = a % b;
+    raft_index_t r = a % b;
     return r < 0 ? r + b : r;
 }
 
-static int __ensurecapacity(log_private_t * me)
+static int ensure_capacity(raft_log_t *me)
 {
     raft_index_t i, j;
     raft_entry_t **temp;
@@ -74,58 +74,53 @@ static int __ensurecapacity(log_private_t * me)
     return 0;
 }
 
-int log_load_from_snapshot(log_t *me_, raft_index_t idx, raft_term_t term)
+int raft_log_load_from_snapshot(raft_log_t *me, raft_index_t idx, raft_term_t term)
 {
     (void) term;
-    log_private_t* me = (log_private_t*)me_;
 
-    log_clear_entries(me_);
-    log_clear(me_);
+    log_clear_entries(me);
+    raft_log_clear(me);
     me->base = idx;
 
     return 0;
 }
 
-log_t* log_alloc(raft_index_t initial_size)
+raft_log_t*raft_log_alloc(raft_index_t initial_size)
 {
-    log_private_t* me = raft_calloc(1, sizeof(log_private_t));
+    raft_log_t *me = raft_calloc(1, sizeof(*me));
     if (!me)
         return NULL;
     me->size = initial_size;
-    log_clear((log_t*)me);
+    raft_log_clear((raft_log_t *) me);
     me->entries = raft_calloc(1, sizeof(raft_entry_t *) * me->size);
     if (!me->entries) {
         raft_free(me);
         return NULL;
     }
-    return (log_t*)me;
+    return (raft_log_t*)me;
 }
 
-log_t* log_new(void)
+raft_log_t*raft_log_new(void)
 {
-    return log_alloc(INITIAL_CAPACITY);
+    return raft_log_alloc(INITIAL_CAPACITY);
 }
 
-void log_set_callbacks(log_t* me_, raft_log_cbs_t* funcs, void* raft)
+void raft_log_set_callbacks(raft_log_t *me, raft_log_cbs_t* funcs, void* raft)
 {
-    log_private_t* me = (log_private_t*)me_;
-
     me->raft = raft;
     me->cb = *funcs;
 }
 
-void log_clear(log_t* me_)
+void raft_log_clear(raft_log_t *me)
 {
-    log_private_t* me = (log_private_t*)me_;
     me->count = 0;
     me->back = 0;
     me->front = 0;
     me->base = 0;
 }
 
-void log_clear_entries(log_t* me_)
+void log_clear_entries(raft_log_t* me)
 {
-    log_private_t* me = (log_private_t*)me_;
     raft_index_t i;
 
     if (!me->count || !me->cb.log_clear)
@@ -139,17 +134,16 @@ void log_clear_entries(log_t* me_)
 }
 
 /** TODO: rename log_append */
-int log_append_entry(log_t* me_, raft_entry_t* ety)
+int raft_log_append_entry(raft_log_t *me, raft_entry_t*c)
 {
-    log_private_t* me = (log_private_t*)me_;
     raft_index_t idx = me->base + me->count + 1;
     int e;
 
-    e = __ensurecapacity(me);
+    e = ensure_capacity(me);
     if (e != 0)
         return e;
 
-    me->entries[me->back] = ety;
+    me->entries[me->back] = c;
 
     if (me->cb.log_offer)
     {
@@ -166,9 +160,8 @@ int log_append_entry(log_t* me_, raft_entry_t* ety)
     return 0;
 }
 
-raft_entry_t** log_get_from_idx(log_t* me_, raft_index_t idx, long *n_etys)
+raft_entry_t**raft_log_get_from_idx(raft_log_t *me, raft_index_t idx, long *n_etys)
 {
-    log_private_t* me = (log_private_t*)me_;
     raft_index_t i;
 
     assert(0 <= idx - 1);
@@ -193,9 +186,8 @@ raft_entry_t** log_get_from_idx(log_t* me_, raft_index_t idx, long *n_etys)
     return &me->entries[i];
 }
 
-raft_entry_t* log_get_at_idx(log_t* me_, raft_index_t idx)
+raft_entry_t*raft_log_get_at_idx(raft_log_t *me, raft_index_t idx)
 {
-    log_private_t* me = (log_private_t*)me_;
     raft_index_t i;
 
     if (idx == 0)
@@ -211,15 +203,13 @@ raft_entry_t* log_get_at_idx(log_t* me_, raft_index_t idx)
     return me->entries[i];
 }
 
-raft_index_t log_count(log_t* me_)
+raft_index_t raft_log_count(raft_log_t *me)
 {
-    return ((log_private_t*)me_)->count;
+    return me->count;
 }
 
-static int __log_delete(log_t* me_, raft_index_t idx, func_entry_notify_f cb, void *cb_arg)
+static int log_delete(raft_log_t* me, raft_index_t idx, func_entry_notify_f cb, void *cb_arg)
 {
-    log_private_t* me = (log_private_t*)me_;
-
     if (0 == idx)
         return -1;
 
@@ -250,14 +240,13 @@ static int __log_delete(log_t* me_, raft_index_t idx, func_entry_notify_f cb, vo
     return 0;
 }
 
-int log_delete(log_t* me_, raft_index_t idx)
+int raft_log_delete(raft_log_t *me, raft_index_t idx)
 {
-    return __log_delete(me_, idx, NULL, NULL);
+    return log_delete(me, idx, NULL, NULL);
 }
 
-int log_poll(log_t * me_, void** etyp)
+int raft_log_poll(raft_log_t *me, raft_entry_t **etyp)
 {
-    log_private_t* me = (log_private_t*)me_;
     raft_index_t idx = me->base + 1;
 
     if (0 == me->count)
@@ -283,10 +272,8 @@ int log_poll(log_t * me_, void** etyp)
     return 0;
 }
 
-raft_entry_t *log_peektail(log_t * me_)
+raft_entry_t *raft_log_peektail(raft_log_t *me)
 {
-    log_private_t* me = (log_private_t*)me_;
-
     if (0 == me->count)
         return NULL;
 
@@ -296,32 +283,27 @@ raft_entry_t *log_peektail(log_t * me_)
         return me->entries[me->back - 1];
 }
 
-void log_empty(log_t * me_)
+void raft_log_empty(raft_log_t *me)
 {
-    log_private_t* me = (log_private_t*)me_;
-
     me->front = 0;
     me->back = 0;
     me->count = 0;
 }
 
-void log_free(log_t * me_)
+void raft_log_free(raft_log_t *me)
 {
-    log_private_t* me = (log_private_t*)me_;
-
     raft_free(me->entries);
     raft_free(me);
 }
 
-raft_index_t log_get_current_idx(log_t* me_)
+raft_index_t raft_log_get_current_idx(raft_log_t *me)
 {
-    log_private_t* me = (log_private_t*)me_;
-    return log_count(me_) + me->base;
+    return raft_log_count(me) + me->base;
 }
 
-raft_index_t log_get_base(log_t* me_)
+raft_index_t raft_log_get_base(raft_log_t *me)
 {
-    return ((log_private_t*)me_)->base;
+    return me->base;
 }
 
 /**
@@ -336,49 +318,49 @@ raft_index_t log_get_base(log_t* me_)
  *      log implementations.
  */
 
-void *__log_init(void *raft, void *arg)
+void *log_init(void *raft, void *arg)
 {
-    log_t *log = log_new();
+    raft_log_t *log = raft_log_new();
     if (arg) {
-        log_set_callbacks(log, arg, raft);
+        raft_log_set_callbacks(log, arg, raft);
     }
     return log;
 }
 
-static void __log_free(void *log)
+static void log_free(void *log)
 {
-    log_free(log);
+    raft_log_free(log);
 }
 
-static void __log_reset(void *log, raft_index_t first_idx, raft_term_t term)
+static void log_reset(void *log, raft_index_t first_idx, raft_term_t term)
 {
     (void) term;
 
     log_clear_entries(log);
-    log_clear(log);
+    raft_log_clear(log);
 
     assert(first_idx >= 1);
-    ((log_private_t*) log)->base = first_idx - 1;
+    ((raft_log_t *) log)->base = first_idx - 1;
 }
 
-static int __log_append(void *log, raft_entry_t *entry)
+static int log_append(void *log, raft_entry_t *entry)
 {
     raft_entry_hold(entry);
-    return log_append_entry(log, entry);
+    return raft_log_append_entry(log, entry);
 }
 
-static raft_entry_t *__log_get(void *log, raft_index_t idx)
+static raft_entry_t *log_get(void *log, raft_index_t idx)
 {
-    raft_entry_t *e = log_get_at_idx(log, idx);
+    raft_entry_t *e = raft_log_get_at_idx(log, idx);
     if (e != NULL)
         raft_entry_hold(e);
     return e;
 }
 
-static int __log_get_batch(void *log, raft_index_t idx, int entries_n, raft_entry_t **entries)
+static int log_get_batch(void *log, raft_index_t idx, int entries_n, raft_entry_t **entries)
 {
     long n, i;
-    raft_entry_t **r = log_get_from_idx(log, idx, &n);
+    raft_entry_t **r = raft_log_get_from_idx(log, idx, &n);
 
     if (!r || n < 1) {
         return 0;
@@ -394,16 +376,16 @@ static int __log_get_batch(void *log, raft_index_t idx, int entries_n, raft_entr
     return (int) n;
 }
 
-static int __log_pop(void *log, raft_index_t from_idx, func_entry_notify_f cb, void *cb_arg)
+static int log_pop(void *log, raft_index_t from_idx, func_entry_notify_f cb, void *cb_arg)
 {
-    return __log_delete(log, from_idx, cb, cb_arg);
+    return log_delete(log, from_idx, cb, cb_arg);
 }
 
-static int __log_poll(void *log, raft_index_t first_idx)
+static int log_poll(void *log, raft_index_t first_idx)
 {
-    while (log_get_base(log) + 1 < first_idx) {
+    while (raft_log_get_base(log) + 1 < first_idx) {
         raft_entry_t *ety;
-        int e = log_poll(log, (void **) &ety);
+        int e = raft_log_poll(log, &ety);
 
         if (e < 0)
             return e;
@@ -412,38 +394,38 @@ static int __log_poll(void *log, raft_index_t first_idx)
     return 0;
 }
 
-static raft_index_t __log_first_idx(void *log)
+static raft_index_t log_first_idx(void *log)
 {
-    return log_get_base(log) + 1;
+    return raft_log_get_base(log) + 1;
 }
 
-static raft_index_t __log_current_idx(void *log)
+static raft_index_t log_current_idx(void *log)
 {
-    return log_get_current_idx(log);
+    return raft_log_get_current_idx(log);
 }
 
-static raft_index_t __log_count(void *log)
+static raft_index_t log_count(void *log)
 {
-    return log_count(log);
+    return raft_log_count(log);
 }
 
-static int __log_sync(void *log)
+static int log_sync(void *log)
 {
     (void) log;
     return 0;
 }
 
 const raft_log_impl_t raft_log_internal_impl = {
-    .init = __log_init,
-    .free = __log_free,
-    .reset = __log_reset,
-    .append = __log_append,
-    .poll = __log_poll,
-    .pop = __log_pop,
-    .get = __log_get,
-    .get_batch = __log_get_batch,
-    .first_idx = __log_first_idx,
-    .current_idx = __log_current_idx,
-    .count = __log_count,
-    .sync = __log_sync
+    .init = log_init,
+    .free = log_free,
+    .reset = log_reset,
+    .append = log_append,
+    .poll = log_poll,
+    .pop = log_pop,
+    .get = log_get,
+    .get_batch = log_get_batch,
+    .first_idx = log_first_idx,
+    .current_idx = log_current_idx,
+    .count = log_count,
+    .sync = log_sync
 };

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -78,14 +78,14 @@ int raft_log_load_from_snapshot(raft_log_t *me, raft_index_t idx, raft_term_t te
 {
     (void) term;
 
-    log_clear_entries(me);
+    raft_log_clear_entries(me);
     raft_log_clear(me);
     me->base = idx;
 
     return 0;
 }
 
-raft_log_t*raft_log_alloc(raft_index_t initial_size)
+raft_log_t *raft_log_alloc(raft_index_t initial_size)
 {
     raft_log_t *me = raft_calloc(1, sizeof(*me));
     if (!me)
@@ -100,7 +100,7 @@ raft_log_t*raft_log_alloc(raft_index_t initial_size)
     return (raft_log_t*)me;
 }
 
-raft_log_t*raft_log_new(void)
+raft_log_t *raft_log_new(void)
 {
     return raft_log_alloc(INITIAL_CAPACITY);
 }
@@ -119,7 +119,7 @@ void raft_log_clear(raft_log_t *me)
     me->base = 0;
 }
 
-void log_clear_entries(raft_log_t* me)
+void raft_log_clear_entries(raft_log_t* me)
 {
     raft_index_t i;
 
@@ -318,7 +318,7 @@ raft_index_t raft_log_get_base(raft_log_t *me)
  *      log implementations.
  */
 
-void *log_init(void *raft, void *arg)
+static void *log_init(void *raft, void *arg)
 {
     raft_log_t *log = raft_log_new();
     if (arg) {
@@ -336,7 +336,7 @@ static void log_reset(void *log, raft_index_t first_idx, raft_term_t term)
 {
     (void) term;
 
-    log_clear_entries(log);
+    raft_log_clear_entries(log);
     raft_log_clear(log);
 
     assert(first_idx >= 1);

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -91,13 +91,13 @@ raft_log_t *raft_log_alloc(raft_index_t initial_size)
     if (!me)
         return NULL;
     me->size = initial_size;
-    raft_log_clear((raft_log_t *) me);
+    raft_log_clear(me);
     me->entries = raft_calloc(1, sizeof(raft_entry_t *) * me->size);
     if (!me->entries) {
         raft_free(me);
         return NULL;
     }
-    return (raft_log_t*)me;
+    return me;
 }
 
 raft_log_t *raft_log_new(void)
@@ -186,7 +186,7 @@ raft_entry_t**raft_log_get_from_idx(raft_log_t *me, raft_index_t idx, long *n_et
     return &me->entries[i];
 }
 
-raft_entry_t*raft_log_get_at_idx(raft_log_t *me, raft_index_t idx)
+raft_entry_t* raft_log_get_at_idx(raft_log_t *me, raft_index_t idx)
 {
     raft_index_t i;
 

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -22,7 +22,7 @@
 #define RAFT_NODE_VOTING_COMMITTED    (1 << 4)
 #define RAFT_NODE_ADDITION_COMMITTED  (1 << 5)
 
-typedef struct
+struct raft_node
 {
     void* udata;
 
@@ -40,13 +40,13 @@ typedef struct
     raft_term_t last_acked_term;
     raft_msg_id_t last_acked_msgid;
     raft_msg_id_t max_seen_msgid;
-} raft_node_private_t;
+};
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
 {
-    raft_node_private_t* me;
+    raft_node_t* me;
 
-    me = raft_calloc(1, sizeof(raft_node_private_t));
+    me = raft_calloc(1, sizeof(*me));
     if (!me)
         return NULL;
 
@@ -58,182 +58,157 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
     return (raft_node_t*)me;
 }
 
-void raft_node_free(raft_node_t* me_)
+void raft_node_free(raft_node_t* me)
 {
-    raft_free(me_);
+    raft_free(me);
 }
 
-raft_index_t raft_node_get_next_idx(raft_node_t* me_)
+raft_index_t raft_node_get_next_idx(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->next_idx;
 }
 
-void raft_node_set_next_idx(raft_node_t* me_, raft_index_t idx)
+void raft_node_set_next_idx(raft_node_t* me, raft_index_t idx)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     /* log index begins at 1 */
     me->next_idx = idx < 1 ? 1 : idx;
 }
 
-raft_index_t raft_node_get_match_idx(raft_node_t* me_)
+raft_index_t raft_node_get_match_idx(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->match_idx;
 }
 
-void raft_node_set_match_idx(raft_node_t* me_, raft_index_t idx)
+void raft_node_set_match_idx(raft_node_t* me, raft_index_t idx)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     me->match_idx = idx;
 }
 
-void* raft_node_get_udata(raft_node_t* me_)
+void* raft_node_get_udata(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->udata;
 }
 
-void raft_node_set_udata(raft_node_t* me_, void* udata)
+void raft_node_set_udata(raft_node_t* me, void* udata)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     me->udata = udata;
 }
 
-void raft_node_vote_for_me(raft_node_t* me_, const int vote)
+void raft_node_vote_for_me(raft_node_t* me, const int vote)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     if (vote)
         me->flags |= RAFT_NODE_VOTED_FOR_ME;
     else
         me->flags &= ~RAFT_NODE_VOTED_FOR_ME;
 }
 
-int raft_node_has_vote_for_me(raft_node_t* me_)
+int raft_node_has_vote_for_me(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return (me->flags & RAFT_NODE_VOTED_FOR_ME) != 0;
 }
 
-void raft_node_set_voting(raft_node_t* me_, int voting)
+void raft_node_set_voting(raft_node_t* me, int voting)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     if (voting)
     {
-        assert(!raft_node_is_voting(me_));
+        assert(!raft_node_is_voting(me));
         me->flags |= RAFT_NODE_VOTING;
     }
     else
     {
-        assert(raft_node_is_voting(me_));
+        assert(raft_node_is_voting(me));
         me->flags &= ~RAFT_NODE_VOTING;
     }
 }
 
-int raft_node_is_voting(raft_node_t* me_)
+int raft_node_is_voting(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return (me->flags & RAFT_NODE_VOTING && !(me->flags & RAFT_NODE_INACTIVE));
 }
 
-int raft_node_has_sufficient_logs(raft_node_t* me_)
+int raft_node_has_sufficient_logs(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return (me->flags & RAFT_NODE_HAS_SUFFICIENT_LOG) != 0;
 }
 
-void raft_node_set_has_sufficient_logs(raft_node_t* me_)
+void raft_node_set_has_sufficient_logs(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     me->flags |= RAFT_NODE_HAS_SUFFICIENT_LOG;
 }
 
-void raft_node_set_active(raft_node_t* me_, int active)
+void raft_node_set_active(raft_node_t* me, int active)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     if (!active)
         me->flags |= RAFT_NODE_INACTIVE;
     else
         me->flags &= ~RAFT_NODE_INACTIVE;
 }
 
-int raft_node_is_active(raft_node_t* me_)
+int raft_node_is_active(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return (me->flags & RAFT_NODE_INACTIVE) == 0;
 }
 
-void raft_node_set_voting_committed(raft_node_t* me_, int voting)
+void raft_node_set_voting_committed(raft_node_t* me, int voting)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     if (voting)
         me->flags |= RAFT_NODE_VOTING_COMMITTED;
     else
         me->flags &= ~RAFT_NODE_VOTING_COMMITTED;
 }
 
-int raft_node_is_voting_committed(raft_node_t* me_)
+int raft_node_is_voting_committed(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return (me->flags & RAFT_NODE_VOTING_COMMITTED) != 0;
 }
 
-raft_node_id_t raft_node_get_id(raft_node_t* me_)
+raft_node_id_t raft_node_get_id(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return me != NULL ? me->id : -1;
 }
 
-void raft_node_set_addition_committed(raft_node_t* me_, int committed)
+void raft_node_set_addition_committed(raft_node_t* me, int committed)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     if (committed)
         me->flags |= RAFT_NODE_ADDITION_COMMITTED;
     else
         me->flags &= ~RAFT_NODE_ADDITION_COMMITTED;
 }
 
-int raft_node_is_addition_committed(raft_node_t* me_)
+int raft_node_is_addition_committed(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return (me->flags & RAFT_NODE_ADDITION_COMMITTED) != 0;
 }
 
-void raft_node_set_last_ack(raft_node_t* me_, raft_msg_id_t msgid, raft_term_t term)
+void raft_node_set_last_ack(raft_node_t* me, raft_msg_id_t msgid, raft_term_t term)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     me->last_acked_msgid = msgid;
     me->last_acked_term = term;
 }
 
-raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me_)
+raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->last_acked_msgid;
 }
 
-void raft_node_update_max_seen_msg_id(raft_node_t *me_, raft_msg_id_t msg_id)
+void raft_node_update_max_seen_msg_id(raft_node_t *me, raft_msg_id_t msg_id)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     if (msg_id > me->max_seen_msgid) {
         me->max_seen_msgid = msg_id;
     }
 }
 
-raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me_)
+raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->max_seen_msgid;
 }
 
-raft_size_t raft_node_get_snapshot_offset(raft_node_t *me_)
+raft_size_t raft_node_get_snapshot_offset(raft_node_t *me)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     return me->snapshot_offset;
 }
 
-void raft_node_set_snapshot_offset(raft_node_t *me_, raft_size_t snapshot_offset)
+void raft_node_set_snapshot_offset(raft_node_t *me, raft_size_t snapshot_offset)
 {
-    raft_node_private_t* me = (raft_node_private_t*)me_;
     me->snapshot_offset = snapshot_offset;
 }

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -55,7 +55,7 @@ raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
     me->match_idx = 0;
     me->id = id;
     me->flags = RAFT_NODE_VOTING;
-    return (raft_node_t*)me;
+    return me;
 }
 
 void raft_node_free(raft_node_t* me)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -46,16 +46,14 @@ void raft_set_heap_functions(void *(*_malloc)(size_t),
     raft_free = _free;
 }
 
-static void raft_log_node(raft_server_t *me_,
+static void raft_log_node(raft_server_t *me,
                           raft_node_id_t id,
                           const char *fmt, ...) __attribute__ ((format (printf, 3, 4)));
 
-static void raft_log_node(raft_server_t *me_,
+static void raft_log_node(raft_server_t *me,
                           raft_node_id_t id,
                           const char *fmt, ...)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     if (!me->log_enabled || me->cb.log == NULL)
         return;
 
@@ -69,36 +67,31 @@ static void raft_log_node(raft_server_t *me_,
     }
     va_end(args);
 
-    me->cb.log(me_, id, me->udata, buf);
+    me->cb.log(me, id, me->udata, buf);
 }
 
 #define raft_log(me, ...) (raft_log_node(me, RAFT_NODE_ID_NONE, __VA_ARGS__))
 
-void raft_randomize_election_timeout(raft_server_t* me_)
+void raft_randomize_election_timeout(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     /* [election_timeout, 2 * election_timeout) */
     me->election_timeout_rand = me->election_timeout + rand() % me->election_timeout;
-    raft_log(me_, "randomize election timeout to %d", me->election_timeout_rand);
+    raft_log(me, "randomize election timeout to %d", me->election_timeout_rand);
 }
 
-void raft_update_quorum_meta(raft_server_t* me_, raft_msg_id_t id)
+void raft_update_quorum_meta(raft_server_t* me, raft_msg_id_t id)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-
     // Make sure that timeout is greater than 'randomized election timeout'
     me->quorum_timeout = me->election_timeout * 2;
     me->last_acked_msg_id = id;
 }
 
-int raft_clear_incoming_snapshot(raft_server_t* me_, raft_index_t new_idx)
+int raft_clear_incoming_snapshot(raft_server_t* me, raft_index_t new_idx)
 {
     int e = 0;
-    raft_server_private_t* me = (raft_server_private_t*)me_;
 
     if (me->snapshot_recv_idx != 0)
-        e = me->cb.clear_snapshot(me_, me->udata);
+        e = me->cb.clear_snapshot(me, me->udata);
 
     me->snapshot_recv_idx = new_idx;
     me->snapshot_recv_offset = 0;
@@ -108,7 +101,7 @@ int raft_clear_incoming_snapshot(raft_server_t* me_, raft_index_t new_idx)
 
 raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
 {
-    raft_server_private_t* me = raft_calloc(1, sizeof(raft_server_private_t));
+    raft_server_t *me = raft_calloc(1, sizeof(*me));
     if (!me)
         return NULL;
 
@@ -145,30 +138,24 @@ raft_server_t* raft_new(void)
     return raft_new_with_log(&raft_log_internal_impl, NULL);
 }
 
-void raft_set_callbacks(raft_server_t* me_, raft_cbs_t* funcs, void* udata)
+void raft_set_callbacks(raft_server_t* me, raft_cbs_t* funcs, void* udata)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     memcpy(&me->cb, funcs, sizeof(raft_cbs_t));
     me->udata = udata;
 }
 
-void raft_destroy(raft_server_t* me_)
+void raft_destroy(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     me->log_impl->free(me->log);
-    raft_free(me_);
+    raft_free(me);
 }
 
-void raft_clear(raft_server_t* me_)
+void raft_clear(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     me->current_term = 0;
     me->voted_for = -1;
     me->timeout_elapsed = 0;
-    raft_randomize_election_timeout(me_);
+    raft_randomize_election_timeout(me);
     me->voting_cfg_change_log_idx = -1;
     raft_set_state((raft_server_t*)me, RAFT_STATE_FOLLOWER);
     me->leader_id = RAFT_NODE_ID_NONE;
@@ -179,15 +166,13 @@ void raft_clear(raft_server_t* me_)
     me->log_impl->reset(me->log, 1, 1);
 }
 
-raft_node_t* raft_add_node_internal(raft_server_t* me_, raft_entry_t *ety, void* udata, raft_node_id_t id, int is_self)
+raft_node_t* raft_add_node_internal(raft_server_t* me, raft_entry_t *ety, void* udata, raft_node_id_t id, int is_self)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     if (id == RAFT_NODE_ID_NONE)
         return NULL;
 
     /* set to voting if node already exists */
-    raft_node_t* node = raft_get_node(me_, id);
+    raft_node_t* node = raft_get_node(me, id);
     if (node)
     {
         if (!raft_node_is_voting(node))
@@ -218,17 +203,17 @@ raft_node_t* raft_add_node_internal(raft_server_t* me_, raft_entry_t *ety, void*
     node = me->nodes[me->num_nodes - 1];
 
     if (me->cb.notify_membership_event)
-        me->cb.notify_membership_event(me_, raft_get_udata(me_), node, ety, RAFT_MEMBERSHIP_ADD);
+        me->cb.notify_membership_event(me, raft_get_udata(me), node, ety, RAFT_MEMBERSHIP_ADD);
 
     return node;
 }
 
-static raft_node_t* raft_add_non_voting_node_internal(raft_server_t* me_, raft_entry_t *ety, void* udata, raft_node_id_t id, int is_self)
+static raft_node_t* raft_add_non_voting_node_internal(raft_server_t* me, raft_entry_t *ety, void* udata, raft_node_id_t id, int is_self)
 {
-    if (raft_get_node(me_, id))
+    if (raft_get_node(me, id))
         return NULL;
 
-    raft_node_t* node = raft_add_node_internal(me_, ety, udata, id, is_self);
+    raft_node_t* node = raft_add_node_internal(me, ety, udata, id, is_self);
     if (!node)
         return NULL;
 
@@ -236,22 +221,20 @@ static raft_node_t* raft_add_non_voting_node_internal(raft_server_t* me_, raft_e
     return node;
 }
 
-raft_node_t* raft_add_node(raft_server_t* me_, void* udata, raft_node_id_t id, int is_self)
+raft_node_t* raft_add_node(raft_server_t* me, void* udata, raft_node_id_t id, int is_self)
 {
-    return raft_add_node_internal(me_, NULL, udata, id, is_self);
+    return raft_add_node_internal(me, NULL, udata, id, is_self);
 }
 
-raft_node_t* raft_add_non_voting_node(raft_server_t* me_, void* udata, raft_node_id_t id, int is_self)
+raft_node_t* raft_add_non_voting_node(raft_server_t* me, void* udata, raft_node_id_t id, int is_self)
 {
-    return raft_add_non_voting_node_internal(me_, NULL, udata, id, is_self);
+    return raft_add_non_voting_node_internal(me, NULL, udata, id, is_self);
 }
 
-void raft_remove_node(raft_server_t* me_, raft_node_t* node)
+void raft_remove_node(raft_server_t* me, raft_node_t* node)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     if (me->cb.notify_membership_event)
-        me->cb.notify_membership_event(me_, raft_get_udata(me_), node, NULL, RAFT_MEMBERSHIP_REMOVE);
+        me->cb.notify_membership_event(me, raft_get_udata(me), node, NULL, RAFT_MEMBERSHIP_REMOVE);
 
     assert(node);
 
@@ -278,20 +261,18 @@ void raft_remove_node(raft_server_t* me_, raft_node_t* node)
     raft_node_free(node);
 }
 
-void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_index_t idx)
+void raft_handle_append_cfg_change(raft_server_t* me, raft_entry_t* ety, raft_index_t idx)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     if (!raft_entry_is_cfg_change(ety))
         return;
 
     if (!me->cb.get_node_id)
         return;
 
-    void* udata = raft_get_udata(me_);
-    raft_node_id_t node_id = me->cb.get_node_id(me_, udata, ety, idx);
-    raft_node_t* node = raft_get_node(me_, node_id);
-    int is_self = node_id == raft_get_nodeid(me_);
+    void* udata = raft_get_udata(me);
+    raft_node_id_t node_id = me->cb.get_node_id(me, udata, ety, idx);
+    raft_node_t* node = raft_get_node(me, node_id);
+    int is_self = node_id == raft_get_nodeid(me);
 
     switch (ety->type)
     {
@@ -304,14 +285,14 @@ void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_i
                 }
                 else if (!node)
                 {
-                    node = raft_add_non_voting_node_internal(me_, ety, NULL, node_id, is_self);
+                    node = raft_add_non_voting_node_internal(me, ety, NULL, node_id, is_self);
                     assert(node);
                 }
              }
             break;
 
         case RAFT_LOGTYPE_ADD_NODE:
-            node = raft_add_node_internal(me_, ety, NULL, node_id, is_self);
+            node = raft_add_node_internal(me, ety, NULL, node_id, is_self);
             assert(node);
             assert(raft_node_is_voting(node));
             break;
@@ -327,19 +308,17 @@ void raft_handle_append_cfg_change(raft_server_t* me_, raft_entry_t* ety, raft_i
     }
 }
 
-void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const raft_index_t idx)
+void raft_handle_remove_cfg_change(raft_server_t* me, raft_entry_t* ety, const raft_index_t idx)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-
     if (!raft_entry_is_cfg_change(ety))
         return;
 
     if (!me->cb.get_node_id)
         return;
 
-    void* udata = raft_get_udata(me_);
-    raft_node_id_t node_id = me->cb.get_node_id(me_, udata, ety, idx);
-    raft_node_t* node = raft_get_node(me_, node_id);
+    void* udata = raft_get_udata(me);
+    raft_node_id_t node_id = me->cb.get_node_id(me, udata, ety, idx);
+    raft_node_t* node = raft_get_node(me, node_id);
 
     switch (ety->type)
     {
@@ -348,8 +327,8 @@ void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const 
             break;
 
         case RAFT_LOGTYPE_ADD_NONVOTING_NODE:
-            assert(node_id != raft_get_nodeid(me_));
-            raft_remove_node(me_, node);
+            assert(node_id != raft_get_nodeid(me));
+            raft_remove_node(me, node);
             break;
 
         case RAFT_LOGTYPE_ADD_NODE:
@@ -362,71 +341,64 @@ void raft_handle_remove_cfg_change(raft_server_t* me_, raft_entry_t* ety, const 
     }
 }
 
-int raft_delete_entry_from_idx(raft_server_t* me_, raft_index_t idx)
+int raft_delete_entry_from_idx(raft_server_t* me, raft_index_t idx)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    assert(raft_get_commit_idx(me_) < idx);
+    assert(raft_get_commit_idx(me) < idx);
 
     if (idx <= me->voting_cfg_change_log_idx)
         me->voting_cfg_change_log_idx = -1;
 
     int e = me->log_impl->pop(me->log, idx,
-             (func_entry_notify_f) raft_handle_remove_cfg_change, me_);
+             (func_entry_notify_f) raft_handle_remove_cfg_change, me);
     if (e != 0)
         return e;
 
     return me->log_impl->sync(me->log);
 }
 
-int raft_election_start(raft_server_t* me_, int skip_precandidate)
+int raft_election_start(raft_server_t* me, int skip_precandidate)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    raft_log(me_,
+    raft_log(me,
         "election starting: %d %d, term: %ld ci: %ld",
         me->election_timeout_rand, me->timeout_elapsed, me->current_term,
-        raft_get_current_idx(me_));
+        raft_get_current_idx(me));
 
     me->leader_id = RAFT_NODE_ID_NONE;
     me->timeout_elapsed = 0;
-    raft_randomize_election_timeout(me_);
+    raft_randomize_election_timeout(me);
 
-    return skip_precandidate ? raft_become_candidate(me_):
-                               raft_become_precandidate(me_);
+    return skip_precandidate ? raft_become_candidate(me):
+                               raft_become_precandidate(me);
 }
 
-void raft_accept_leader(raft_server_t* me_, raft_node_id_t leader)
+void raft_accept_leader(raft_server_t* me, raft_node_id_t leader)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    if (!raft_is_follower(me_)) {
-        raft_become_follower(me_);
+    if (!raft_is_follower(me)) {
+        raft_become_follower(me);
     }
 
     if (me->leader_id != leader) {
-        raft_clear_incoming_snapshot(me_, 0);
+        raft_clear_incoming_snapshot(me, 0);
     }
 
     me->timeout_elapsed = 0;
     me->leader_id = leader;
 }
 
-int raft_become_leader(raft_server_t* me_)
+int raft_become_leader(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int i;
 
-    raft_log(me_, "becoming leader term:%ld", raft_get_current_term(me_));
+    raft_log(me, "becoming leader term:%ld", raft_get_current_term(me));
 
-    raft_index_t next_idx = raft_get_current_idx(me_) + 1;
+    raft_index_t next_idx = raft_get_current_idx(me) + 1;
 
-    if (raft_get_current_term(me_) > 1) {
+    if (raft_get_current_term(me) > 1) {
         raft_entry_t *noop = raft_entry_new(0);
-        noop->term = raft_get_current_term(me_);
+        noop->term = raft_get_current_term(me);
         noop->type = RAFT_LOGTYPE_NO_OP;
 
-        int e = raft_append_entry(me_, noop);
+        int e = raft_append_entry(me, noop);
         raft_entry_release(noop);
         if (0 != e)
             return e;
@@ -435,24 +407,24 @@ int raft_become_leader(raft_server_t* me_)
         if (0 != e)
             return e;
 
-        raft_node_set_match_idx(me->node, raft_get_current_idx(me_));
-        me->next_sync_index = raft_get_current_idx(me_) + 1;
+        raft_node_set_match_idx(me->node, raft_get_current_idx(me));
+        me->next_sync_index = raft_get_current_idx(me) + 1;
 
         // Commit noop immediately if this is a single node cluster
-        if (raft_is_single_node_voting_cluster(me_)) {
-            raft_set_commit_idx(me_, raft_get_current_idx(me_));
+        if (raft_is_single_node_voting_cluster(me)) {
+            raft_set_commit_idx(me, raft_get_current_idx(me));
         }
     }
 
-    raft_set_state(me_, RAFT_STATE_LEADER);
-    raft_update_quorum_meta(me_, me->msg_id);
-    raft_clear_incoming_snapshot(me_, 0);
+    raft_set_state(me, RAFT_STATE_LEADER);
+    raft_update_quorum_meta(me, me->msg_id);
+    raft_clear_incoming_snapshot(me, 0);
     me->timeout_elapsed = 0;
 
-    raft_reset_transfer_leader(me_, 0);
+    raft_reset_transfer_leader(me, 0);
 
     if (me->cb.notify_state_event)
-        me->cb.notify_state_event(me_, raft_get_udata(me_), RAFT_STATE_LEADER);
+        me->cb.notify_state_event(me, raft_get_udata(me), RAFT_STATE_LEADER);
 
     for (i = 0; i < me->num_nodes; i++)
     {
@@ -464,59 +436,56 @@ int raft_become_leader(raft_server_t* me_)
         raft_node_set_snapshot_offset(node, 0);
         raft_node_set_next_idx(node, next_idx);
         raft_node_set_match_idx(node, 0);
-        raft_send_appendentries(me_, node);
+        raft_send_appendentries(me, node);
     }
 
     return 0;
 }
 
-int raft_become_precandidate(raft_server_t* me_)
+int raft_become_precandidate(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    raft_log(me_,
+    raft_log(me,
              "becoming pre-candidate, next term : %ld", me->current_term + 1);
 
     if (me->cb.notify_state_event)
-        me->cb.notify_state_event(me_, me->udata, RAFT_STATE_PRECANDIDATE);
+        me->cb.notify_state_event(me, me->udata, RAFT_STATE_PRECANDIDATE);
 
     for (int i = 0; i < me->num_nodes; i++)
         raft_node_vote_for_me(me->nodes[i], 0);
 
-    raft_set_state(me_, RAFT_STATE_PRECANDIDATE);
+    raft_set_state(me, RAFT_STATE_PRECANDIDATE);
 
     for (int i = 0; i < me->num_nodes; i++)
     {
         raft_node_t* node = me->nodes[i];
 
         if (me->node != node && raft_node_is_voting(node)) {
-            raft_send_requestvote(me_, node);
+            raft_send_requestvote(me, node);
         }
     }
 
     return 0;
 }
 
-int raft_become_candidate(raft_server_t* me_)
+int raft_become_candidate(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int i;
 
-    raft_log(me_, "becoming candidate");
+    raft_log(me, "becoming candidate");
     if (me->cb.notify_state_event)
-        me->cb.notify_state_event(me_, raft_get_udata(me_), RAFT_STATE_CANDIDATE);
+        me->cb.notify_state_event(me, raft_get_udata(me), RAFT_STATE_CANDIDATE);
 
-    int e = raft_set_current_term(me_, raft_get_current_term(me_) + 1);
+    int e = raft_set_current_term(me, raft_get_current_term(me) + 1);
     if (0 != e)
         return e;
     for (i = 0; i < me->num_nodes; i++)
         raft_node_vote_for_me(me->nodes[i], 0);
 
     if (raft_node_is_voting(me->node))
-        raft_vote(me_, me->node);
+        raft_vote(me, me->node);
 
     me->leader_id = RAFT_NODE_ID_NONE;
-    raft_set_state(me_, RAFT_STATE_CANDIDATE);
+    raft_set_state(me, RAFT_STATE_CANDIDATE);
 
     for (i = 0; i < me->num_nodes; i++)
     {
@@ -524,23 +493,21 @@ int raft_become_candidate(raft_server_t* me_)
 
         if (me->node != node && raft_node_is_voting(node))
         {
-            raft_send_requestvote(me_, node);
+            raft_send_requestvote(me, node);
         }
     }
     return 0;
 }
 
-void raft_become_follower(raft_server_t* me_)
+void raft_become_follower(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    raft_log(me_, "becoming follower");
+    raft_log(me, "becoming follower");
     if (me->cb.notify_state_event)
-        me->cb.notify_state_event(me_, raft_get_udata(me_), RAFT_STATE_FOLLOWER);
+        me->cb.notify_state_event(me, raft_get_udata(me), RAFT_STATE_FOLLOWER);
 
-    raft_set_state(me_, RAFT_STATE_FOLLOWER);
-    raft_randomize_election_timeout(me_);
-    raft_clear_incoming_snapshot(me_, 0);
+    raft_set_state(me, RAFT_STATE_FOLLOWER);
+    raft_randomize_election_timeout(me);
+    raft_clear_incoming_snapshot(me, 0);
     me->timeout_elapsed = 0;
     me->leader_id = RAFT_NODE_ID_NONE;
 }
@@ -553,9 +520,8 @@ static int msgid_cmp(const void *a, const void *b)
     return va > vb ? -1 : 1;
 }
 
-static raft_msg_id_t quorum_msg_id(raft_server_t* me_)
+static raft_msg_id_t quorum_msg_id(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
     raft_msg_id_t msg_ids[me->num_nodes];
     int num_voters = 0;
 
@@ -572,7 +538,7 @@ static raft_msg_id_t quorum_msg_id(raft_server_t* me_)
         }
     }
 
-    assert(num_voters == raft_get_num_voting_nodes(me_));
+    assert(num_voters == raft_get_num_voting_nodes(me));
 
     /**
      *  Sort the acknowledged msg_ids in the descending order and return
@@ -584,21 +550,19 @@ static raft_msg_id_t quorum_msg_id(raft_server_t* me_)
     return msg_ids[num_voters / 2];
 }
 
-int raft_periodic(raft_server_t* me_, int msec_since_last_period)
+int raft_periodic(raft_server_t* me, int msec_since_last_period)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     me->timeout_elapsed += msec_since_last_period;
 
     /* Only one voting node means it's safe for us to become the leader */
-    if (raft_is_single_node_voting_cluster(me_) && !raft_is_leader(me_)) {
+    if (raft_is_single_node_voting_cluster(me) && !raft_is_leader(me)) {
         // need to update term on new leadership
-        int e = raft_set_current_term(me_, raft_get_current_term(me_) + 1);
+        int e = raft_set_current_term(me, raft_get_current_term(me) + 1);
         if (e != 0) {
             return e;
         }
 
-        e = raft_become_leader(me_);
+        e = raft_become_leader(me);
         if (e != 0) {
             return e;
         }
@@ -608,7 +572,7 @@ int raft_periodic(raft_server_t* me_, int msec_since_last_period)
     if (me->node_transferring_leader_to != RAFT_NODE_ID_NONE) {
         me->transfer_leader_time -= msec_since_last_period;
         if (me->transfer_leader_time < 0) {
-            raft_reset_transfer_leader(me_, 1);
+            raft_reset_transfer_leader(me, 1);
         }
     }
 
@@ -618,7 +582,7 @@ int raft_periodic(raft_server_t* me_, int msec_since_last_period)
         {
             me->msg_id++;
             me->timeout_elapsed = 0;
-            raft_send_appendentries_all(me_);
+            raft_send_appendentries_all(me);
         }
 
         me->quorum_timeout -= msec_since_last_period;
@@ -636,64 +600,61 @@ int raft_periodic(raft_server_t* me_, int msec_since_last_period)
              * quorum_timeout timer. Otherwise, it means quorum does not exist.
              * We should step down and become a follower.
              */
-            raft_msg_id_t quorum_id = quorum_msg_id(me_);
+            raft_msg_id_t quorum_id = quorum_msg_id(me);
 
             if (me->last_acked_msg_id == quorum_id)
             {
-                raft_log(me_, "quorum does not exist, stepping down");
-                raft_become_follower(me_);
+                raft_log(me, "quorum does not exist, stepping down");
+                raft_become_follower(me);
             }
 
-            raft_update_quorum_meta(me_, quorum_id);
+            raft_update_quorum_meta(me, quorum_id);
 	    }
     }
     else if (me->election_timeout_rand <= me->timeout_elapsed)
     {
-        int e = raft_election_start(me_, 0);
+        int e = raft_election_start(me, 0);
         if (0 != e)
             return e;
     }
 
-    if (me->last_applied_idx < raft_get_commit_idx(me_) &&
-            raft_is_apply_allowed(me_))
+    if (me->last_applied_idx < raft_get_commit_idx(me) &&
+            raft_is_apply_allowed(me))
     {
-        int e = raft_apply_all(me_);
+        int e = raft_apply_all(me);
         if (0 != e)
             return e;
     }
 
-    raft_process_read_queue(me_);
+    raft_process_read_queue(me);
 
     return 0;
 }
 
-raft_entry_t* raft_get_entry_from_idx(raft_server_t* me_, raft_index_t etyidx)
+raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, raft_index_t etyidx)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->log_impl->get(me->log, etyidx);
 }
 
-int raft_voting_change_is_in_progress(raft_server_t* me_)
+int raft_voting_change_is_in_progress(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->voting_cfg_change_log_idx != -1;
+    return me->voting_cfg_change_log_idx != -1;
 }
 
-int raft_recv_appendentries_response(raft_server_t* me_,
+int raft_recv_appendentries_response(raft_server_t* me,
                                      raft_node_t* node,
                                      msg_appendentries_response_t* r)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    raft_log_node(me_, raft_node_get_id(node),
+    raft_log_node(me, raft_node_get_id(node),
           "received appendentries response %s ci:%ld rci:%ld msgid:%lu",
           r->success == 1 ? "SUCCESS" : "fail",
-          raft_get_current_idx(me_),
+          raft_get_current_idx(me),
           r->current_idx, r->msg_id);
 
     if (!node)
         return -1;
 
-    if (!raft_is_leader(me_))
+    if (!raft_is_leader(me))
         return RAFT_ERR_NOT_LEADER;
 
     if (raft_node_get_last_acked_msgid(node) > r->msg_id) {
@@ -705,10 +666,10 @@ int raft_recv_appendentries_response(raft_server_t* me_,
        and convert to follower (§5.3) */
     if (me->current_term < r->term)
     {
-        int e = raft_set_current_term(me_, r->term);
+        int e = raft_set_current_term(me, r->term);
         if (0 != e)
             return e;
-        raft_become_follower(me_);
+        raft_become_follower(me);
 
         return 0;
     }
@@ -726,32 +687,32 @@ int raft_recv_appendentries_response(raft_server_t* me_,
         if (r->current_idx < match_idx)
             return 0;
 
-        raft_index_t next = min(r->current_idx + 1, raft_get_current_idx(me_));
+        raft_index_t next = min(r->current_idx + 1, raft_get_current_idx(me));
         assert(0 < next);
 
         raft_node_set_next_idx(node, next);
 
         /* retry */
-        raft_send_appendentries(me_, node);
+        raft_send_appendentries(me, node);
         return 0;
     }
 
-    if (me->cb.send_timeoutnow && raft_get_transfer_leader(me_) == raft_node_get_id(node) && !me->sent_timeout_now
-        && raft_get_current_idx(me_) == r->current_idx) {
-        me->cb.send_timeoutnow(me_, node);
+    if (me->cb.send_timeoutnow && raft_get_transfer_leader(me) == raft_node_get_id(node) && !me->sent_timeout_now
+        && raft_get_current_idx(me) == r->current_idx) {
+        me->cb.send_timeoutnow(me, node);
         me->sent_timeout_now = 1;
     }
 
     if (!raft_node_is_voting(node) &&
-        !raft_voting_change_is_in_progress(me_) &&
-        raft_get_current_idx(me_) <= r->current_idx + 1 &&
+        !raft_voting_change_is_in_progress(me) &&
+        raft_get_current_idx(me) <= r->current_idx + 1 &&
         !raft_node_is_voting_committed(node) &&
         raft_node_is_addition_committed(node) &&
         me->cb.node_has_sufficient_logs &&
         0 == raft_node_has_sufficient_logs(node)
         )
     {
-        int e = me->cb.node_has_sufficient_logs(me_, me->udata, node);
+        int e = me->cb.node_has_sufficient_logs(me, me->udata, node);
         if (0 == e)
             raft_node_set_has_sufficient_logs(node);
     }
@@ -759,33 +720,32 @@ int raft_recv_appendentries_response(raft_server_t* me_,
     if (r->current_idx <= match_idx)
         return 0;
 
-    assert(r->current_idx <= raft_get_current_idx(me_));
+    assert(r->current_idx <= raft_get_current_idx(me));
 
     raft_node_set_next_idx(node, r->current_idx + 1);
     raft_node_set_match_idx(node, r->current_idx);
 
     if (me->auto_flush)
-        return raft_flush(me_, 0);
+        return raft_flush(me, 0);
 
     return 0;
 }
 
-static int raft_receive_term(raft_server_t* me_, raft_term_t term)
+static int raft_receive_term(raft_server_t* me, raft_term_t term)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int e;
 
-    if (raft_is_candidate(me_) && me->current_term == term)
+    if (raft_is_candidate(me) && me->current_term == term)
     {
-        raft_become_follower(me_);
+        raft_become_follower(me);
     }
     else if (me->current_term < term)
     {
-        e = raft_set_current_term(me_, term);
+        e = raft_set_current_term(me, term);
         if (0 != e)
             return e;
 
-        raft_become_follower(me_);
+        raft_become_follower(me);
     }
     else if (term < me->current_term)
     {
@@ -796,21 +756,20 @@ static int raft_receive_term(raft_server_t* me_, raft_term_t term)
 }
 
 int raft_recv_appendentries(
-    raft_server_t* me_,
+    raft_server_t* me,
     raft_node_t* node,
     msg_appendentries_t* ae,
     msg_appendentries_response_t *r
     )
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int e = 0;
 
     if (0 < ae->n_entries)
     {
         raft_log_node(
-            me_, ae->leader_id,
+            me, ae->leader_id,
             "recvd appendentries li:%d t:%ld ci:%ld lc:%ld pli:%ld plt:%ld #%d",
-            ae->leader_id, ae->term, raft_get_current_idx(me_),
+            ae->leader_id, ae->term, raft_get_current_idx(me),
             ae->leader_commit, ae->prev_log_idx, ae->prev_log_term,
             ae->n_entries);
     }
@@ -818,11 +777,11 @@ int raft_recv_appendentries(
     r->msg_id = ae->msg_id;
     r->success = 0;
 
-    e = raft_receive_term(me_, ae->term);
+    e = raft_receive_term(me, ae->term);
     if (e != 0) {
         if (e == RAFT_ERR_STALE_TERM) {
             /* 1. Reply false if term < currentTerm (§5.1) */
-            raft_log_node(me_, ae->leader_id,
+            raft_log_node(me, ae->leader_id,
                           "AE term %ld is less than current term %ld", ae->term,
                           me->current_term);
             e = 0;
@@ -836,14 +795,14 @@ int raft_recv_appendentries(
     }
 
     /* update current leader because ae->term is up to date */
-    raft_accept_leader(me_, ae->leader_id);
-    raft_reset_transfer_leader(me_, 0);
+    raft_accept_leader(me, ae->leader_id);
+    raft_reset_transfer_leader(me, 0);
 
     /* Not the first appendentries we've received */
     /* NOTE: the log starts at 1 */
     if (0 < ae->prev_log_idx)
     {
-        raft_entry_t* ety = raft_get_entry_from_idx(me_, ae->prev_log_idx);
+        raft_entry_t* ety = raft_get_entry_from_idx(me, ae->prev_log_idx);
 
         /* Is a snapshot */
         if (ae->prev_log_idx == me->snapshot_last_idx)
@@ -851,7 +810,7 @@ int raft_recv_appendentries(
             if (me->snapshot_last_term != ae->prev_log_term)
             {
                 /* Should never happen; something is seriously wrong! */
-                raft_log_node(me_, ae->leader_id,
+                raft_log_node(me, ae->leader_id,
                             "Snapshot AE prev conflicts with committed entry");
                 e = RAFT_ERR_SHUTDOWN;
                 if (ety)
@@ -863,26 +822,26 @@ int raft_recv_appendentries(
            whose term matches prevLogTerm (§5.3) */
         else if (!ety)
         {
-            raft_log_node(me_, ae->leader_id,
+            raft_log_node(me, ae->leader_id,
                       "AE no log at prev_idx %ld", ae->prev_log_idx);
             goto out;
         }
         else if (ety->term != ae->prev_log_term)
         {
-            raft_log_node(me_, ae->leader_id, "AE term doesn't match prev_term (ie. %ld vs %ld) ci:%ld comi:%ld lcomi:%ld pli:%ld",
-                  ety->term, ae->prev_log_term, raft_get_current_idx(me_),
-                  raft_get_commit_idx(me_), ae->leader_commit, ae->prev_log_idx);
-            if (ae->prev_log_idx <= raft_get_commit_idx(me_))
+            raft_log_node(me, ae->leader_id, "AE term doesn't match prev_term (ie. %ld vs %ld) ci:%ld comi:%ld lcomi:%ld pli:%ld",
+                  ety->term, ae->prev_log_term, raft_get_current_idx(me),
+                  raft_get_commit_idx(me), ae->leader_commit, ae->prev_log_idx);
+            if (ae->prev_log_idx <= raft_get_commit_idx(me))
             {
                 /* Should never happen; something is seriously wrong! */
-                raft_log_node(me_, ae->leader_id,
+                raft_log_node(me, ae->leader_id,
                             "AE prev conflicts with committed entry");
                 e = RAFT_ERR_SHUTDOWN;
                 raft_entry_release(ety);
                 goto out;
             }
             /* Delete all the following log entries because they don't match */
-            e = raft_delete_entry_from_idx(me_, ae->prev_log_idx);
+            e = raft_delete_entry_from_idx(me, ae->prev_log_idx);
             raft_entry_release(ety);
             goto out;
         }
@@ -909,23 +868,23 @@ int raft_recv_appendentries(
         raft_entry_t* ety = ae->entries[i];
         raft_index_t ety_index = ae->prev_log_idx + 1 + i;
 
-        raft_entry_t* existing_ety = raft_get_entry_from_idx(me_, ety_index);
+        raft_entry_t* existing_ety = raft_get_entry_from_idx(me, ety_index);
         raft_term_t existing_term = existing_ety ? existing_ety->term : 0;
         if (existing_ety)
             raft_entry_release(existing_ety);
 
         if (existing_ety && existing_term != ety->term)
         {
-            if (ety_index <= raft_get_commit_idx(me_))
+            if (ety_index <= raft_get_commit_idx(me))
             {
                 /* Should never happen; something is seriously wrong! */
-                raft_log_node(me_, ae->leader_id, "AE entry conflicts with committed entry ci:%ld comi:%ld lcomi:%ld pli:%ld",
-                      raft_get_current_idx(me_), raft_get_commit_idx(me_),
+                raft_log_node(me, ae->leader_id, "AE entry conflicts with committed entry ci:%ld comi:%ld lcomi:%ld pli:%ld",
+                      raft_get_current_idx(me), raft_get_commit_idx(me),
                       ae->leader_commit, ae->prev_log_idx);
                 e = RAFT_ERR_SHUTDOWN;
                 goto out;
             }
-            e = raft_delete_entry_from_idx(me_, ety_index);
+            e = raft_delete_entry_from_idx(me, ety_index);
             if (0 != e)
                 goto out;
             break;
@@ -938,7 +897,7 @@ int raft_recv_appendentries(
     /* Pick up remainder in case of mismatch or missing entry */
     for (; i < ae->n_entries; i++)
     {
-        e = raft_append_entry(me_, ae->entries[i]);
+        e = raft_append_entry(me, ae->entries[i]);
         if (0 != e)
             goto out;
         r->current_idx = ae->prev_log_idx + 1 + i;
@@ -952,26 +911,25 @@ int raft_recv_appendentries(
 
     /* 4. If leaderCommit > commitIndex, set commitIndex =
         min(leaderCommit, index of most recent entry) */
-    if (raft_get_commit_idx(me_) < ae->leader_commit)
+    if (raft_get_commit_idx(me) < ae->leader_commit)
     {
-        raft_index_t last_log_idx = max(raft_get_current_idx(me_), 1);
-        raft_set_commit_idx(me_, min(last_log_idx, ae->leader_commit));
+        raft_index_t last_log_idx = max(raft_get_current_idx(me), 1);
+        raft_set_commit_idx(me, min(last_log_idx, ae->leader_commit));
     }
 
 out:
     r->term = me->current_term;
     if (0 == r->success)
-        r->current_idx = raft_get_current_idx(me_);
+        r->current_idx = raft_get_current_idx(me);
     return e;
 }
 
-int raft_recv_requestvote(raft_server_t* me_,
+int raft_recv_requestvote(raft_server_t* me,
                           raft_node_t* node,
                           msg_requestvote_t* vr,
                           msg_requestvote_response_t *r)
 {
     (void) node;
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int e = 0;
 
     r->prevote = vr->prevote;
@@ -987,13 +945,13 @@ int raft_recv_requestvote(raft_server_t* me_,
     }
 
     /* Update the term only if this is not a prevote request */
-    if (!vr->prevote && raft_get_current_term(me_) < vr->term)
+    if (!vr->prevote && raft_get_current_term(me) < vr->term)
     {
-        e = raft_set_current_term(me_, vr->term);
+        e = raft_set_current_term(me, vr->term);
         if (0 != e) {
             goto done;
         }
-        raft_become_follower(me_);
+        raft_become_follower(me);
     }
 
     if (me->current_term > vr->term) {
@@ -1006,8 +964,8 @@ int raft_recv_requestvote(raft_server_t* me_,
     }
 
     /* Below we check if log is more up-to-date... */
-    raft_index_t current_idx = raft_get_current_idx(me_);
-    raft_term_t ety_term = raft_get_last_log_term(me_);
+    raft_index_t current_idx = raft_get_current_idx(me);
+    raft_term_t ety_term = raft_get_last_log_term(me);
 
     if (vr->last_log_term < ety_term ||
         (vr->last_log_term == ety_term && vr->last_log_idx < current_idx)) {
@@ -1020,9 +978,9 @@ int raft_recv_requestvote(raft_server_t* me_,
     {
         /* It shouldn't be possible for a leader or candidate to grant a vote
          * Both states would have voted for themselves */
-        assert(!(raft_is_leader(me_) || raft_is_candidate(me_)));
+        assert(!(raft_is_leader(me) || raft_is_candidate(me)));
 
-        e = raft_vote_for_nodeid(me_, vr->candidate_id);
+        e = raft_vote_for_nodeid(me, vr->candidate_id);
         if (0 != e)
             r->vote_granted = 0;
 
@@ -1032,14 +990,14 @@ int raft_recv_requestvote(raft_server_t* me_,
     }
 
 done:
-    raft_log_node(me_, vr->candidate_id, "node requested vote: %d, t:%ld, pv:%d replying: %s",
+    raft_log_node(me, vr->candidate_id, "node requested vote: %d, t:%ld, pv:%d replying: %s",
           vr->candidate_id,
           vr->term,
           vr->prevote,
           r->vote_granted == 1 ? "granted" :
           r->vote_granted == 0 ? "not granted" : "unknown");
 
-    r->term = raft_get_current_term(me_);
+    r->term = raft_get_current_term(me);
     return e;
 }
 
@@ -1051,13 +1009,11 @@ int raft_votes_is_majority(const int num_nodes, const int nvotes)
     return half + 1 <= nvotes;
 }
 
-int raft_recv_requestvote_response(raft_server_t* me_,
+int raft_recv_requestvote_response(raft_server_t* me,
                                    raft_node_t* node,
                                    msg_requestvote_response_t* r)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    raft_log_node(me_, raft_node_get_id(node),
+    raft_log_node(me, raft_node_get_id(node),
              "node responded to requestvote status:%s pv:%d rt:%ld ct:%ld rt:%ld",
              r->vote_granted == 1 ? "granted" :
              r->vote_granted == 0 ? "not granted" : "unknown",
@@ -1068,21 +1024,21 @@ int raft_recv_requestvote_response(raft_server_t* me_,
 
     if (r->term > me->current_term)
     {
-        int e = raft_set_current_term(me_, r->term);
+        int e = raft_set_current_term(me, r->term);
         if (0 != e)
             return e;
-        raft_become_follower(me_);
+        raft_become_follower(me);
 
         return 0;
     }
 
     if (r->prevote) {
         /* Validate prevote is not stale */
-        if (!raft_is_precandidate(me_) || r->request_term != me->current_term + 1)
+        if (!raft_is_precandidate(me) || r->request_term != me->current_term + 1)
             return 0;
     } else {
         /* Validate reqvote is not stale */
-        if (!raft_is_candidate(me_) || r->request_term != me->current_term)
+        if (!raft_is_candidate(me) || r->request_term != me->current_term)
             return 0;
     }
 
@@ -1091,12 +1047,12 @@ int raft_recv_requestvote_response(raft_server_t* me_,
         if (node)
             raft_node_vote_for_me(node, 1);
 
-        int votes = raft_get_nvotes_for_me(me_);
-        int nodes = raft_get_num_voting_nodes(me_);
+        int votes = raft_get_nvotes_for_me(me);
+        int nodes = raft_get_num_voting_nodes(me);
 
         if (raft_votes_is_majority(nodes, votes)) {
-            int e = raft_is_precandidate(me_) ? raft_become_candidate(me_) :
-                                                raft_become_leader(me_);
+            int e = raft_is_precandidate(me) ? raft_become_candidate(me) :
+                                                raft_become_leader(me);
             if (0 != e)
                 return e;
         }
@@ -1105,40 +1061,38 @@ int raft_recv_requestvote_response(raft_server_t* me_,
     return 0;
 }
 
-int raft_recv_entry(raft_server_t* me_,
+int raft_recv_entry(raft_server_t* me,
                     msg_entry_t* ety,
                     msg_entry_response_t *r)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     if (raft_entry_is_voting_cfg_change(ety))
     {
         /* Only one voting cfg change at a time */
-        if (raft_voting_change_is_in_progress(me_))
+        if (raft_voting_change_is_in_progress(me))
             return RAFT_ERR_ONE_VOTING_CHANGE_ONLY;
 
         /* Multi-threading: need to fail here because user might be
          * snapshotting membership settings. */
-        if (!raft_is_apply_allowed(me_))
+        if (!raft_is_apply_allowed(me))
             return RAFT_ERR_SNAPSHOT_IN_PROGRESS;
     }
 
-    if (!raft_is_leader(me_))
+    if (!raft_is_leader(me))
         return RAFT_ERR_NOT_LEADER;
 
-    if (raft_get_transfer_leader(me_) != RAFT_NODE_ID_NONE)
+    if (raft_get_transfer_leader(me) != RAFT_NODE_ID_NONE)
         return RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS;
 
-    raft_log(me_, "received entry t:%ld id: %d idx: %ld",
-          me->current_term, ety->id, raft_get_current_idx(me_) + 1);
+    raft_log(me, "received entry t:%ld id: %d idx: %ld",
+          me->current_term, ety->id, raft_get_current_idx(me) + 1);
 
     ety->term = me->current_term;
-    int e = raft_append_entry(me_, ety);
+    int e = raft_append_entry(me, ety);
     if (0 != e)
         return e;
 
     r->id = ety->id;
-    r->idx = raft_get_current_idx(me_);
+    r->idx = raft_get_current_idx(me);
     r->term = me->current_term;
 
     if (me->auto_flush) {
@@ -1146,15 +1100,14 @@ int raft_recv_entry(raft_server_t* me_,
         if (0 != e)
             return e;
 
-        return raft_flush(me_, raft_get_current_idx(me_));
+        return raft_flush(me, raft_get_current_idx(me));
     }
 
     return 0;
 }
 
-int raft_send_requestvote(raft_server_t* me_, raft_node_t* node)
+int raft_send_requestvote(raft_server_t* me, raft_node_t* node)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     msg_requestvote_t rv;
     int e = 0;
 
@@ -1162,9 +1115,9 @@ int raft_send_requestvote(raft_server_t* me_, raft_node_t* node)
     assert(node != me->node);
 
     raft_node_id_t id = raft_node_get_id(node);
-    raft_log_node(me_, id, "sending requestvote to: %d", id);
+    raft_log_node(me, id, "sending requestvote to: %d", id);
 
-    if (raft_is_precandidate(me_))
+    if (raft_is_precandidate(me))
     {
         rv.prevote = 1;
         rv.term = me->current_term + 1;
@@ -1175,20 +1128,18 @@ int raft_send_requestvote(raft_server_t* me_, raft_node_t* node)
         rv.term = me->current_term;
     }
 
-    rv.last_log_idx = raft_get_current_idx(me_);
-    rv.last_log_term = raft_get_last_log_term(me_);
-    rv.candidate_id = raft_get_nodeid(me_);
+    rv.last_log_idx = raft_get_current_idx(me);
+    rv.last_log_term = raft_get_last_log_term(me);
+    rv.candidate_id = raft_get_nodeid(me);
 
     if (me->cb.send_requestvote)
-        e = me->cb.send_requestvote(me_, me->udata, node, &rv);
+        e = me->cb.send_requestvote(me, me->udata, node, &rv);
 
     return e;
 }
 
-int raft_append_entry(raft_server_t* me_, raft_entry_t* ety)
+int raft_append_entry(raft_server_t* me, raft_entry_t* ety)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     /* Don't allow inserting entries that are > our term.
      * term needs to be updated first
      */
@@ -1199,39 +1150,37 @@ int raft_append_entry(raft_server_t* me_, raft_entry_t* ety)
         return e;
 
     if (raft_entry_is_voting_cfg_change(ety))
-        me->voting_cfg_change_log_idx = raft_get_current_idx(me_);
+        me->voting_cfg_change_log_idx = raft_get_current_idx(me);
 
     if (raft_entry_is_cfg_change(ety)) {
-        raft_handle_append_cfg_change(me_, ety, raft_get_current_idx(me_));
+        raft_handle_append_cfg_change(me, ety, raft_get_current_idx(me));
     }
 
     return 0;
 }
 
-int raft_apply_entry(raft_server_t* me_)
+int raft_apply_entry(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    if (!raft_is_apply_allowed(me_))
+    if (!raft_is_apply_allowed(me))
         return -1;
 
     /* Don't apply after the commit_idx */
-    if (me->last_applied_idx == raft_get_commit_idx(me_))
+    if (me->last_applied_idx == raft_get_commit_idx(me))
         return -1;
 
     raft_index_t log_idx = me->last_applied_idx + 1;
 
-    raft_entry_t* ety = raft_get_entry_from_idx(me_, log_idx);
+    raft_entry_t* ety = raft_get_entry_from_idx(me, log_idx);
     if (!ety)
         return -1;
 
-    raft_log(me_, "applying log: %ld, id: %d size: %d",
+    raft_log(me, "applying log: %ld, id: %d size: %d",
           log_idx, ety->id, ety->data_len);
 
     me->last_applied_idx++;
     if (me->cb.applylog)
     {
-        int e = me->cb.applylog(me_, me->udata, ety, me->last_applied_idx);
+        int e = me->cb.applylog(me, me->udata, ety, me->last_applied_idx);
         assert(e == 0 || e == RAFT_ERR_SHUTDOWN);
         if (RAFT_ERR_SHUTDOWN == e) {
             raft_entry_release(ety);
@@ -1249,8 +1198,8 @@ int raft_apply_entry(raft_server_t* me_)
     if (!raft_entry_is_cfg_change(ety))
         goto exit;
 
-    raft_node_id_t node_id = me->cb.get_node_id(me_, raft_get_udata(me_), ety, log_idx);
-    raft_node_t* node = raft_get_node(me_, node_id);
+    raft_node_id_t node_id = me->cb.get_node_id(me, raft_get_udata(me), ety, log_idx);
+    raft_node_t* node = raft_get_node(me, node_id);
 
     switch (ety->type) {
         case RAFT_LOGTYPE_ADD_NODE:
@@ -1263,7 +1212,7 @@ int raft_apply_entry(raft_server_t* me_)
             break;
         case RAFT_LOGTYPE_REMOVE_NODE:
             if (node) {
-                raft_remove_node(me_, node);
+                raft_remove_node(me, node);
             }
             break;
         default:
@@ -1276,15 +1225,14 @@ exit:
     return 0;
 }
 
-raft_entry_t** raft_get_entries_from_idx(raft_server_t* me_, raft_index_t idx, int* n_etys)
+raft_entry_t** raft_get_entries_from_idx(raft_server_t* me, raft_index_t idx, int* n_etys)
 {
-    if (raft_get_current_idx(me_) < idx) {
+    if (raft_get_current_idx(me) < idx) {
         *n_etys = 0;
         return NULL;
     }
-
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-    raft_index_t size = raft_get_current_idx(me_) - idx + 1;
+    
+    raft_index_t size = raft_get_current_idx(me) - idx + 1;
     raft_entry_t **e = raft_malloc(size * sizeof(raft_entry_t*));
     int n = me->log_impl->get_batch(me->log, idx, (int) size, e);
 
@@ -1298,10 +1246,8 @@ raft_entry_t** raft_get_entries_from_idx(raft_server_t* me_, raft_index_t idx, i
     return e;
 }
 
-int raft_send_snapshot(raft_server_t* me_, raft_node_t* node)
+int raft_send_snapshot(raft_server_t* me, raft_node_t* node)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     if (!me->cb.send_snapshot)
         return 0;
 
@@ -1309,7 +1255,7 @@ int raft_send_snapshot(raft_server_t* me_, raft_node_t* node)
         raft_size_t offset = raft_node_get_snapshot_offset(node);
 
         msg_snapshot_t msg = {
-            .leader_id = raft_get_nodeid(me_),
+            .leader_id = raft_get_nodeid(me),
             .snapshot_index = me->snapshot_last_idx,
             .snapshot_term = me->snapshot_last_term,
             .term = me->current_term,
@@ -1319,12 +1265,12 @@ int raft_send_snapshot(raft_server_t* me_, raft_node_t* node)
 
         raft_snapshot_chunk_t *chunk = &msg.chunk;
 
-        int e = me->cb.get_snapshot_chunk(me_, me->udata, node, offset, chunk);
+        int e = me->cb.get_snapshot_chunk(me, me->udata, node, offset, chunk);
         if (e != 0) {
             return (e != RAFT_ERR_DONE) ? e : 0;
         }
 
-        e = me->cb.send_snapshot(me_, me->udata, node, &msg);
+        e = me->cb.send_snapshot(me, me->udata, node, &msg);
         if (e != 0) {
             return e;
         }
@@ -1339,19 +1285,17 @@ int raft_send_snapshot(raft_server_t* me_, raft_node_t* node)
     }
 }
 
-int raft_recv_snapshot(raft_server_t* me_,
+int raft_recv_snapshot(raft_server_t* me,
                        raft_node_t* node,
                        msg_snapshot_t *req,
                        msg_snapshot_response_t *resp)
 {
     int e = 0;
 
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    raft_log_node(me_, raft_node_get_id(node),
+    raft_log_node(me, raft_node_get_id(node),
                   "recv snapshot: ci:%lu comi:%lu t:%lu li:%d mi:%lu si:%lu st:%lu o:%llu, lc:%d, len:%llu",
-                  raft_get_current_idx(me_),
-                  raft_get_commit_idx(me_),
+                  raft_get_current_idx(me),
+                  raft_get_commit_idx(me),
                   req->term,
                   req->leader_id,
                   req->msg_id,
@@ -1366,10 +1310,10 @@ int raft_recv_snapshot(raft_server_t* me_,
     resp->offset = 0;
     resp->success = 0;
 
-    e = raft_receive_term(me_, req->term);
+    e = raft_receive_term(me, req->term);
     if (e != 0) {
         if (e == RAFT_ERR_STALE_TERM) {
-            raft_log_node(me_, req->leader_id,
+            raft_log_node(me, req->leader_id,
                           "Snapshot req term %ld is less than current term %ld",
                           req->term, me->current_term);
             e = 0;
@@ -1382,8 +1326,8 @@ int raft_recv_snapshot(raft_server_t* me_,
         raft_node_update_max_seen_msg_id(node, req->msg_id);
     }
 
-    raft_accept_leader(me_, req->leader_id);
-    raft_reset_transfer_leader(me_, 0);
+    raft_accept_leader(me, req->leader_id);
+    raft_reset_transfer_leader(me, 0);
 
     /** If we already have this snapshot, inform the leader. */
     if (req->snapshot_index <= me->snapshot_last_idx) {
@@ -1396,7 +1340,7 @@ int raft_recv_snapshot(raft_server_t* me_,
     /** In case leader takes another snapshot, it may start sending a more
      * recent snapshot. In that case, we dismiss existing snapshot file. */
     if (me->snapshot_recv_idx != req->snapshot_index) {
-        e = raft_clear_incoming_snapshot(me_, req->snapshot_index);
+        e = raft_clear_incoming_snapshot(me, req->snapshot_index);
         if (e != 0) {
             goto out;
         }
@@ -1408,7 +1352,7 @@ int raft_recv_snapshot(raft_server_t* me_,
         goto out;
     }
 
-    e = me->cb.store_snapshot_chunk(me_, me->udata, req->snapshot_index,
+    e = me->cb.store_snapshot_chunk(me, me->udata, req->snapshot_index,
                                     req->chunk.offset, &req->chunk);
     if (e != 0) {
         goto out;
@@ -1417,7 +1361,7 @@ int raft_recv_snapshot(raft_server_t* me_,
     me->snapshot_recv_offset = req->chunk.offset + req->chunk.len;
 
     if (req->chunk.last_chunk) {
-        e = me->cb.load_snapshot(me_, me->udata,
+        e = me->cb.load_snapshot(me, me->udata,
                                  req->snapshot_index, req->snapshot_term);
         if (e != 0) {
             goto out;
@@ -1433,23 +1377,21 @@ out:
     return e;
 }
 
-int raft_recv_snapshot_response(raft_server_t* me_,
+int raft_recv_snapshot_response(raft_server_t* me,
                                 raft_node_t* node,
                                 msg_snapshot_response_t *r)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    raft_log_node(me_, raft_node_get_id(node),
+    raft_log_node(me, raft_node_get_id(node),
                   "recv snapshot response: ci:%lu comi:%lu mi:%lu t:%ld o:%llu s:%d lc:%d",
-                  raft_get_current_idx(me_),
-                  raft_get_commit_idx(me_),
+                  raft_get_current_idx(me),
+                  raft_get_commit_idx(me),
                   r->msg_id,
                   r->term,
                   r->offset,
                   r->success,
                   r->last_chunk);
 
-    if (!raft_is_leader(me_))
+    if (!raft_is_leader(me))
         return RAFT_ERR_NOT_LEADER;
 
     if (raft_node_get_last_acked_msgid(node) > r->msg_id) {
@@ -1458,11 +1400,11 @@ int raft_recv_snapshot_response(raft_server_t* me_,
 
     if (me->current_term < r->term)
     {
-        int e = raft_set_current_term(me_, r->term);
+        int e = raft_set_current_term(me, r->term);
         if (0 != e)
             return e;
 
-        raft_become_follower(me_);
+        raft_become_follower(me);
         return 0;
     }
     else if (me->current_term != r->term)
@@ -1483,15 +1425,13 @@ int raft_recv_snapshot_response(raft_server_t* me_,
     }
 
     if (me->auto_flush)
-        return raft_flush(me_, 0);
+        return raft_flush(me, 0);
 
     return 0;
 }
 
-int raft_send_appendentries(raft_server_t* me_, raft_node_t* node)
+int raft_send_appendentries(raft_server_t* me, raft_node_t* node)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     assert(node);
     assert(node != me->node);
 
@@ -1504,33 +1444,33 @@ int raft_send_appendentries(raft_server_t* me_, raft_node_t* node)
     /* figure out if the client needs a snapshot sent */
     if (me->snapshot_last_idx > 0 && next_idx <= me->snapshot_last_idx)
     {
-        return raft_send_snapshot(me_, node);
+        return raft_send_snapshot(me, node);
     }
 
     if (!me->cb.send_appendentries)
         return -1;
 
     if (me->cb.backpressure) {
-        if (me->cb.backpressure(me_, me->udata, node) != 0) {
+        if (me->cb.backpressure(me, me->udata, node) != 0) {
             return 0;
         }
     }
 
     msg_appendentries_t ae = {
         .term = me->current_term,
-        .leader_id = raft_get_nodeid(me_),
-        .leader_commit = raft_get_commit_idx(me_),
+        .leader_id = raft_get_nodeid(me),
+        .leader_commit = raft_get_commit_idx(me),
         .msg_id = ++me->msg_id,
     };
 
-    ae.entries = raft_get_entries_from_idx(me_, next_idx, &ae.n_entries);
+    ae.entries = raft_get_entries_from_idx(me, next_idx, &ae.n_entries);
     assert((!ae.entries && 0 == ae.n_entries) ||
             (ae.entries && 0 < ae.n_entries));
 
     /* previous log is the log just before the new logs */
     if (next_idx > 1)
     {
-        raft_entry_t* prev_ety = raft_get_entry_from_idx(me_, next_idx - 1);
+        raft_entry_t* prev_ety = raft_get_entry_from_idx(me, next_idx - 1);
         if (!prev_ety)
         {
             ae.prev_log_idx = me->snapshot_last_idx;
@@ -1544,11 +1484,11 @@ int raft_send_appendentries(raft_server_t* me_, raft_node_t* node)
         }
     }
 
-    raft_log_node(me_,
+    raft_log_node(me,
               raft_node_get_id(node),
               "sending appendentries: ci:%lu comi:%lu t:%lu lc:%lu pli:%lu plt:%lu msgid:%lu #%d",
-              raft_get_current_idx(me_),
-              raft_get_commit_idx(me_),
+              raft_get_current_idx(me),
+              raft_get_commit_idx(me),
               ae.term,
               ae.leader_commit,
               ae.prev_log_idx,
@@ -1556,7 +1496,7 @@ int raft_send_appendentries(raft_server_t* me_, raft_node_t* node)
               ae.msg_id,
               ae.n_entries);
 
-    int res = me->cb.send_appendentries(me_, me->udata, node, &ae);
+    int res = me->cb.send_appendentries(me, me->udata, node, &ae);
     if (!res) {
         raft_node_set_next_idx(node, next_idx + ae.n_entries);
     }
@@ -1566,9 +1506,8 @@ int raft_send_appendentries(raft_server_t* me_, raft_node_t* node)
     return res;
 }
 
-int raft_send_appendentries_all(raft_server_t* me_)
+int raft_send_appendentries_all(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int i, e;
     int ret = 0;
 
@@ -1577,7 +1516,7 @@ int raft_send_appendentries_all(raft_server_t* me_)
         if (me->node == me->nodes[i])
             continue;
 
-        e = raft_send_appendentries(me_, me->nodes[i]);
+        e = raft_send_appendentries(me, me->nodes[i]);
         if (0 != e)
             ret = e;
     }
@@ -1585,9 +1524,8 @@ int raft_send_appendentries_all(raft_server_t* me_)
     return ret;
 }
 
-int raft_get_nvotes_for_me(raft_server_t* me_)
+int raft_get_nvotes_for_me(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int i, votes;
 
     for (i = 0, votes = 0; i < me->num_nodes; i++)
@@ -1606,17 +1544,15 @@ int raft_get_nvotes_for_me(raft_server_t* me_)
     return votes;
 }
 
-int raft_vote(raft_server_t* me_, raft_node_t* node)
+int raft_vote(raft_server_t* me, raft_node_t* node)
 {
-    return raft_vote_for_nodeid(me_, node ? raft_node_get_id(node) : -1);
+    return raft_vote_for_nodeid(me, node ? raft_node_get_id(node) : -1);
 }
 
-int raft_vote_for_nodeid(raft_server_t* me_, const raft_node_id_t nodeid)
+int raft_vote_for_nodeid(raft_server_t* me, const raft_node_id_t nodeid)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     if (me->cb.persist_vote) {
-        int e = me->cb.persist_vote(me_, me->udata, nodeid);
+        int e = me->cb.persist_vote(me, me->udata, nodeid);
         if (0 != e)
             return e;
     }
@@ -1624,10 +1560,10 @@ int raft_vote_for_nodeid(raft_server_t* me_, const raft_node_id_t nodeid)
     return 0;
 }
 
-int raft_msg_entry_response_committed(raft_server_t* me_,
+int raft_msg_entry_response_committed(raft_server_t* me,
                                       const msg_entry_response_t* r)
 {
-    raft_entry_t* ety = raft_get_entry_from_idx(me_, r->idx);
+    raft_entry_t* ety = raft_get_entry_from_idx(me, r->idx);
     if (!ety)
         return 0;
     raft_term_t ety_term = ety->term;
@@ -1636,17 +1572,17 @@ int raft_msg_entry_response_committed(raft_server_t* me_,
     /* entry from another leader has invalidated this entry message */
     if (r->term != ety_term)
         return -1;
-    return r->idx <= raft_get_commit_idx(me_);
+    return r->idx <= raft_get_commit_idx(me);
 }
 
-int raft_apply_all(raft_server_t* me_)
+int raft_apply_all(raft_server_t* me)
 {
-    if (!raft_is_apply_allowed(me_))
+    if (!raft_is_apply_allowed(me))
         return 0;
 
-    while (raft_get_last_applied_idx(me_) < raft_get_commit_idx(me_))
+    while (raft_get_last_applied_idx(me) < raft_get_commit_idx(me))
     {
-        int e = raft_apply_entry(me_);
+        int e = raft_apply_entry(me);
         if (0 != e)
             return e;
     }
@@ -1668,25 +1604,21 @@ int raft_entry_is_cfg_change(raft_entry_t* ety)
         RAFT_LOGTYPE_REMOVE_NODE == ety->type);
 }
 
-int raft_pop_entry(raft_server_t* me_)
+int raft_pop_entry(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     raft_index_t cur_idx = me->log_impl->current_idx(me->log);
 
     int e = me->log_impl->pop(me->log, cur_idx,
-               (func_entry_notify_f) raft_handle_remove_cfg_change, me_);
+               (func_entry_notify_f) raft_handle_remove_cfg_change, me);
     if (e != 0)
         return e;
 
     return me->log_impl->sync(me->log);
 }
 
-raft_index_t raft_get_first_entry_idx(raft_server_t* me_)
+raft_index_t raft_get_first_entry_idx(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    assert(0 < raft_get_current_idx(me_));
+    assert(0 < raft_get_current_idx(me));
 
     if (me->snapshot_last_idx == 0)
         return 1;
@@ -1694,65 +1626,57 @@ raft_index_t raft_get_first_entry_idx(raft_server_t* me_)
     return me->snapshot_last_idx;
 }
 
-raft_index_t raft_get_num_snapshottable_logs(raft_server_t *me_)
+raft_index_t raft_get_num_snapshottable_logs(raft_server_t *me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-    if (raft_get_log_count(me_) <= 1)
+    if (raft_get_log_count(me) <= 1)
         return 0;
-    return raft_get_commit_idx(me_) - me->log_impl->first_idx(me->log) + 1;
+    return raft_get_commit_idx(me) - me->log_impl->first_idx(me->log) + 1;
 }
 
-int raft_begin_snapshot(raft_server_t *me_, int flags)
+int raft_begin_snapshot(raft_server_t *me, int flags)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    if (raft_get_num_snapshottable_logs(me_) == 0)
+    if (raft_get_num_snapshottable_logs(me) == 0)
         return -1;
 
-    raft_index_t snapshot_target = raft_get_commit_idx(me_);
+    raft_index_t snapshot_target = raft_get_commit_idx(me);
     if (!snapshot_target)
         return -1;
 
-    raft_entry_t* ety = raft_get_entry_from_idx(me_, snapshot_target);
+    raft_entry_t* ety = raft_get_entry_from_idx(me, snapshot_target);
     if (!ety)
         return -1;
     raft_term_t ety_term = ety->term;
     raft_entry_release(ety);
 
     /* we need to get all the way to the commit idx */
-    int e = raft_apply_all(me_);
+    int e = raft_apply_all(me);
     if (e != 0)
         return e;
 
-    assert(raft_get_commit_idx(me_) == raft_get_last_applied_idx(me_));
+    assert(raft_get_commit_idx(me) == raft_get_last_applied_idx(me));
 
     me->snapshot_in_progress = 1;
     me->next_snapshot_last_idx = snapshot_target;
     me->next_snapshot_last_term = ety_term;
     me->snapshot_flags = flags;
 
-    raft_log(me_,
+    raft_log(me,
         "begin snapshot sli:%ld slt:%ld slogs:%ld",
         me->snapshot_last_idx,
         me->snapshot_last_term,
-        raft_get_num_snapshottable_logs(me_));
+        raft_get_num_snapshottable_logs(me));
 
     return 0;
 }
 
-int raft_cancel_snapshot(raft_server_t *me_)
+int raft_cancel_snapshot(raft_server_t *me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     me->snapshot_in_progress = 0;
-
     return 0;
 }
 
-int raft_end_snapshot(raft_server_t *me_)
+int raft_end_snapshot(raft_server_t *me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     if (!me->snapshot_in_progress)
         return -1;
 
@@ -1770,13 +1694,13 @@ int raft_end_snapshot(raft_server_t *me_)
 
     me->snapshot_in_progress = 0;
 
-    raft_log(me_,
+    raft_log(me,
         "end snapshot base:%ld commit-index:%ld current-index:%ld",
         me->log_impl->first_idx(me->log) - 1,
-        raft_get_commit_idx(me_),
-        raft_get_current_idx(me_));
+        raft_get_commit_idx(me),
+        raft_get_current_idx(me));
 
-    if (!raft_is_leader(me_))
+    if (!raft_is_leader(me))
         return 0;
 
     for (int i = 0; i < me->num_nodes; i++)
@@ -1792,7 +1716,7 @@ int raft_end_snapshot(raft_server_t *me_)
         /* figure out if the client needs a snapshot sent */
         if (me->snapshot_last_idx > 0 && next_idx <= me->snapshot_last_idx)
         {
-            raft_send_snapshot(me_, node);
+            raft_send_snapshot(me, node);
         }
     }
 
@@ -1800,12 +1724,10 @@ int raft_end_snapshot(raft_server_t *me_)
 }
 
 int raft_begin_load_snapshot(
-    raft_server_t *me_,
+    raft_server_t *me,
     raft_term_t last_included_term,
     raft_index_t last_included_index)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     if (last_included_index == -1)
         return -1;
 
@@ -1817,14 +1739,14 @@ int raft_begin_load_snapshot(
         return -1;
 
     /* snapshot was unnecessary */
-    if (last_included_index < raft_get_current_idx(me_))
+    if (last_included_index < raft_get_current_idx(me))
         return -1;
 
     if (last_included_index <= me->snapshot_last_idx)
         return RAFT_ERR_SNAPSHOT_ALREADY_LOADED;
 
     if (me->current_term < last_included_term) {
-        raft_set_current_term(me_, last_included_term);
+        raft_set_current_term(me, last_included_term);
         me->current_term = last_included_term;
     }
 
@@ -1833,8 +1755,8 @@ int raft_begin_load_snapshot(
 
     me->log_impl->reset(me->log, last_included_index + 1, last_included_term);
 
-    if (raft_get_commit_idx(me_) < last_included_index)
-        raft_set_commit_idx(me_, last_included_index);
+    if (raft_get_commit_idx(me) < last_included_index)
+        raft_set_commit_idx(me, last_included_index);
 
     me->last_applied_idx = last_included_index;
     me->next_snapshot_last_term = last_included_term;
@@ -1844,7 +1766,7 @@ int raft_begin_load_snapshot(
     int i, my_node_by_idx = 0;
     for (i = 0; i < me->num_nodes; i++)
     {
-        if (raft_get_nodeid(me_) == raft_node_get_id(me->nodes[i]))
+        if (raft_get_nodeid(me) == raft_node_get_id(me->nodes[i]))
             my_node_by_idx = i;
         else {
             raft_node_free(me->nodes[i]);
@@ -1856,18 +1778,17 @@ int raft_begin_load_snapshot(
     me->nodes[0] = me->nodes[my_node_by_idx];
     me->num_nodes = 1;
 
-    raft_log(me_,
+    raft_log(me,
         "loaded snapshot sli:%ld slt:%ld slogs:%ld",
         me->snapshot_last_idx,
         me->snapshot_last_term,
-        raft_get_num_snapshottable_logs(me_));
+        raft_get_num_snapshottable_logs(me));
 
     return 0;
 }
 
-int raft_end_load_snapshot(raft_server_t *me_)
+int raft_end_load_snapshot(raft_server_t *me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int i;
 
     me->snapshot_last_idx = me->next_snapshot_last_idx;
@@ -1886,9 +1807,8 @@ int raft_end_load_snapshot(raft_server_t *me_)
     return 0;
 }
 
-void *raft_get_log(raft_server_t *me_)
+void *raft_get_log(raft_server_t *me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->log;
 }
 
@@ -1930,14 +1850,12 @@ void raft_entry_release_list(raft_entry_t **ety_list, size_t len)
     }
 }
 
-int raft_queue_read_request(raft_server_t* me_, func_read_request_callback_f cb, void *cb_arg)
+int raft_queue_read_request(raft_server_t* me, func_read_request_callback_f cb, void *cb_arg)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-
     raft_read_request_t *req = raft_malloc(sizeof(raft_read_request_t));
 
-    req->read_idx = raft_get_current_idx(me_);
-    req->read_term = raft_get_current_term(me_);
+    req->read_idx = raft_get_current_idx(me);
+    req->read_term = raft_get_current_term(me);
     req->msg_id = ++me->msg_id;
     req->cb = cb;
     req->cb_arg = cb_arg;
@@ -1952,12 +1870,12 @@ int raft_queue_read_request(raft_server_t* me_, func_read_request_callback_f cb,
     me->need_quorum_round = 1;
 
     if (me->auto_flush)
-        return raft_flush(me_, 0);
+        return raft_flush(me, 0);
 
     return 0;
 }
 
-static void pop_read_queue(raft_server_private_t *me, int can_read)
+static void pop_read_queue(raft_server_t *me, int can_read)
 {
     raft_read_request_t *p = me->read_queue_head;
 
@@ -1976,15 +1894,13 @@ static void pop_read_queue(raft_server_private_t *me, int can_read)
     raft_free(p);
 }
 
-void raft_process_read_queue(raft_server_t* me_)
+void raft_process_read_queue(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-
     if (!me->read_queue_head)
         return;
 
     /* As a follower we drop all queued read requests */
-    if (raft_is_follower(me_)) {
+    if (raft_is_follower(me)) {
         while (me->read_queue_head) {
             pop_read_queue(me, 0);
         }
@@ -1995,15 +1911,15 @@ void raft_process_read_queue(raft_server_t* me_)
      * 1) Heartbeat acknowledged by majority
      * 2) We're on the same term (note: is this needed or over cautious?)
      */
-    if (!raft_is_leader(me_))
+    if (!raft_is_leader(me))
         return;
 
     /* Quickly bail if nothing to do */
     if (!me->read_queue_head)
         return;
 
-    if (raft_get_num_voting_nodes(me_) > 1) {
-        raft_entry_t *ety = raft_get_entry_from_idx(me_, raft_get_commit_idx(me_));
+    if (raft_get_num_voting_nodes(me) > 1) {
+        raft_entry_t *ety = raft_get_entry_from_idx(me, raft_get_commit_idx(me));
         if (!ety)
             return;
 
@@ -2018,7 +1934,7 @@ void raft_process_read_queue(raft_server_t* me_)
             return;
     }
 
-    raft_msg_id_t last_acked_msgid = quorum_msg_id(me_);
+    raft_msg_id_t last_acked_msgid = quorum_msg_id(me);
     raft_index_t last_applied_idx = me->last_applied_idx;
 
     /* Special case: the log's first index is 1, so we need to account
@@ -2027,7 +1943,7 @@ void raft_process_read_queue(raft_server_t* me_)
      * Note that this also implies a single node because adding nodes would
      * bump the log and commit index.
      */
-    if (!me->commit_idx && !me->last_applied_idx && raft_get_current_idx(me_) == 1)
+    if (!me->commit_idx && !me->last_applied_idx && raft_get_current_idx(me) == 1)
         last_applied_idx = 1;
 
     while (me->read_queue_head &&
@@ -2042,10 +1958,8 @@ void raft_process_read_queue(raft_server_t* me_)
  * timeout = how long this should be allowed to take in milliseconds, as calculated by calls to raft_periodic
  * return an error if leadership transfer is already in progress of the targeted node_id is unknown
  */
-int raft_transfer_leader(raft_server_t* me_, raft_node_id_t node_id, long timeout)
+int raft_transfer_leader(raft_server_t* me, raft_node_id_t node_id, long timeout)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-
     if (me->state != RAFT_STATE_LEADER) {
         return RAFT_ERR_NOT_LEADER;
     }
@@ -2054,14 +1968,14 @@ int raft_transfer_leader(raft_server_t* me_, raft_node_id_t node_id, long timeou
         return RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS;
     }
 
-    raft_node_t *target = raft_get_node(me_, node_id);
+    raft_node_t *target = raft_get_node(me, node_id);
     if (target == NULL || target == me->node) {
         return RAFT_ERR_INVALID_NODEID;
     }
 
     if (me->cb.send_timeoutnow &&
-        raft_get_current_idx(me_) == raft_node_get_match_idx(target)) {
-        me->cb.send_timeoutnow(me_, target);
+        raft_get_current_idx(me) == raft_node_get_match_idx(target)) {
+        me->cb.send_timeoutnow(me, target);
         me->sent_timeout_now = 1;
     }
 
@@ -2073,9 +1987,9 @@ int raft_transfer_leader(raft_server_t* me_, raft_node_id_t node_id, long timeou
 
 /* Forces the raft server to invoke an election as part of leader transfer
  * operation. */
-int raft_timeout_now(raft_server_t* me_)
+int raft_timeout_now(raft_server_t* me)
 {
-    if (raft_is_leader(me_)) {
+    if (raft_is_leader(me)) {
         return 0;
     }
 
@@ -2087,17 +2001,16 @@ int raft_timeout_now(raft_server_t* me_)
      * round, leader transfer operation can be completed faster and cluster will
      * experience less downtime.
      */
-    return raft_election_start(me_, 1);
+    return raft_election_start(me, 1);
 }
 
 /* Stop trying to transfer leader to a targeted node
  * internally used because either we have timed out our attempt or because we are no longer the leader
  * possible to be used by a client as well.
  */
-void raft_reset_transfer_leader(raft_server_t* me_, int timed_out)
+void raft_reset_transfer_leader(raft_server_t* me, int timed_out)
 {
     raft_leader_transfer_e result;
-    raft_server_private_t* me = (raft_server_private_t*) me_;
 
     if (me->node_transferring_leader_to == RAFT_NODE_ID_NONE)  {
         return;
@@ -2112,7 +2025,7 @@ void raft_reset_transfer_leader(raft_server_t* me_, int timed_out)
     }
 
     if (me->cb.notify_transfer_event) {
-        me->cb.notify_transfer_event(me_, me->udata, result);
+        me->cb.notify_transfer_event(me, me->udata, result);
     }
 
     me->node_transferring_leader_to = RAFT_NODE_ID_NONE;
@@ -2128,9 +2041,8 @@ static int index_cmp(const void *a, const void *b)
     return va > vb ? -1 : 1;
 }
 
-static int raft_update_commit_idx(raft_server_t* me_)
+static int raft_update_commit_idx(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
     raft_index_t indexes[me->num_nodes];
     int num_voters = 0;
 
@@ -2147,9 +2059,9 @@ static int raft_update_commit_idx(raft_server_t* me_)
     raft_index_t commit = indexes[num_voters / 2];
     if (commit > me->commit_idx) {
         /* Leader can only commit entries from the current term */
-        raft_entry_t *ety = raft_get_entry_from_idx(me_, commit);
+        raft_entry_t *ety = raft_get_entry_from_idx(me, commit);
         if (ety->term == me->current_term)
-            raft_set_commit_idx(me_, commit);
+            raft_set_commit_idx(me, commit);
 
         raft_entry_release(ety);
     }
@@ -2157,12 +2069,11 @@ static int raft_update_commit_idx(raft_server_t* me_)
     return 0;
 }
 
-raft_index_t raft_get_index_to_sync(raft_server_t *me_)
+raft_index_t raft_get_index_to_sync(raft_server_t *me)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-    raft_index_t idx = raft_get_current_idx(me_);
+    raft_index_t idx = raft_get_current_idx(me);
 
-    if (!raft_is_leader(me_) || idx < me->next_sync_index) {
+    if (!raft_is_leader(me) || idx < me->next_sync_index) {
         return 0;
     }
 
@@ -2170,18 +2081,15 @@ raft_index_t raft_get_index_to_sync(raft_server_t *me_)
     return idx;
 }
 
-int raft_set_auto_flush(raft_server_t* me_, int flush)
+int raft_set_auto_flush(raft_server_t* me, int flush)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
     me->auto_flush = flush ? 1 : 0;
     return 0;
 }
 
-int raft_flush(raft_server_t* me_, raft_index_t sync_index)
+int raft_flush(raft_server_t* me, raft_index_t sync_index)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-
-    if (!raft_is_leader(me_)) {
+    if (!raft_is_leader(me)) {
         return 0;
     }
 
@@ -2189,7 +2097,7 @@ int raft_flush(raft_server_t* me_, raft_index_t sync_index)
         raft_node_set_match_idx(me->node, sync_index);
     }
 
-    int e = raft_update_commit_idx(me_);
+    int e = raft_update_commit_idx(me);
     if (e != 0) {
         return e;
     }
@@ -2200,22 +2108,22 @@ int raft_flush(raft_server_t* me_, raft_index_t sync_index)
             continue;
 
         if (!me->need_quorum_round &&
-            raft_node_get_next_idx(me->nodes[i]) > raft_get_current_idx(me_))
+            raft_node_get_next_idx(me->nodes[i]) > raft_get_current_idx(me))
             continue;
 
-        raft_send_appendentries(me_, me->nodes[i]);
+        raft_send_appendentries(me, me->nodes[i]);
     }
 
     me->need_quorum_round = 0;
 
-    if (me->last_applied_idx < raft_get_commit_idx(me_)) {
-        e = raft_apply_all(me_);
+    if (me->last_applied_idx < raft_get_commit_idx(me)) {
+        e = raft_apply_all(me);
         if (e != 0) {
             return e;
         }
     }
 
-    raft_process_read_queue(me_);
+    raft_process_read_queue(me);
 
     return 0;
 }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -13,54 +13,48 @@
 #include "raft.h"
 #include "raft_private.h"
 
-void raft_set_election_timeout(raft_server_t* me_, int millisec)
+void raft_set_election_timeout(raft_server_t* me, int millisec)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
     me->election_timeout = millisec;
 
-    raft_update_quorum_meta(me_, me->last_acked_msg_id);
-    raft_randomize_election_timeout(me_);
+    raft_update_quorum_meta(me, me->last_acked_msg_id);
+    raft_randomize_election_timeout(me);
 }
 
-void raft_set_request_timeout(raft_server_t* me_, int millisec)
+void raft_set_request_timeout(raft_server_t* me, int millisec)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     me->request_timeout = millisec;
 }
 
-void raft_set_log_enabled(raft_server_t* me_, int enable)
+void raft_set_log_enabled(raft_server_t* me, int enable)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     me->log_enabled = enable;
 }
 
-raft_node_id_t raft_get_nodeid(raft_server_t* me_)
+raft_node_id_t raft_get_nodeid(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     if (!me->node)
         return -1;
     return raft_node_get_id(me->node);
 }
 
-int raft_get_election_timeout(raft_server_t* me_)
+int raft_get_election_timeout(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->election_timeout;
+    return me->election_timeout;
 }
 
-int raft_get_request_timeout(raft_server_t* me_)
+int raft_get_request_timeout(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->request_timeout;
+    return me->request_timeout;
 }
 
-int raft_get_num_nodes(raft_server_t* me_)
+int raft_get_num_nodes(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->num_nodes;
+    return me->num_nodes;
 }
 
-int raft_get_num_voting_nodes(raft_server_t* me_)
+int raft_get_num_voting_nodes(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int i, num = 0;
     for (i = 0; i < me->num_nodes; i++)
         if (raft_node_is_voting(me->nodes[i]))
@@ -68,32 +62,29 @@ int raft_get_num_voting_nodes(raft_server_t* me_)
     return num;
 }
 
-int raft_get_timeout_elapsed(raft_server_t* me_)
+int raft_get_timeout_elapsed(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->timeout_elapsed;
+    return me->timeout_elapsed;
 }
 
-raft_index_t raft_get_log_count(raft_server_t* me_)
+raft_index_t raft_get_log_count(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->log_impl->count(me->log);
 }
 
-int raft_get_voted_for(raft_server_t* me_)
+int raft_get_voted_for(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->voted_for;
 }
 
-int raft_set_current_term(raft_server_t* me_, const raft_term_t term)
+int raft_set_current_term(raft_server_t* me, const raft_term_t term)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     if (me->current_term < term)
     {
         int voted_for = -1;
         if (me->cb.persist_term)
         {
-            int e = me->cb.persist_term(me_, me->udata, term, voted_for);
+            int e = me->cb.persist_term(me, me->udata, term, voted_for);
             if (0 != e)
                 return e;
         }
@@ -104,58 +95,53 @@ int raft_set_current_term(raft_server_t* me_, const raft_term_t term)
     return 0;
 }
 
-raft_term_t raft_get_current_term(raft_server_t* me_)
+raft_term_t raft_get_current_term(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->current_term;
+    return me->current_term;
 }
 
-raft_index_t raft_get_current_idx(raft_server_t* me_)
+raft_index_t raft_get_current_idx(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->log_impl->current_idx(me->log);
 }
 
-void raft_set_commit_idx(raft_server_t* me_, raft_index_t idx)
+void raft_set_commit_idx(raft_server_t* me, raft_index_t idx)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     assert(me->commit_idx <= idx);
-    assert(idx <= raft_get_current_idx(me_));
+    assert(idx <= raft_get_current_idx(me));
     me->commit_idx = idx;
 }
 
-void raft_set_last_applied_idx(raft_server_t* me_, raft_index_t idx)
+void raft_set_last_applied_idx(raft_server_t* me, raft_index_t idx)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     me->last_applied_idx = idx;
 }
 
-raft_index_t raft_get_last_applied_idx(raft_server_t* me_)
+raft_index_t raft_get_last_applied_idx(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->last_applied_idx;
+    return me->last_applied_idx;
 }
 
-raft_index_t raft_get_commit_idx(raft_server_t* me_)
+raft_index_t raft_get_commit_idx(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->commit_idx;
+    return me->commit_idx;
 }
 
-void raft_set_state(raft_server_t* me_, int state)
+void raft_set_state(raft_server_t* me, int state)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     /* if became the leader, then update the current leader entry */
     if (state == RAFT_STATE_LEADER)
         me->leader_id = raft_node_get_id(me->node);
     me->state = state;
 }
 
-int raft_get_state(raft_server_t* me_)
+int raft_get_state(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->state;
+    return me->state;
 }
 
-raft_node_t* raft_get_node(raft_server_t *me_, raft_node_id_t nodeid)
+raft_node_t* raft_get_node(raft_server_t *me, raft_node_id_t nodeid)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int i;
 
     for (i = 0; i < me->num_nodes; i++)
@@ -165,136 +151,125 @@ raft_node_t* raft_get_node(raft_server_t *me_, raft_node_id_t nodeid)
     return NULL;
 }
 
-raft_node_t* raft_get_my_node(raft_server_t *me_)
+raft_node_t* raft_get_my_node(raft_server_t *me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     int i;
 
     for (i = 0; i < me->num_nodes; i++)
-        if (raft_get_nodeid(me_) == raft_node_get_id(me->nodes[i]))
+        if (raft_get_nodeid(me) == raft_node_get_id(me->nodes[i]))
             return me->nodes[i];
 
     return NULL;
 }
 
-raft_node_t* raft_get_node_from_idx(raft_server_t* me_, const raft_index_t idx)
+raft_node_t* raft_get_node_from_idx(raft_server_t* me, const raft_index_t idx)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->nodes[idx];
 }
 
-raft_node_id_t raft_get_leader_id(raft_server_t* me_)
+raft_node_id_t raft_get_leader_id(raft_server_t* me)
 {
-    raft_server_private_t* me = (void*)me_;
     return me->leader_id;
 }
 
-raft_node_t* raft_get_leader_node(raft_server_t* me_)
+raft_node_t* raft_get_leader_node(raft_server_t* me)
 {
-    raft_server_private_t* me = (void*)me_;
-    return raft_get_node(me_, me->leader_id);
+    return raft_get_node(me, me->leader_id);
 }
 
-void* raft_get_udata(raft_server_t* me_)
+void* raft_get_udata(raft_server_t* me)
 {
-    return ((raft_server_private_t*)me_)->udata;
+    return me->udata;
 }
 
-int raft_is_follower(raft_server_t* me_)
+int raft_is_follower(raft_server_t* me)
 {
-    return raft_get_state(me_) == RAFT_STATE_FOLLOWER;
+    return raft_get_state(me) == RAFT_STATE_FOLLOWER;
 }
 
-int raft_is_leader(raft_server_t* me_)
+int raft_is_leader(raft_server_t* me)
 {
-    return raft_get_state(me_) == RAFT_STATE_LEADER;
+    return raft_get_state(me) == RAFT_STATE_LEADER;
 }
 
-int raft_is_precandidate(raft_server_t* me_)
+int raft_is_precandidate(raft_server_t* me)
 {
-    return raft_get_state(me_) == RAFT_STATE_PRECANDIDATE;
+    return raft_get_state(me) == RAFT_STATE_PRECANDIDATE;
 }
 
-int raft_is_candidate(raft_server_t* me_)
+int raft_is_candidate(raft_server_t* me)
 {
-    return raft_get_state(me_) == RAFT_STATE_CANDIDATE;
+    return raft_get_state(me) == RAFT_STATE_CANDIDATE;
 }
 
-raft_term_t raft_get_last_log_term(raft_server_t* me_)
+raft_term_t raft_get_last_log_term(raft_server_t* me)
 {
-    raft_index_t current_idx = raft_get_current_idx(me_);
+    raft_index_t current_idx = raft_get_current_idx(me);
     if (0 < current_idx)
     {
-        raft_entry_t* ety = raft_get_entry_from_idx(me_, current_idx);
+        raft_entry_t* ety = raft_get_entry_from_idx(me, current_idx);
         if (ety) {
             raft_term_t term = ety->term;
             raft_entry_release(ety);
             return term;
-        } else if (raft_get_snapshot_last_idx(me_) == current_idx) {
-            return raft_get_snapshot_last_term(me_);
+        } else if (raft_get_snapshot_last_idx(me) == current_idx) {
+            return raft_get_snapshot_last_term(me);
         }
     }
 
     return 0;
 }
 
-int raft_snapshot_is_in_progress(raft_server_t *me_)
+int raft_snapshot_is_in_progress(raft_server_t *me)
 {
-    return ((raft_server_private_t*)me_)->snapshot_in_progress;
+    return me->snapshot_in_progress;
 }
 
-int raft_is_apply_allowed(raft_server_t* me_)
+int raft_is_apply_allowed(raft_server_t* me)
 {
-    return (!raft_snapshot_is_in_progress(me_) ||
-            (((raft_server_private_t*)me_)->snapshot_flags & RAFT_SNAPSHOT_NONBLOCKING_APPLY));
+    return (!raft_snapshot_is_in_progress(me) ||
+            (me->snapshot_flags & RAFT_SNAPSHOT_NONBLOCKING_APPLY));
 }
 
-raft_entry_t *raft_get_last_applied_entry(raft_server_t *me_)
+raft_entry_t *raft_get_last_applied_entry(raft_server_t *me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-    if (raft_get_last_applied_idx(me_) == 0)
+    if (raft_get_last_applied_idx(me) == 0)
         return NULL;
-    return me->log_impl->get(me->log, raft_get_last_applied_idx(me_));
+    return me->log_impl->get(me->log, raft_get_last_applied_idx(me));
 }
 
-raft_index_t raft_get_snapshot_last_idx(raft_server_t *me_)
+raft_index_t raft_get_snapshot_last_idx(raft_server_t *me)
 {
-    return ((raft_server_private_t*)me_)->snapshot_last_idx;
+    return me->snapshot_last_idx;
 }
 
-raft_term_t raft_get_snapshot_last_term(raft_server_t *me_)
+raft_term_t raft_get_snapshot_last_term(raft_server_t *me)
 {
-    return ((raft_server_private_t*)me_)->snapshot_last_term;
+    return me->snapshot_last_term;
 }
 
-void raft_set_snapshot_metadata(raft_server_t *me_, raft_term_t term, raft_index_t idx)
+void raft_set_snapshot_metadata(raft_server_t *me, raft_term_t term, raft_index_t idx)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     me->last_applied_idx = idx;
     me->snapshot_last_term = term;
     me->snapshot_last_idx = idx;
 }
 
-int raft_is_single_node_voting_cluster(raft_server_t *me_)
+int raft_is_single_node_voting_cluster(raft_server_t *me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
-
-    return (1 == raft_get_num_voting_nodes(me_) && raft_node_is_voting(me->node));
+    return (1 == raft_get_num_voting_nodes(me) && raft_node_is_voting(me->node));
 }
 
-raft_msg_id_t raft_get_msg_id(raft_server_t* me_)
+raft_msg_id_t raft_get_msg_id(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*)me_;
     return me->msg_id;
 }
 
 /* return the targeted node_id if we are in the middle of attempting a leadership transfer
  * return RAFT_NODE_ID_NONE if no leadership transfer is in progress
  */
-raft_node_id_t raft_get_transfer_leader(raft_server_t* me_)
+raft_node_id_t raft_get_transfer_leader(raft_server_t* me)
 {
-    raft_server_private_t* me = (raft_server_private_t*) me_;
-
     return me->node_transferring_leader_to;
 }
 

--- a/tests/log_fuzzer.py
+++ b/tests/log_fuzzer.py
@@ -47,7 +47,7 @@ class CoreTestCase(unittest.TestCase):
         r = self.r.lib
 
         unique_id = 1
-        l = r.log_alloc(1)
+        l = r.raft_log_alloc(1)
 
         log = Log()
 
@@ -57,32 +57,31 @@ class CoreTestCase(unittest.TestCase):
                 entry.id = unique_id
                 unique_id += 1
 
-                ret = r.log_append_entry(l, entry)
+                ret = r.raft_log_append_entry(l, entry)
                 assert ret == 0
 
                 log.append(entry)
 
             elif cmd == 'poll':
-                entry_ptr = self.r.ffi.new('void**')
+                entry_ptr = self.r.ffi.new('raft_entry_t**')
 
                 if log.entries:
-                    ret = r.log_poll(l, entry_ptr)
+                    ret = r.raft_log_poll(l, entry_ptr)
                     assert ret == 0
 
                     ety_expected = log.poll()
-                    ety_actual = self.r.ffi.cast('raft_entry_t**', entry_ptr)[0]
-                    assert ety_actual.id == ety_expected.id
+                    assert entry_ptr[0].id == ety_expected.id
 
             elif isinstance(cmd, int):
                 if log.entries:
                     log.delete(cmd)
-                    ret = r.log_delete(l, cmd)
+                    ret = r.raft_log_delete(l, cmd)
                     assert ret == 0
 
             else:
                 assert False
 
-            self.assertEqual(r.log_count(l), log.count())
+            self.assertEqual(r.raft_log_count(l), log.count())
 
 
 if __name__ == '__main__':

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -18,7 +18,7 @@ static void __LOG_APPEND_ENTRY(void *l, int id, raft_term_t term, const char *da
 {
     raft_entry_t *e = __MAKE_ENTRY(id, term, data);
     raft_entry_hold(e); /* need an extra ref because tests assume it lives on */
-    log_append_entry(l, e);
+    raft_log_append_entry(l, e);
 }
 
 static void __LOG_APPEND_ENTRIES_SEQ_ID(void *l, int count, int id, raft_term_t term, const char *data)
@@ -27,7 +27,7 @@ static void __LOG_APPEND_ENTRIES_SEQ_ID(void *l, int count, int id, raft_term_t 
     for (i = 0; i < count; i++) {
         raft_entry_t *e = __MAKE_ENTRY(id++, term, data);
         raft_entry_hold(e); /* need an extra ref because tests assume it lives on */
-        log_append_entry(l, e);
+        raft_log_append_entry(l, e);
     }
 }
 
@@ -87,7 +87,7 @@ void* __set_up()
     void* queue = llqueue_new();
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, queue);
-    log_set_callbacks(raft_get_log(r), &log_funcs, r);
+    raft_log_set_callbacks(raft_get_log(r), &log_funcs, r);
     return r;
 }
 
@@ -95,8 +95,8 @@ void TestLog_new_is_empty(CuTest * tc)
 {
     void *l;
 
-    l = log_new();
-    CuAssertTrue(tc, 0 == log_count(l));
+    l = raft_log_new();
+    CuAssertTrue(tc, 0 == raft_log_count(l));
 }
 
 void TestLog_append_is_not_empty(CuTest * tc)
@@ -105,38 +105,38 @@ void TestLog_append_is_not_empty(CuTest * tc)
 
     void *r = raft_new();
 
-    l = log_new();
+    l = raft_log_new();
     raft_log_cbs_t funcs = {
         .log_offer = __log_offer
     };
-    log_set_callbacks(l, &funcs, r);
+    raft_log_set_callbacks(l, &funcs, r);
     __LOG_APPEND_ENTRY(l, 1, 0, NULL);
-    CuAssertIntEquals(tc, 1, log_count(l));
+    CuAssertIntEquals(tc, 1, raft_log_count(l));
 }
 
 void TestLog_get_at_idx(CuTest * tc)
 {
     void *l;
 
-    l = log_new();
+    l = raft_log_new();
     __LOG_APPEND_ENTRIES_SEQ_ID(l, 3, 1, 0, NULL);
-    CuAssertIntEquals(tc, 3, log_count(l));
+    CuAssertIntEquals(tc, 3, raft_log_count(l));
 
-    CuAssertIntEquals(tc, 1, log_get_at_idx(l, 1)->id);
-    CuAssertIntEquals(tc, 2, log_get_at_idx(l, 2)->id);
-    CuAssertIntEquals(tc, 3, log_get_at_idx(l, 3)->id);
+    CuAssertIntEquals(tc, 1, raft_log_get_at_idx(l, 1)->id);
+    CuAssertIntEquals(tc, 2, raft_log_get_at_idx(l, 2)->id);
+    CuAssertIntEquals(tc, 3, raft_log_get_at_idx(l, 3)->id);
 }
 
 void TestLog_get_at_idx_returns_null_where_out_of_bounds(CuTest * tc)
 {
     void *l;
 
-    l = log_new();
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 0));
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 1));
+    l = raft_log_new();
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 0));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 1));
 
     __LOG_APPEND_ENTRY(l, 1, 0, NULL);
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 2));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 2));
 }
 
 void TestLog_delete(CuTest * tc)
@@ -154,26 +154,26 @@ void TestLog_delete(CuTest * tc)
 
     raft_set_callbacks(r, &funcs, queue);
 
-    l = log_new();
-    log_set_callbacks(l, &log_funcs, r);
+    l = raft_log_new();
+    raft_log_set_callbacks(l, &log_funcs, r);
 
     __LOG_APPEND_ENTRIES_SEQ_ID(l, 3, 1, 0, NULL);
-    CuAssertIntEquals(tc, 3, log_count(l));
-    CuAssertIntEquals(tc, 3, log_get_current_idx(l));
+    CuAssertIntEquals(tc, 3, raft_log_count(l));
+    CuAssertIntEquals(tc, 3, raft_log_get_current_idx(l));
 
-    log_delete(l, 3);
-    CuAssertIntEquals(tc, 2, log_count(l));
+    raft_log_delete(l, 3);
+    CuAssertIntEquals(tc, 2, raft_log_count(l));
     CuAssertIntEquals(tc, 3, ((raft_entry_t*)llqueue_poll(queue))->id);
-    CuAssertIntEquals(tc, 2, log_count(l));
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 3));
+    CuAssertIntEquals(tc, 2, raft_log_count(l));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 3));
 
-    log_delete(l, 2);
-    CuAssertIntEquals(tc, 1, log_count(l));
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 2));
+    raft_log_delete(l, 2);
+    CuAssertIntEquals(tc, 1, raft_log_count(l));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 2));
 
-    log_delete(l, 1);
-    CuAssertIntEquals(tc, 0, log_count(l));
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 1));
+    raft_log_delete(l, 1);
+    CuAssertIntEquals(tc, 0, raft_log_count(l));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 1));
 }
 
 void TestLog_delete_onwards(CuTest * tc)
@@ -189,18 +189,18 @@ void TestLog_delete_onwards(CuTest * tc)
 
     void *l;
 
-    l = log_new();
-    log_set_callbacks(l, &log_funcs, r);
+    l = raft_log_new();
+    raft_log_set_callbacks(l, &log_funcs, r);
 
     __LOG_APPEND_ENTRIES_SEQ_ID(l, 3, 1, 0, NULL);
-    CuAssertIntEquals(tc, 3, log_count(l));
+    CuAssertIntEquals(tc, 3, raft_log_count(l));
 
     /* even 3 gets deleted */
-    log_delete(l, 2);
-    CuAssertIntEquals(tc, 1, log_count(l));
-    CuAssertIntEquals(tc, 1, log_get_at_idx(l, 1)->id);
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 2));
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 3));
+    raft_log_delete(l, 2);
+    CuAssertIntEquals(tc, 1, raft_log_count(l));
+    CuAssertIntEquals(tc, 1, raft_log_get_at_idx(l, 1)->id);
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 2));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 3));
 }
 
 void TestLog_delete_handles_log_pop_failure(CuTest * tc)
@@ -216,17 +216,17 @@ void TestLog_delete_handles_log_pop_failure(CuTest * tc)
     };
     raft_set_callbacks(r, &funcs, queue);
 
-    l = log_new();
-    log_set_callbacks(l, &log_funcs, r);
+    l = raft_log_new();
+    raft_log_set_callbacks(l, &log_funcs, r);
 
     __LOG_APPEND_ENTRIES_SEQ_ID(l, 3, 1, 0, NULL);
-    CuAssertIntEquals(tc, 3, log_count(l));
-    CuAssertIntEquals(tc, 3, log_get_current_idx(l));
+    CuAssertIntEquals(tc, 3, raft_log_count(l));
+    CuAssertIntEquals(tc, 3, raft_log_get_current_idx(l));
 
-    CuAssertIntEquals(tc, -1, log_delete(l, 3));
-    CuAssertIntEquals(tc, 3, log_count(l));
-    CuAssertIntEquals(tc, 3, log_count(l));
-    CuAssertIntEquals(tc, 3, ((raft_entry_t*)log_peektail(l))->id);
+    CuAssertIntEquals(tc, -1, raft_log_delete(l, 3));
+    CuAssertIntEquals(tc, 3, raft_log_count(l));
+    CuAssertIntEquals(tc, 3, raft_log_count(l));
+    CuAssertIntEquals(tc, 3, ((raft_entry_t*) raft_log_peektail(l))->id);
  }
 
 void TestLog_delete_fails_for_idx_zero(CuTest * tc)
@@ -239,14 +239,14 @@ void TestLog_delete_fails_for_idx_zero(CuTest * tc)
         .log_pop = __log_pop
     };
     raft_set_callbacks(r, &funcs, queue);
-    log_set_callbacks(raft_get_log(r), &log_funcs, r);
+    raft_log_set_callbacks(raft_get_log(r), &log_funcs, r);
 
     void *l;
 
-    l = log_alloc(1);
-    log_set_callbacks(l, &log_funcs, r);
+    l = raft_log_alloc(1);
+    raft_log_set_callbacks(l, &log_funcs, r);
     __LOG_APPEND_ENTRIES_SEQ_ID(l, 4, 1, 0, NULL);
-    CuAssertIntEquals(tc, log_delete(l, 0), -1);
+    CuAssertIntEquals(tc, raft_log_delete(l, 0), -1);
 }
 
 void TestLog_poll(CuTest * tc)
@@ -262,65 +262,65 @@ void TestLog_poll(CuTest * tc)
 
     void *l;
 
-    l = log_new();
-    log_set_callbacks(l, &log_funcs, r);
+    l = raft_log_new();
+    raft_log_set_callbacks(l, &log_funcs, r);
 
     __LOG_APPEND_ENTRY(l, 1, 0, NULL);
-    CuAssertIntEquals(tc, 1, log_get_current_idx(l));
+    CuAssertIntEquals(tc, 1, raft_log_get_current_idx(l));
 
     __LOG_APPEND_ENTRY(l, 2, 0, NULL);
-    CuAssertIntEquals(tc, 2, log_get_current_idx(l));
+    CuAssertIntEquals(tc, 2, raft_log_get_current_idx(l));
 
     __LOG_APPEND_ENTRY(l, 3, 0, NULL);
-    CuAssertIntEquals(tc, 3, log_count(l));
-    CuAssertIntEquals(tc, 3, log_get_current_idx(l));
+    CuAssertIntEquals(tc, 3, raft_log_count(l));
+    CuAssertIntEquals(tc, 3, raft_log_get_current_idx(l));
 
     raft_entry_t *ety;
 
     /* remove 1st */
     ety = NULL;
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertTrue(tc, NULL != ety);
-    CuAssertIntEquals(tc, 2, log_count(l));
+    CuAssertIntEquals(tc, 2, raft_log_count(l));
     CuAssertIntEquals(tc, ety->id, 1);
-    CuAssertIntEquals(tc, 1, log_get_base(l));
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 1));
-    CuAssertTrue(tc, NULL != log_get_at_idx(l, 2));
-    CuAssertTrue(tc, NULL != log_get_at_idx(l, 3));
-    CuAssertIntEquals(tc, 3, log_get_current_idx(l));
+    CuAssertIntEquals(tc, 1, raft_log_get_base(l));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 1));
+    CuAssertTrue(tc, NULL != raft_log_get_at_idx(l, 2));
+    CuAssertTrue(tc, NULL != raft_log_get_at_idx(l, 3));
+    CuAssertIntEquals(tc, 3, raft_log_get_current_idx(l));
 
     /* remove 2nd */
     ety = NULL;
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertTrue(tc, NULL != ety);
-    CuAssertIntEquals(tc, 1, log_count(l));
+    CuAssertIntEquals(tc, 1, raft_log_count(l));
     CuAssertIntEquals(tc, ety->id, 2);
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 1));
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 2));
-    CuAssertTrue(tc, NULL != log_get_at_idx(l, 3));
-    CuAssertIntEquals(tc, 3, log_get_current_idx(l));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 1));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 2));
+    CuAssertTrue(tc, NULL != raft_log_get_at_idx(l, 3));
+    CuAssertIntEquals(tc, 3, raft_log_get_current_idx(l));
 
     /* remove 3rd */
     ety = NULL;
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertTrue(tc, NULL != ety);
-    CuAssertIntEquals(tc, 0, log_count(l));
+    CuAssertIntEquals(tc, 0, raft_log_count(l));
     CuAssertIntEquals(tc, ety->id, 3);
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 1));
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 2));
-    CuAssertTrue(tc, NULL == log_get_at_idx(l, 3));
-    CuAssertIntEquals(tc, 3, log_get_current_idx(l));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 1));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 2));
+    CuAssertTrue(tc, NULL == raft_log_get_at_idx(l, 3));
+    CuAssertIntEquals(tc, 3, raft_log_get_current_idx(l));
 }
 
 void TestLog_peektail(CuTest * tc)
 {
     void *l;
 
-    l = log_new();
+    l = raft_log_new();
 
     __LOG_APPEND_ENTRIES_SEQ_ID(l, 3, 1, 0, NULL);
-    CuAssertIntEquals(tc, 3, log_count(l));
-    CuAssertIntEquals(tc, 3, log_peektail(l)->id);
+    CuAssertIntEquals(tc, 3, raft_log_count(l));
+    CuAssertIntEquals(tc, 3, raft_log_peektail(l)->id);
 }
 
 #if 0
@@ -342,26 +342,26 @@ void TestLog_load_from_snapshot(CuTest * tc)
 {
     void *l;
 
-    l = log_new();
-    CuAssertIntEquals(tc, 0, log_get_current_idx(l));
-    CuAssertIntEquals(tc, 0, log_load_from_snapshot(l, 10, 5));
-    CuAssertIntEquals(tc, 10, log_get_current_idx(l));
-    CuAssertIntEquals(tc, 0, log_count(l));
+    l = raft_log_new();
+    CuAssertIntEquals(tc, 0, raft_log_get_current_idx(l));
+    CuAssertIntEquals(tc, 0, raft_log_load_from_snapshot(l, 10, 5));
+    CuAssertIntEquals(tc, 10, raft_log_get_current_idx(l));
+    CuAssertIntEquals(tc, 0, raft_log_count(l));
 }
 
 void TestLog_load_from_snapshot_clears_log(CuTest * tc)
 {
     void *l;
 
-    l = log_new();
+    l = raft_log_new();
 
     __LOG_APPEND_ENTRIES_SEQ_ID(l, 2, 1, 0, NULL);
-    CuAssertIntEquals(tc, 2, log_count(l));
-    CuAssertIntEquals(tc, 2, log_get_current_idx(l));
+    CuAssertIntEquals(tc, 2, raft_log_count(l));
+    CuAssertIntEquals(tc, 2, raft_log_get_current_idx(l));
 
-    CuAssertIntEquals(tc, 0, log_load_from_snapshot(l, 10, 5));
-    CuAssertIntEquals(tc, 0, log_count(l));
-    CuAssertIntEquals(tc, 10, log_get_current_idx(l));
+    CuAssertIntEquals(tc, 0, raft_log_load_from_snapshot(l, 10, 5));
+    CuAssertIntEquals(tc, 0, raft_log_count(l));
+    CuAssertIntEquals(tc, 10, raft_log_get_current_idx(l));
 }
 
 void TestLog_front_pushes_across_boundary(CuTest * tc)
@@ -370,16 +370,16 @@ void TestLog_front_pushes_across_boundary(CuTest * tc)
 
     void *l;
 
-    l = log_alloc(1);
-    log_set_callbacks(l, &log_funcs, r);
+    l = raft_log_alloc(1);
+    raft_log_set_callbacks(l, &log_funcs, r);
 
     raft_entry_t* ety;
 
     __LOG_APPEND_ENTRY(l, 1, 0, NULL);
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertIntEquals(tc, ety->id, 1);
     __LOG_APPEND_ENTRY(l, 2, 0, NULL);
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertIntEquals(tc, ety->id, 2);
 }
 
@@ -387,7 +387,7 @@ void TestLog_front_and_back_pushed_across_boundary_with_enlargement_required(CuT
 {
     void *l;
 
-    l = log_alloc(1);
+    l = raft_log_alloc(1);
 
     raft_entry_t* ety;
 
@@ -395,14 +395,14 @@ void TestLog_front_and_back_pushed_across_boundary_with_enlargement_required(CuT
     __LOG_APPEND_ENTRY(l, 1, 0, NULL);
 
     /* poll */
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertIntEquals(tc, ety->id, 1);
 
     /* append */
     __LOG_APPEND_ENTRY(l, 2, 0, NULL);
 
     /* poll */
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertIntEquals(tc, ety->id, 2);
 
     /* append append */
@@ -410,7 +410,7 @@ void TestLog_front_and_back_pushed_across_boundary_with_enlargement_required(CuT
     __LOG_APPEND_ENTRY(l, 4, 0, NULL);
 
     /* poll */
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertIntEquals(tc, ety->id, 3);
 }
 
@@ -418,26 +418,26 @@ void TestLog_delete_after_polling(CuTest * tc)
 {
     void *l;
 
-    l = log_alloc(1);
+    l = raft_log_alloc(1);
 
     raft_entry_t* ety;
 
     /* append */
     __LOG_APPEND_ENTRY(l, 1, 0, NULL);
-    CuAssertIntEquals(tc, 1, log_count(l));
+    CuAssertIntEquals(tc, 1, raft_log_count(l));
 
     /* poll */
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertIntEquals(tc, ety->id, 1);
-    CuAssertIntEquals(tc, 0, log_count(l));
+    CuAssertIntEquals(tc, 0, raft_log_count(l));
 
     /* append */
     __LOG_APPEND_ENTRY(l, 2, 0, NULL);
-    CuAssertIntEquals(tc, 1, log_count(l));
+    CuAssertIntEquals(tc, 1, raft_log_count(l));
 
     /* poll */
-    CuAssertIntEquals(tc, log_delete(l, 1), 0);
-    CuAssertIntEquals(tc, 0, log_count(l));
+    CuAssertIntEquals(tc, raft_log_delete(l, 1), 0);
+    CuAssertIntEquals(tc, 0, raft_log_count(l));
 }
 
 void TestLog_delete_after_polling_from_double_append(CuTest * tc)
@@ -453,27 +453,27 @@ void TestLog_delete_after_polling_from_double_append(CuTest * tc)
 
     void *l;
 
-    l = log_alloc(1);
-    log_set_callbacks(l, &log_funcs, r);
+    l = raft_log_alloc(1);
+    raft_log_set_callbacks(l, &log_funcs, r);
 
     raft_entry_t* ety;
 
     /* append append */
     __LOG_APPEND_ENTRIES_SEQ_ID(l, 2, 1, 0, NULL);
-    CuAssertIntEquals(tc, 2, log_count(l));
+    CuAssertIntEquals(tc, 2, raft_log_count(l));
 
     /* poll */
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertIntEquals(tc, ety->id, 1);
-    CuAssertIntEquals(tc, 1, log_count(l));
+    CuAssertIntEquals(tc, 1, raft_log_count(l));
 
     /* append */
     __LOG_APPEND_ENTRY(l, 3, 0, NULL);
-    CuAssertIntEquals(tc, 2, log_count(l));
+    CuAssertIntEquals(tc, 2, raft_log_count(l));
 
     /* poll */
-    CuAssertIntEquals(tc, log_delete(l, 1), 0);
-    CuAssertIntEquals(tc, 0, log_count(l));
+    CuAssertIntEquals(tc, raft_log_delete(l, 1), 0);
+    CuAssertIntEquals(tc, 0, raft_log_count(l));
 }
 
 void TestLog_get_from_idx_with_base_off_by_one(CuTest * tc)
@@ -489,28 +489,28 @@ void TestLog_get_from_idx_with_base_off_by_one(CuTest * tc)
 
     void *l;
 
-    l = log_alloc(1);
-    log_set_callbacks(l, &log_funcs, r);
+    l = raft_log_alloc(1);
+    raft_log_set_callbacks(l, &log_funcs, r);
 
     raft_entry_t* ety;
 
     /* append append */
     __LOG_APPEND_ENTRIES_SEQ_ID(l, 2, 1, 0, NULL);
-    CuAssertIntEquals(tc, 2, log_count(l));
+    CuAssertIntEquals(tc, 2, raft_log_count(l));
 
     /* poll */
-    CuAssertIntEquals(tc, log_poll(l, (void*)&ety), 0);
+    CuAssertIntEquals(tc, raft_log_poll(l, (void *) &ety), 0);
     CuAssertIntEquals(tc, ety->id, 1);
-    CuAssertIntEquals(tc, 1, log_count(l));
+    CuAssertIntEquals(tc, 1, raft_log_count(l));
 
     /* get off-by-one index */
     long n_etys;
-    CuAssertPtrEquals(tc, log_get_from_idx(l, 1, &n_etys), NULL);
+    CuAssertPtrEquals(tc, raft_log_get_from_idx(l, 1, &n_etys), NULL);
     CuAssertIntEquals(tc, n_etys, 0);
 
     /* now get the correct index */
     raft_entry_t** e;
-    e = log_get_from_idx(l, 2, &n_etys);
+    e = raft_log_get_from_idx(l, 2, &n_etys);
     CuAssertPtrNotNull(tc, e);
     CuAssertIntEquals(tc, n_etys, 1);
     CuAssertIntEquals(tc, e[0]->id, 2);

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -4452,7 +4452,6 @@ void Test_reset_transfer_leader(CuTest *tc)
     };
     raft_server_t *r = raft_new();
     raft_set_state(r, RAFT_STATE_LEADER);
-    raft_server_private_t * me = (raft_server_private_t *) r;
 
     raft_set_callbacks(r, &funcs, &state);
 
@@ -4465,12 +4464,12 @@ void Test_reset_transfer_leader(CuTest *tc)
 
     ret = raft_transfer_leader(r, 2, 0);
     CuAssertIntEquals(tc, 0, ret);
-    me->leader_id = 2;
+    r->leader_id = 2;
     raft_reset_transfer_leader(r, 0);
     CuAssertIntEquals(tc, RAFT_LEADER_TRANSFER_EXPECTED_LEADER, state);
 
     /* tests timeout in general, so don't need a separate test for it */
-    me->leader_id = 1;
+    r->leader_id = 1;
     ret = raft_transfer_leader(r, 2, 1);
     CuAssertIntEquals(tc, 0, ret);
     raft_periodic(r, 2);

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -1585,7 +1585,7 @@ void TestRaft_follower_recv_appendentries_partial_failures(
     void *r = raft_new();
     __raft_error_t error = {};
     raft_set_callbacks(r, &funcs, &error);
-    log_set_callbacks(raft_get_log(r), &log_funcs, r);
+    raft_log_set_callbacks(raft_get_log(r), &log_funcs, r);
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -3761,7 +3761,7 @@ void TestRaft_leader_recv_entry_add_nonvoting_node_remove_and_revert(CuTest *tc)
 
     int has_sufficient_logs_flag = 0;
     raft_set_callbacks(r, &funcs, &has_sufficient_logs_flag);
-    log_set_callbacks(raft_get_log(r), &log_funcs, r);
+    raft_log_set_callbacks(raft_get_log(r), &log_funcs, r);
 
     /* I'm the leader */
     raft_set_state(r, RAFT_STATE_LEADER);
@@ -3807,7 +3807,7 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_after_v
 
     int has_sufficient_logs_flag = 0;
     raft_set_callbacks(r, &funcs, &has_sufficient_logs_flag);
-    log_set_callbacks(raft_get_log(r), &log_funcs, r);
+    raft_log_set_callbacks(raft_get_log(r), &log_funcs, r);
 
     /* I'm the leader */
     raft_set_state(r, RAFT_STATE_LEADER);

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -319,7 +319,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
         .send_appendentries = __raft_send_appendentries,
     };
 
-    void *r = raft_new();
+    raft_server_t *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
     msg_entry_response_t cr;
@@ -366,8 +366,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
     CuAssertIntEquals(tc, 2, raft_get_log_count(r));
     CuAssertIntEquals(tc, 4, raft_get_commit_idx(r));
-    raft_server_private_t *r_p = (raft_server_private_t *) r;
-    CuAssertIntEquals(tc, 3, r_p->log_impl->first_idx(r_p->log));
+    CuAssertIntEquals(tc, 3, r->log_impl->first_idx(r->log));
     CuAssertIntEquals(tc, 2, raft_get_num_snapshottable_logs(r));
     CuAssertIntEquals(tc, 0, raft_begin_snapshot(r, 0));
     CuAssertIntEquals(tc, 0, raft_end_snapshot(r));

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -847,7 +847,7 @@ class RaftServer(object):
         log_cbs.log_pop = self.raft_logentry_pop
 
         lib.raft_set_callbacks(self.raft, cbs, self.udata)
-        lib.log_set_callbacks(lib.raft_get_log(self.raft), log_cbs, self.raft)
+        lib.raft_log_set_callbacks(lib.raft_get_log(self.raft), log_cbs, self.raft)
         lib.raft_set_election_timeout(self.raft, 500)
         lib.raft_set_auto_flush(self.raft, network.auto_flush)
 


### PR DESCRIPTION
Deleted private_t typedefs.

Reviewing commit by commit might be easier.

Previously:

```c
typedef void* raft_server_t;
typedef void* raft_node_t;
```
These typedefs require unnecessary pointer casts all around the codebase. These are not just unnecessary, also harmful. Using `void*` means ignoring type-safety and accepting any kind of pointer. (I passed different kind of pointers before by mistake).  

After this PR, we forward declare these:

```c
typedef struct raft_server raft_server_t;
typedef struct raft_node raft_node_t;
```

Concrete implementation is still hidden. We avoid pointer casts and provide type-safety.
As part of this PR, also changed `log_` family symbols to start with `raft_` to avoid symbol collusion.