### PR TITLE
Refactor msgid usage

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -102,16 +102,9 @@ struct raft_server {
      * we're still the leader.
      */
     raft_msg_id_t msg_id;
-    /*
-     * the maximum msg_id we've seen from our current leader.  reset on term change
-     */
-    raft_msg_id_t max_seen_msg_id;
+
     raft_read_request_t *read_queue_head;
     raft_read_request_t *read_queue_tail;
-
-    /* Do we need quorum ? e.g Leader received a read request, need quorum round
-     * before processing it */
-    int need_quorum_round;
 
     raft_node_id_t node_transferring_leader_to; // the node we are targeting for leadership
     long transfer_leader_time; // how long we should wait for leadership transfer to take, before aborting
@@ -174,9 +167,11 @@ int raft_is_single_node_voting_cluster(raft_server_t *me);
 
 int raft_votes_is_majority(int nnodes, int nvotes);
 
-void raft_node_set_last_ack(raft_node_t* me, raft_msg_id_t msgid, raft_term_t term);
+void raft_node_set_match_msgid(raft_node_t *me, raft_msg_id_t msgid);
+raft_msg_id_t raft_node_get_match_msgid(raft_node_t *me);
 
-raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me);
+void raft_node_set_next_msgid(raft_node_t *me, raft_msg_id_t msgid);
+raft_msg_id_t raft_node_get_next_msgid(raft_node_t *me);
 
 /* Heap functions */
 extern void *(*raft_malloc)(size_t size);

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -29,17 +29,16 @@ struct raft_node
     raft_index_t next_idx;
     raft_index_t match_idx;
 
+    raft_msg_id_t next_msgid;
+    raft_msg_id_t match_msgid;
+    raft_msg_id_t max_seen_msgid;
+
     int flags;
 
     raft_node_id_t id;
 
     /* Next snapshot offset to send to this node */
     raft_size_t snapshot_offset;
-
-    /* last AE heartbeat response received */
-    raft_term_t last_acked_term;
-    raft_msg_id_t last_acked_msgid;
-    raft_msg_id_t max_seen_msgid;
 };
 
 raft_node_t* raft_node_new(void* udata, raft_node_id_t id)
@@ -82,6 +81,38 @@ raft_index_t raft_node_get_match_idx(raft_node_t* me)
 void raft_node_set_match_idx(raft_node_t* me, raft_index_t idx)
 {
     me->match_idx = idx;
+}
+
+void raft_node_set_match_msgid(raft_node_t *me, raft_msg_id_t msgid)
+{
+    me->match_msgid = msgid;
+}
+
+raft_msg_id_t raft_node_get_match_msgid(raft_node_t *me)
+{
+    return me->match_msgid;
+}
+
+void raft_node_set_next_msgid(raft_node_t *me, raft_msg_id_t msgid)
+{
+    me->next_msgid = msgid;
+}
+
+raft_msg_id_t raft_node_get_next_msgid(raft_node_t *me)
+{
+    return me->next_msgid;
+}
+
+void raft_node_update_max_seen_msg_id(raft_node_t *me, raft_msg_id_t msg_id)
+{
+    if (me->max_seen_msgid < msg_id) {
+        me->max_seen_msgid = msg_id;
+    }
+}
+
+raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me)
+{
+    return me->max_seen_msgid;
 }
 
 void* raft_node_get_udata(raft_node_t* me)
@@ -178,29 +209,6 @@ void raft_node_set_addition_committed(raft_node_t* me, int committed)
 int raft_node_is_addition_committed(raft_node_t* me)
 {
     return (me->flags & RAFT_NODE_ADDITION_COMMITTED) != 0;
-}
-
-void raft_node_set_last_ack(raft_node_t* me, raft_msg_id_t msgid, raft_term_t term)
-{
-    me->last_acked_msgid = msgid;
-    me->last_acked_term = term;
-}
-
-raft_msg_id_t raft_node_get_last_acked_msgid(raft_node_t* me)
-{
-    return me->last_acked_msgid;
-}
-
-void raft_node_update_max_seen_msg_id(raft_node_t *me, raft_msg_id_t msg_id)
-{
-    if (msg_id > me->max_seen_msgid) {
-        me->max_seen_msgid = msg_id;
-    }
-}
-
-raft_msg_id_t raft_node_get_max_seen_msg_id(raft_node_t *me)
-{
-    return me->max_seen_msgid;
 }
 
 raft_size_t raft_node_get_snapshot_offset(raft_node_t *me)

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -90,7 +90,6 @@ int raft_set_current_term(raft_server_t* me, const raft_term_t term)
         }
         me->current_term = term;
         me->voted_for = voted_for;
-        me->max_seen_msg_id = 0;
     }
     return 0;
 }

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -4056,7 +4056,7 @@ void TestRaft_quorum_msg_id_correctness(CuTest * tc)
     CuAssertIntEquals(tc, 0, val);
 
     // Second node acknowledges reaq req
-    raft_node_set_last_ack(raft_get_node(r, 2), 1, 1);
+    raft_node_set_match_msgid(raft_get_node(r, 2), 1);
     raft_periodic(r, 200);
 
     CuAssertIntEquals(tc, 1, val);
@@ -4072,12 +4072,12 @@ void TestRaft_quorum_msg_id_correctness(CuTest * tc)
     CuAssertIntEquals(tc, 0, val);
 
     // Second node acknowledges read req,
-    raft_node_set_last_ack(raft_get_node(r, 2), 2, 1);
+    raft_node_set_match_msgid(raft_get_node(r, 2), 2);
     raft_periodic(r, 200);
     CuAssertIntEquals(tc, 0, val);
 
     // Third node acknowledges read req
-    raft_node_set_last_ack(raft_get_node(r, 3), 2, 1);
+    raft_node_set_match_msgid(raft_get_node(r, 3), 2);
     raft_periodic(r, 200);
     CuAssertIntEquals(tc, 1, val);
 }
@@ -4186,7 +4186,7 @@ void TestRaft_leader_steps_down_if_there_is_no_quorum(CuTest * tc)
     raft_periodic(r, quorum_timeout + 1);
     CuAssertTrue(tc, !raft_is_leader(r));
 
-    raft_node_set_last_ack(raft_get_node(r, 2), 1, 1);
+    raft_node_set_match_msgid(raft_get_node(r, 2), 1);
     raft_become_leader(r);
     raft_periodic(r, 200);
     CuAssertTrue(tc, raft_is_leader(r));
@@ -4196,7 +4196,7 @@ void TestRaft_leader_steps_down_if_there_is_no_quorum(CuTest * tc)
     CuAssertTrue(tc, raft_is_leader(r));
 
     // If there is an ack from the follower, leader won't step down.
-    raft_node_set_last_ack(raft_get_node(r, 2), 2, 1);
+    raft_node_set_match_msgid(raft_get_node(r, 2), 2);
     raft_periodic(r, quorum_timeout);
     CuAssertTrue(tc, raft_is_leader(r));
 

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -850,6 +850,7 @@ class RaftServer(object):
         lib.raft_log_set_callbacks(lib.raft_get_log(self.raft), log_cbs, self.raft)
         lib.raft_set_election_timeout(self.raft, 500)
         lib.raft_set_auto_flush(self.raft, network.auto_flush)
+        lib.raft_set_log_enabled(self.raft, 1)
 
         self.fsm_dict = {}
         self.fsm_log = []


### PR DESCRIPTION
- Added `match_msgid` and `next_msgid` to the node structure to track if node needs to be sent an appenreq for read-only requests. This is similar to `next_index` and `match_index` of the log entries. 
Previously, we were controlling this with a single `need_quorum` flag. In case of backpressure, we skip sending appendreq and setting `need_quorum` flag to false unconditionally. That flag should be per node. Even we skip an appendreq due to backpressure, in the next iteration, we should try to send appendreq to that node. Otherwise, we wait until periodic() call and this extends latency of the operation.

- Made `raft_flush()` decide whether to send an appendreq depending on the node's `next_msgid` and the last `msgid` in the read queue.  

- `raft_flush()` should still process read queue if the node is not leader. This way if a leader becomes follower, it processes read requests and generates failure responses faster. Otherwise, we wait until periodic call. 


