### PR TITLE
Add raft_ prefix for exported symbols

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -119,7 +119,21 @@ typedef struct raft_entry
 /** Message sent from client to server.
  * The client sends this message to a server with the intention of having it
  * applied to the FSM. */
-typedef raft_entry_t msg_entry_t;
+typedef raft_entry_t raft_entry_req_t;
+
+/** Entry message response.
+ * Indicates to client if entry was committed or not. */
+typedef struct
+{
+    /** the entry's unique ID */
+    raft_entry_id_t id;
+
+    /** the entry's term */
+    raft_term_t term;
+
+    /** the entry's index */
+    raft_index_t idx;
+} raft_entry_resp_t;
 
 typedef struct
 {
@@ -135,20 +149,6 @@ typedef struct
     /** 1 if this is the last chunk */
     int last_chunk;
 } raft_snapshot_chunk_t;
-
-/** Entry message response.
- * Indicates to client if entry was committed or not. */
-typedef struct
-{
-    /** the entry's unique ID */
-    raft_entry_id_t id;
-
-    /** the entry's term */
-    raft_term_t term;
-
-    /** the entry's index */
-    raft_index_t idx;
-} msg_entry_response_t;
 
 /** Vote request message.
  * Sent to nodes when a server wants to become leader.
@@ -169,7 +169,7 @@ typedef struct
 
     /** term of candidate's last log entry */
     raft_term_t last_log_term;
-} msg_requestvote_t;
+} raft_requestvote_req_t;
 
 /** Vote request response message.
  * Indicates if node has accepted the server's vote request. */
@@ -186,7 +186,7 @@ typedef struct
 
     /** true means candidate received vote */
     int vote_granted;
-} msg_requestvote_response_t;
+} raft_requestvote_resp_t;
 
 typedef struct
 {
@@ -209,7 +209,7 @@ typedef struct
     /** snapshot chunk **/
     raft_snapshot_chunk_t chunk;
 
-} msg_snapshot_t;
+} raft_snapshot_req_t;
 
 typedef struct
 {
@@ -227,7 +227,7 @@ typedef struct
 
      /** 1 if this is a response to the final chunk */
     int last_chunk;
-} msg_snapshot_response_t;
+} raft_snapshot_resp_t;
 
 /** Appendentries message.
  * This message is used to tell nodes if it's safe to apply entries to the FSM.
@@ -261,8 +261,8 @@ typedef struct
     int n_entries;
 
     /** array of pointers to entries within this message */
-    msg_entry_t** entries;
-} msg_appendentries_t;
+    raft_entry_req_t** entries;
+} raft_appendentries_req_t;
 
 /** Appendentries response message.
  * Can be sent without any entries as a keep alive message.
@@ -285,7 +285,7 @@ typedef struct
     /** If success, this is the highest log IDX we've received and appended to
      * our log; otherwise, this is the our currentIndex */
     raft_index_t current_idx;
-} msg_appendentries_response_t;
+} raft_appendentries_resp_t;
 
 typedef struct raft_server raft_server_t;
 typedef struct raft_node raft_node_t;
@@ -297,12 +297,12 @@ typedef struct raft_node raft_node_t;
  * @param[in] msg The request vote message to be sent
  * @return 0 on success */
 typedef int (
-*func_send_requestvote_f
+*raft_send_requestvote_f
 )   (
     raft_server_t* raft,
     void *user_data,
     raft_node_t* node,
-    msg_requestvote_t* msg
+    raft_requestvote_req_t* msg
     );
 
 /** Callback for sending append entries messages.
@@ -312,12 +312,12 @@ typedef int (
  * @param[in] msg The appendentries message to be sent
  * @return 0 on success */
 typedef int (
-*func_send_appendentries_f
+*raft_send_appendentries_f
 )   (
     raft_server_t* raft,
     void *user_data,
     raft_node_t* node,
-    msg_appendentries_t* msg
+    raft_appendentries_req_t* msg
     );
 
 /** Callback for sending snapshot messages.
@@ -327,12 +327,12 @@ typedef int (
  * @param[in] msg  Snapshot msg
  **/
 typedef int (
-*func_send_snapshot_f
+*raft_send_snapshot_f
 )   (
     raft_server_t* raft,
     void *user_data,
     raft_node_t* node,
-    msg_snapshot_t* msg
+    raft_snapshot_req_t* msg
     );
 
 /** Callback for loading the received snapshot. User should load snapshot using
@@ -366,7 +366,7 @@ typedef int (
  * @param[in] snapshot_term  Received snapshot term
  * @return 0 on success */
 typedef int (
-*func_load_snapshot_f
+*raft_load_snapshot_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -386,7 +386,7 @@ typedef int (
  * @param[in] chunk Snapshot chunk
  * @return 0 on success */
 typedef int (
-*func_get_snapshot_chunk_f
+*raft_get_snapshot_chunk_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -403,7 +403,7 @@ typedef int (
  * @param[in] chunk Snapshot chunk
  * @return 0 on success */
 typedef int (
-*func_store_snapshot_chunk_f
+*raft_store_snapshot_chunk_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -420,7 +420,7 @@ typedef int (
  * @param[in] user_data User data that is passed from Raft server
  * @return 0 on success */
 typedef int (
-*func_clear_snapshot_f
+*raft_clear_snapshot_f
 )   (
     raft_server_t* raft,
     void *user_data
@@ -433,7 +433,7 @@ typedef int (
  * @param[in] node The node
  * @return 0 does not want to be notified again; otherwise -1 */
 typedef int (
-*func_node_has_sufficient_logs_f
+*raft_node_has_sufficient_logs_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -450,7 +450,7 @@ typedef int (
  * @param[in] user_data User data that is passed from Raft server
  * @param[in] buf The buffer that was logged */
 typedef void (
-*func_log_f
+*raft_log_f
 )    (
     raft_server_t* raft,
     raft_node_id_t node_id,
@@ -466,7 +466,7 @@ typedef void (
  * @param[in] vote The node we voted for
  * @return 0 on success */
 typedef int (
-*func_persist_vote_f
+*raft_persist_vote_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -482,7 +482,7 @@ typedef int (
  * @param[in] vote The node value dictating we haven't voted for anybody
  * @return 0 on success */
 typedef int (
-*func_persist_term_f
+*raft_persist_term_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -509,7 +509,7 @@ typedef int (
  * @return 0 on success
  * */
 typedef int (
-*func_logentry_event_f
+*raft_logentry_event_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -528,7 +528,7 @@ typedef int (
 *  @return the node ID of the node
  * */
 typedef raft_node_id_t (
-*func_get_node_id_f
+*raft_get_node_id_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -548,7 +548,7 @@ typedef raft_node_id_t (
  * @param[in] entry The entry that was the trigger for the event. Could be NULL.
  * @param[in] type The type of membership change */
 typedef void (
-*func_membership_event_f
+*raft_membership_event_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -565,7 +565,7 @@ typedef void (
  * @param[in] user_data User data that is passed from Raft server
  * @param[in] state The new cluster state. */
 typedef void (
-*func_state_event_f
+*raft_state_event_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -581,7 +581,7 @@ typedef void (
  * @param[in] result the leadership transfer result
  */
 typedef void (
-*func_transfer_event_f
+*raft_transfer_event_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -594,19 +594,19 @@ typedef void (
  * @return 0 on success
  */
 typedef int (
-*func_send_timeoutnow_f
+*raft_send_timeoutnow_f
 )   (
     raft_server_t* raft,
     raft_node_t* node
     );
 
-/** Callback to skip sending msg_appendentries to the node
+/** Callback to skip sending raft_appendentries_req to the node
  *
  * Implementing this callback is optional
  *
  * If there are already pending appendentries messages in flight, you may want
  * to skip sending more until you receive response for the previous ones.
- * If the node is a slow consumer and you create msg_appendentries for each
+ * If the node is a slow consumer and you create raft_appendentries_req for each
  * batch of new entries received, it may cause out of memory.
  *
  * Also, this way you can do batching. If new entries are received with an
@@ -620,12 +620,12 @@ typedef int (
  * performance.
  *
  * @param[in] raft The Raft server making this callback
- * @param[in] node The node that we are about to send msg_appendentries to
+ * @param[in] node The node that we are about to send raft_appendentries_req to
  * @return 0 to send message
  *         Any other value to skip sending message
  */
 typedef int (
-*func_backpressure_f
+*raft_backpressure_f
 )   (
     raft_server_t* raft,
     void *user_data,
@@ -635,68 +635,68 @@ typedef int (
 typedef struct
 {
     /** Callback for sending request vote messages */
-    func_send_requestvote_f send_requestvote;
+    raft_send_requestvote_f send_requestvote;
 
     /** Callback for sending appendentries messages */
-    func_send_appendentries_f send_appendentries;
+    raft_send_appendentries_f send_appendentries;
 
     /** Callback for sending snapshot messages */
-    func_send_snapshot_f send_snapshot;
+    raft_send_snapshot_f send_snapshot;
 
     /** Callback for loading snapshot. This will be called when we complete
      * receiving snapshot from the leader */
-    func_load_snapshot_f load_snapshot;
+    raft_load_snapshot_f load_snapshot;
 
     /** Callback to get a chunk of the snapshot file */
-    func_get_snapshot_chunk_f get_snapshot_chunk;
+    raft_get_snapshot_chunk_f get_snapshot_chunk;
 
     /** Callback to store a chunk of the snapshot */
-    func_store_snapshot_chunk_f store_snapshot_chunk;
+    raft_store_snapshot_chunk_f store_snapshot_chunk;
 
     /** Callback to dismiss temporary file which is used for incoming
      * snapshot chunks */
-    func_clear_snapshot_f clear_snapshot;
+    raft_clear_snapshot_f clear_snapshot;
 
     /** Callback for finite state machine application
      * Return 0 on success.
      * Return RAFT_ERR_SHUTDOWN if you want the server to shutdown. */
-    func_logentry_event_f applylog;
+    raft_logentry_event_f applylog;
 
     /** Callback for persisting vote data
      * For safety reasons this callback MUST flush the change to disk. */
-    func_persist_vote_f persist_vote;
+    raft_persist_vote_f persist_vote;
 
     /** Callback for persisting term (and nil vote) data
      * For safety reasons this callback MUST flush the term and vote changes to
      * disk atomically. */
-    func_persist_term_f persist_term;
+    raft_persist_term_f persist_term;
 
     /** Callback for determining which node this configuration log entry
      * affects. This call only applies to configuration change log entries.
      * @return the node ID of the node */
-    func_get_node_id_f get_node_id;
+    raft_get_node_id_f get_node_id;
 
     /** Callback for detecting when a non-voting node has sufficient logs. */
-    func_node_has_sufficient_logs_f node_has_sufficient_logs;
+    raft_node_has_sufficient_logs_f node_has_sufficient_logs;
 
     /** Callback for being notified of membership changes (optional). */
-    func_membership_event_f notify_membership_event;
+    raft_membership_event_f notify_membership_event;
 
     /** Callback for being notified of state changes (optional). */
-    func_state_event_f notify_state_event;
+    raft_state_event_f notify_state_event;
 
     /** Callbakc for notified of transfer leadership events (optional) */
-    func_transfer_event_f notify_transfer_event;
+    raft_transfer_event_f notify_transfer_event;
 
     /** Callback for catching debugging log messages
      * This callback is optional */
-    func_log_f log;
+    raft_log_f log;
 
     /** Callback for sending TimeoutNow RPC messages to nodes */
-    func_send_timeoutnow_f send_timeoutnow;
+    raft_send_timeoutnow_f send_timeoutnow;
 
-    /** Callback for deciding whether to send msg_appendentries to a node. */
-    func_backpressure_f backpressure;
+    /** Callback for deciding whether to send raft_appendentries_req to a node. */
+    raft_backpressure_f backpressure;
 } raft_cbs_t;
 
 /** A generic notification callback used to allow Raft to notify caller
@@ -710,7 +710,7 @@ typedef struct
  * log operation until it returns.
  */
 typedef void (
-*func_entry_notify_f
+*raft_entry_notify_f
 )   (
     void* arg,
     raft_entry_t *entry,
@@ -725,7 +725,7 @@ typedef void (
  *   arriving to a non leader.
  */
 typedef void (
-*func_read_request_callback_f
+*raft_read_request_callback_f
 )   (
     void *arg,
     int can_read
@@ -827,7 +827,7 @@ typedef struct raft_log_impl
      *  0 on success;
      *  -1 on error.
      */
-    int (*pop) (void *log, raft_index_t from_idx, func_entry_notify_f cb, void *cb_arg);
+    int (*pop) (void *log, raft_index_t from_idx, raft_entry_notify_f cb, void *cb_arg);
 
     /** Get a single entry from the log.
      *
@@ -977,26 +977,26 @@ int raft_periodic(raft_server_t* me, int msec_elapsed);
  * included entries.
  *
  * @param[in] node The node who sent us this message
- * @param[in] ae The appendentries message
- * @param[out] r The resulting response
+ * @param[in] req The appendentries message
+ * @param[out] resp The resulting response
  * @return
  *  0 on success
  *  */
 int raft_recv_appendentries(raft_server_t* me,
                             raft_node_t* node,
-                            msg_appendentries_t* ae,
-                            msg_appendentries_response_t *r);
+                            raft_appendentries_req_t* req,
+                            raft_appendentries_resp_t* resp);
 
 /** Receive a response from an appendentries message we sent.
  * @param[in] node The node who sent us this message
- * @param[in] r The appendentries response message
+ * @param[in] resp The appendentries response message
  * @return
  *  0 on success;
  *  -1 on error;
  *  RAFT_ERR_NOT_LEADER server is not the leader */
 int raft_recv_appendentries_response(raft_server_t* me,
                                      raft_node_t* node,
-                                     msg_appendentries_response_t* r);
+                                     raft_appendentries_resp_t* resp);
 
 /** Receive a snapshot message.
  * @param[in] node The node who sent us this message
@@ -1006,39 +1006,39 @@ int raft_recv_appendentries_response(raft_server_t* me,
  *  0 on success  */
 int raft_recv_snapshot(raft_server_t* me,
                        raft_node_t* node,
-                       msg_snapshot_t *req,
-                       msg_snapshot_response_t *resp);
+                       raft_snapshot_req_t *req,
+                       raft_snapshot_resp_t *resp);
 
 /** Receive a response from a snapshot message we sent.
  * @param[in] node The node who sent us this message
- * @param[in] r The snapshot response message
+ * @param[in] resp The snapshot response message
  * @return
  *  0 on success;
  *  -1 on error;
  *  RAFT_ERR_NOT_LEADER server is not the leader */
 int raft_recv_snapshot_response(raft_server_t* me,
                                 raft_node_t* node,
-                                msg_snapshot_response_t *r);
+                                raft_snapshot_resp_t *resp);
 
 /** Receive a requestvote message.
  * @param[in] node The node who sent us this message
- * @param[in] vr The requestvote message
- * @param[out] r The resulting response
+ * @param[in] req The requestvote message
+ * @param[out] resp The resulting response
  * @return 0 on success */
 int raft_recv_requestvote(raft_server_t* me,
                           raft_node_t* node,
-                          msg_requestvote_t* vr,
-                          msg_requestvote_response_t *r);
+                          raft_requestvote_req_t* req,
+                          raft_requestvote_resp_t* resp);
 
 /** Receive a response from a requestvote message we sent.
  * @param[in] node The node this response was sent by
- * @param[in] r The requestvote response message
+ * @param[in] req The requestvote response message
  * @return
  *  0 on success;
  *  RAFT_ERR_SHUTDOWN server MUST shutdown; */
 int raft_recv_requestvote_response(raft_server_t* me,
                                    raft_node_t* node,
-                                   msg_requestvote_response_t* r);
+                                   raft_requestvote_resp_t* req);
 
 /** Receive an entry message from the client.
  *
@@ -1055,8 +1055,8 @@ int raft_recv_requestvote_response(raft_server_t* me,
  * </ul>
  *
  * @param[in] node The node who sent us this message
- * @param[in] ety The entry message
- * @param[out] r The resulting response
+ * @param[in] req The entry message
+ * @param[out] resp The resulting response
  * @return
  *  0 on success;
  *  RAFT_ERR_NOT_LEADER server is not the leader;
@@ -1065,8 +1065,8 @@ int raft_recv_requestvote_response(raft_server_t* me,
  *  RAFT_ERR_NOMEM memory allocation failure
  */
 int raft_recv_entry(raft_server_t* me,
-                    msg_entry_t* ety,
-                    msg_entry_response_t *r);
+                    raft_entry_req_t *req,
+                    raft_entry_resp_t *resp);
 
 /**
  * @return server's node ID; -1 if it doesn't know what it is */
@@ -1239,7 +1239,7 @@ int raft_pop_entry(raft_server_t* me);
 /** Confirm if a msg_entry_response has been committed.
  * @param[in] r The response we want to check */
 int raft_msg_entry_response_committed(raft_server_t* me,
-                                      const msg_entry_response_t* r);
+                                      const raft_entry_resp_t* r);
 
 /** Get node's ID.
  * @return ID of node */
@@ -1445,7 +1445,7 @@ typedef struct {
      * Return 0 on success.
      * Return RAFT_ERR_SHUTDOWN if you want the server to shutdown. */
 
-    func_logentry_event_f log_offer;
+    raft_logentry_event_f log_offer;
 
     /** Callback for removing the oldest entry from the log
      * For safety reasons this callback MUST flush the change to disk.
@@ -1454,7 +1454,7 @@ typedef struct {
      *   desired after the callback returns, raft_entry_hold() should be
      *   used.
      */
-    func_logentry_event_f log_poll;
+    raft_logentry_event_f log_poll;
 
     /** Callback for removing the youngest entry from the log
      * For safety reasons this callback MUST flush the change to disk.
@@ -1463,13 +1463,13 @@ typedef struct {
      *   desired after the callback returns, raft_entry_hold() should be
      *   used.
      */
-    func_logentry_event_f log_pop;
+    raft_logentry_event_f log_pop;
 
     /** Callback called for every existing log entry when clearing the log.
      * If memory was malloc'd in log_offer and the entry doesn't get a chance
      * to go through log_poll or log_pop, this is the last chance to free it.
      */
-    func_logentry_event_f log_clear;
+    raft_logentry_event_f log_clear;
 } raft_log_cbs_t;
 
 /** Allocate a new Raft Log entry.
@@ -1511,7 +1511,7 @@ extern const raft_log_impl_t raft_log_internal_impl;
 
 void raft_handle_append_cfg_change(raft_server_t* me, raft_entry_t* ety, raft_index_t idx);
 
-int raft_queue_read_request(raft_server_t* me, func_read_request_callback_f cb, void *cb_arg);
+int raft_queue_read_request(raft_server_t* me, raft_read_request_callback_f cb, void *cb_arg);
 
 /** Attempt to process read queue.
  */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -19,7 +19,7 @@ typedef struct raft_read_request {
     raft_term_t read_term;
 
     raft_msg_id_t msg_id;
-    func_read_request_callback_f cb;
+    raft_read_request_callback_f cb;
     void *cb_arg;
 
     struct raft_read_request *next;

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -208,7 +208,7 @@ raft_index_t raft_log_count(raft_log_t *me)
     return me->count;
 }
 
-static int log_delete(raft_log_t* me, raft_index_t idx, func_entry_notify_f cb, void *cb_arg)
+static int log_delete(raft_log_t* me, raft_index_t idx, raft_entry_notify_f cb, void *cb_arg)
 {
     if (0 == idx)
         return -1;
@@ -376,7 +376,7 @@ static int log_get_batch(void *log, raft_index_t idx, int entries_n, raft_entry_
     return (int) n;
 }
 
-static int log_pop(void *log, raft_index_t from_idx, func_entry_notify_f cb, void *cb_arg)
+static int log_pop(void *log, raft_index_t from_idx, raft_entry_notify_f cb, void *cb_arg)
 {
     return log_delete(log, from_idx, cb, cb_arg);
 }

--- a/tests/mock_send_functions.c
+++ b/tests/mock_send_functions.c
@@ -74,33 +74,35 @@ static int __append_msg(
 }
 
 int sender_requestvote(raft_server_t* raft,
-                       void* udata, raft_node_t* node, msg_requestvote_t* msg)
+                       void* udata, raft_node_t* node,
+                       raft_requestvote_req_t* msg)
 {
-    return __append_msg(udata, msg, RAFT_MSG_REQUESTVOTE, sizeof(*msg), node,
+    return __append_msg(udata, msg, RAFT_REQUESTVOTE_REQ, sizeof(*msg), node,
                         raft);
 }
 
 int sender_requestvote_response(raft_server_t* raft,
                                 void* udata, raft_node_t* node,
-                                msg_requestvote_response_t* msg)
+                                raft_requestvote_resp_t* msg)
 {
-    return __append_msg(udata, msg, RAFT_MSG_REQUESTVOTE_RESPONSE, sizeof(*msg),
+    return __append_msg(udata, msg, RAFT_REQUESTVOTE_RESP, sizeof(*msg),
                         node, raft);
 }
 
 int sender_appendentries(raft_server_t* raft,
-                         void* udata, raft_node_t* node, msg_appendentries_t* msg)
+                         void* udata, raft_node_t* node,
+                         raft_appendentries_req_t* msg)
 {
-    msg_entry_t** entries = calloc(1, sizeof(msg_entry_t *) * msg->n_entries);
+    raft_entry_req_t** entries = calloc(1, sizeof(raft_entry_req_t *) * msg->n_entries);
     int i;
     for (i = 0; i < msg->n_entries; i++) {
         entries[i] = msg->entries[i];
         raft_entry_hold(entries[i]);
     }
 
-    msg_entry_t** old_entries = msg->entries;
+    raft_entry_req_t** old_entries = msg->entries;
     msg->entries = entries;
-    int ret = __append_msg(udata, msg, RAFT_MSG_APPENDENTRIES, sizeof(*msg), node,
+    int ret = __append_msg(udata, msg, RAFT_APPENDENTRIES_REQ, sizeof(*msg), node,
                         raft);
     msg->entries = old_entries;
     return ret;
@@ -108,17 +110,17 @@ int sender_appendentries(raft_server_t* raft,
 
 int sender_appendentries_response(raft_server_t* raft,
                                   void* udata, raft_node_t* node,
-                                  msg_appendentries_response_t* msg)
+                                  raft_appendentries_resp_t* msg)
 {
-    return __append_msg(udata, msg, RAFT_MSG_APPENDENTRIES_RESPONSE,
+    return __append_msg(udata, msg, RAFT_APPENDENTRIES_RESP,
                         sizeof(*msg), node, raft);
 }
 
 int sender_entries_response(raft_server_t* raft,
-                            void* udata, raft_node_t* node, msg_entry_response_t* msg)
+                            void* udata, raft_node_t* node,
+                            raft_entry_resp_t* msg)
 {
-    return __append_msg(udata, msg, RAFT_MSG_ENTRY_RESPONSE, sizeof(*msg), node,
-                        raft);
+    return __append_msg(udata, msg, RAFT_ENTRY_RESP, sizeof(*msg), node, raft);
 }
 
 void* sender_new(void* address)
@@ -160,38 +162,38 @@ void sender_poll_msgs(void* s)
     {
         switch (m->type)
         {
-        case RAFT_MSG_APPENDENTRIES:
+        case RAFT_APPENDENTRIES_REQ:
         {
-            msg_appendentries_response_t response;
+            raft_appendentries_resp_t response;
             raft_recv_appendentries(me->raft, m->sender, m->data, &response);
-            __append_msg(me, &response, RAFT_MSG_APPENDENTRIES_RESPONSE,
+            __append_msg(me, &response, RAFT_APPENDENTRIES_RESP,
                          sizeof(response), m->sender, me->raft);
         }
         break;
-        case RAFT_MSG_APPENDENTRIES_RESPONSE:
+        case RAFT_APPENDENTRIES_RESP:
             raft_recv_appendentries_response(me->raft, m->sender, m->data);
             break;
-        case RAFT_MSG_REQUESTVOTE:
+        case RAFT_REQUESTVOTE_REQ:
         {
-            msg_requestvote_response_t response;
+            raft_requestvote_resp_t response;
             raft_recv_requestvote(me->raft, m->sender, m->data, &response);
-            __append_msg(me, &response, RAFT_MSG_REQUESTVOTE_RESPONSE,
+            __append_msg(me, &response, RAFT_REQUESTVOTE_RESP,
                          sizeof(response), m->sender, me->raft);
         }
         break;
-        case RAFT_MSG_REQUESTVOTE_RESPONSE:
+        case RAFT_REQUESTVOTE_RESP:
             raft_recv_requestvote_response(me->raft, m->sender, m->data);
             break;
-        case RAFT_MSG_ENTRY:
+        case RAFT_ENTRY_REQ:
         {
-            msg_entry_response_t response;
+            raft_entry_resp_t response;
             raft_recv_entry(me->raft, m->data, &response);
-            __append_msg(me, &response, RAFT_MSG_ENTRY_RESPONSE,
+            __append_msg(me, &response, RAFT_ENTRY_RESP,
                          sizeof(response), m->sender, me->raft);
         }
         break;
 
-        case RAFT_MSG_ENTRY_RESPONSE:
+        case RAFT_ENTRY_RESP:
 #if 0
             raft_recv_entry_response(me->raft, m->sender, m->data);
 #endif

--- a/tests/mock_send_functions.h
+++ b/tests/mock_send_functions.h
@@ -3,12 +3,12 @@
 
 typedef enum
 {
-    RAFT_MSG_REQUESTVOTE,
-    RAFT_MSG_REQUESTVOTE_RESPONSE,
-    RAFT_MSG_APPENDENTRIES,
-    RAFT_MSG_APPENDENTRIES_RESPONSE,
-    RAFT_MSG_ENTRY,
-    RAFT_MSG_ENTRY_RESPONSE,
+    RAFT_REQUESTVOTE_REQ,
+    RAFT_REQUESTVOTE_RESP,
+    RAFT_APPENDENTRIES_REQ,
+    RAFT_APPENDENTRIES_RESP,
+    RAFT_ENTRY_REQ,
+    RAFT_ENTRY_RESP,
 } raft_message_type_e;
 
 void senders_new();
@@ -24,21 +24,21 @@ int sender_msgs_available(void* s);
 void sender_set_raft(void* s, void* r);
 
 int sender_requestvote(raft_server_t* raft,
-        void* udata, raft_node_t* node, msg_requestvote_t* msg);
+        void* udata, raft_node_t* node, raft_requestvote_req_t* msg);
 
 int sender_requestvote_response(raft_server_t* raft,
-        void* udata, raft_node_t* node, msg_requestvote_response_t* msg);
+        void* udata, raft_node_t* node, raft_requestvote_resp_t* msg);
 
 int sender_appendentries(raft_server_t* raft,
-        void* udata, raft_node_t* node, msg_appendentries_t* msg);
+        void* udata, raft_node_t* node, raft_appendentries_req_t* msg);
 
 int sender_appendentries_response(raft_server_t* raft,
-        void* udata, raft_node_t* node, msg_appendentries_response_t* msg);
+        void* udata, raft_node_t* node, raft_appendentries_resp_t* msg);
 
 int sender_entries(raft_server_t* raft,
-        void* udata, raft_node_t* node, msg_entry_t* msg);
+        void* udata, raft_node_t* node, raft_entry_req_t* msg);
 
 int sender_entries_response(raft_server_t* raft,
-        void* udata, raft_node_t* node, msg_entry_response_t* msg);
+        void* udata, raft_node_t* node, raft_entry_resp_t* msg);
 
 #endif /* MOCK_SEND_FUNCTIONS_H */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -57,7 +57,7 @@ int __raft_applylog_shutdown(
 int __raft_send_requestvote(raft_server_t* raft,
                             void* udata,
                             raft_node_t* node,
-                            msg_requestvote_t* msg)
+                            raft_requestvote_req_t * msg)
 {
     return 0;
 }
@@ -65,7 +65,7 @@ int __raft_send_requestvote(raft_server_t* raft,
 static int __raft_send_appendentries(raft_server_t* raft,
                               void* udata,
                               raft_node_t* node,
-                              msg_appendentries_t* msg)
+                                     raft_appendentries_req_t * msg)
 {
     return 0;
 }
@@ -566,10 +566,10 @@ void TestRaft_server_recv_entry_auto_commits_if_we_are_the_only_node(CuTest * tc
     CuAssertTrue(tc, 0 == raft_get_commit_idx(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
     raft_recv_entry(r, ety, &cr);
     CuAssertTrue(tc, 1 == raft_get_log_count(r));
     CuAssertTrue(tc, 1 == raft_get_commit_idx(r));
@@ -585,11 +585,11 @@ void TestRaft_server_recv_entry_fails_if_there_is_already_a_voting_change(CuTest
     CuAssertTrue(tc, 0 == raft_get_commit_idx(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
     ety->type = RAFT_LOGTYPE_ADD_NODE;
 
     /* receive entry */
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
     CuAssertTrue(tc, 0 == raft_recv_entry(r, ety, &cr));
     CuAssertTrue(tc, 1 == raft_get_log_count(r));
 
@@ -659,8 +659,8 @@ void TestRaft_server_recv_requestvote_response_dont_increase_votes_for_me_when_n
     raft_set_current_term(r, 1);
     CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
 
-    msg_requestvote_response_t rvr;
-    memset(&rvr, 0, sizeof(msg_requestvote_response_t));
+    raft_requestvote_resp_t rvr;
+    memset(&rvr, 0, sizeof(raft_requestvote_resp_t));
     rvr.term = 1;
     rvr.vote_granted = 0;
     int e = raft_recv_requestvote_response(r, raft_get_node(r, 2), &rvr);
@@ -685,8 +685,8 @@ void TestRaft_server_recv_requestvote_response_dont_increase_votes_for_me_when_t
     raft_set_current_term(r, 3);
     CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
 
-    msg_requestvote_response_t rvr;
-    memset(&rvr, 0, sizeof(msg_requestvote_response_t));
+    raft_requestvote_resp_t rvr;
+    memset(&rvr, 0, sizeof(raft_requestvote_resp_t));
     rvr.term = 2;
     rvr.vote_granted = 1;
     raft_recv_requestvote_response(r, raft_get_node(r, 2), &rvr);
@@ -717,8 +717,8 @@ void TestRaft_server_recv_requestvote_response_increase_votes_for_me(
     CuAssertIntEquals(tc, 2, raft_get_current_term(r));
     CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
 
-    msg_requestvote_response_t rvr;
-    memset(&rvr, 0, sizeof(msg_requestvote_response_t));
+    raft_requestvote_resp_t rvr;
+    memset(&rvr, 0, sizeof(raft_requestvote_resp_t));
     rvr.request_term = 2;
     rvr.term = 2;
     rvr.vote_granted = 1;
@@ -747,8 +747,8 @@ void TestRaft_server_recv_requestvote_response_must_be_candidate_to_receive(
 
     raft_become_leader(r);
 
-    msg_requestvote_response_t rvr;
-    memset(&rvr, 0, sizeof(msg_requestvote_response_t));
+    raft_requestvote_resp_t rvr;
+    memset(&rvr, 0, sizeof(raft_requestvote_resp_t));
     rvr.term = 1;
     rvr.vote_granted = 1;
     raft_recv_requestvote_response(r, raft_get_node(r, 2), &rvr);
@@ -768,15 +768,15 @@ void TestRaft_server_recv_requestvote_reply_false_if_term_less_than_current_term
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_requestvote_response_t rvr;
+    raft_requestvote_resp_t rvr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 2);
 
     /* term is less than current term */
-    msg_requestvote_t rv;
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    raft_requestvote_req_t rv;
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     rv.term = 1;
     int e = raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
     CuAssertIntEquals(tc, 0, e);
@@ -796,7 +796,7 @@ void TestRaft_leader_recv_requestvote_does_not_step_down(
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_requestvote_response_t rvr;
+    raft_requestvote_resp_t rvr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -806,8 +806,8 @@ void TestRaft_leader_recv_requestvote_does_not_step_down(
     CuAssertIntEquals(tc, 1, raft_is_leader(r));
 
     /* term is less than current term */
-    msg_requestvote_t rv;
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    raft_requestvote_req_t rv;
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     rv.term = 1;
     raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
     CuAssertIntEquals(tc, 1, raft_get_leader_id(r));
@@ -818,8 +818,8 @@ void TestRaft_server_recv_requestvote_reply_true_if_term_greater_than_or_equal_t
     CuTest * tc
     )
 {
-    msg_requestvote_t rv;
-    msg_requestvote_response_t rvr;
+    raft_requestvote_req_t rv;
+    raft_requestvote_resp_t rvr;
 
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
@@ -834,7 +834,7 @@ void TestRaft_server_recv_requestvote_reply_true_if_term_greater_than_or_equal_t
     raft_set_current_term(r, 1);
 
     /* term is less than current term */
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     rv.term = 2;
     rv.last_log_idx = 1;
     raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
@@ -846,8 +846,8 @@ void TestRaft_server_recv_requestvote_reset_timeout(
     CuTest * tc
     )
 {
-    msg_requestvote_t rv;
-    msg_requestvote_response_t rvr;
+    raft_requestvote_req_t rv;
+    raft_requestvote_resp_t rvr;
 
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
@@ -864,7 +864,7 @@ void TestRaft_server_recv_requestvote_reset_timeout(
     raft_set_election_timeout(r, 1000);
     raft_periodic(r, 900);
 
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     rv.term = 2;
     rv.last_log_idx = 1;
     raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
@@ -892,12 +892,12 @@ void TestRaft_server_recv_requestvote_candidate_step_down_if_term_is_higher_than
     CuAssertIntEquals(tc, 1, raft_get_voted_for(r));
 
     /* current term is less than term */
-    msg_requestvote_t rv;
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    raft_requestvote_req_t rv;
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     rv.candidate_id = 2;
     rv.term = 2;
     rv.last_log_idx = 1;
-    msg_requestvote_response_t rvr;
+    raft_requestvote_resp_t rvr;
     raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
     CuAssertIntEquals(tc, 1, raft_is_follower(r));
     CuAssertIntEquals(tc, 2, raft_get_current_term(r));
@@ -924,12 +924,12 @@ void TestRaft_server_recv_requestvote_depends_on_candidate_id(
     CuAssertIntEquals(tc, 1, raft_get_voted_for(r));
 
     /* current term is less than term */
-    msg_requestvote_t rv;
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    raft_requestvote_req_t rv;
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     rv.candidate_id = 3;
     rv.term = 2;
     rv.last_log_idx = 1;
-    msg_requestvote_response_t rvr;
+    raft_requestvote_resp_t rvr;
     raft_recv_requestvote(r, NULL, &rv, &rvr);
     CuAssertIntEquals(tc, 1, raft_is_follower(r));
     CuAssertIntEquals(tc, 2, raft_get_current_term(r));
@@ -958,12 +958,12 @@ void TestRaft_server_recv_requestvote_dont_grant_vote_if_we_didnt_vote_for_this_
     /* vote for self */
     raft_vote_for_nodeid(r, 1);
 
-    msg_requestvote_t rv = {};
+    raft_requestvote_req_t rv = {};
     rv.term = 1;
     rv.candidate_id = 2;
     rv.last_log_idx = 1;
     rv.last_log_term = 1;
-    msg_requestvote_response_t rvr;
+    raft_requestvote_resp_t rvr;
     raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
     CuAssertTrue(tc, 0 == rvr.vote_granted);
 
@@ -990,21 +990,21 @@ void TestRaft_server_recv_requestvote_ignore_if_master_is_fresh(CuTest * tc)
     raft_set_current_term(r, 1);
     raft_set_election_timeout(r, 1000);
 
-    msg_appendentries_t ae = { 0 };
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae = { 0 };
+    raft_appendentries_resp_t aer;
     ae.term = 1;
 
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
     CuAssertTrue(tc, 1 == aer.success);
 
-    msg_requestvote_t rv = {
+    raft_requestvote_req_t rv = {
         .prevote = 1,
         .term = 2,
         .candidate_id = 3,
         .last_log_idx = 0,
         .last_log_term = 1
     };
-    msg_requestvote_response_t rvr;
+    raft_requestvote_resp_t rvr;
     raft_recv_requestvote(r, raft_get_node(r, 3), &rv, &rvr);
     CuAssertTrue(tc, 1 != rvr.vote_granted);
 
@@ -1025,7 +1025,7 @@ void TestRaft_server_recv_prevote_ignore_if_candidate(CuTest * tc)
 
     raft_become_candidate(r);
 
-    msg_requestvote_response_t rv = {
+    raft_requestvote_resp_t rv = {
         .term = 1,
         .request_term = 1,
         .prevote = 1,
@@ -1048,7 +1048,7 @@ void TestRaft_server_recv_reqvote_ignore_if_not_candidate(CuTest * tc)
 
     raft_become_precandidate(r);
 
-    msg_requestvote_response_t rv = {
+    raft_requestvote_resp_t rv = {
         .term = 1,
         .request_term = 1
     };
@@ -1070,7 +1070,7 @@ void TestRaft_server_recv_reqvote_always_update_term(CuTest * tc)
 
     raft_become_precandidate(r);
 
-    msg_requestvote_response_t rv = {
+    raft_requestvote_resp_t rv = {
         .term = 3,
         .request_term = 3,
     };
@@ -1124,13 +1124,13 @@ void TestRaft_follower_recv_appendentries_reply_false_if_term_less_than_currentt
     CuAssertTrue(tc, -1 == raft_get_leader_id(r));
 
     /* term is low */
-    msg_appendentries_t ae;
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    raft_appendentries_req_t ae;
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
 
     /*  higher current term */
     raft_set_current_term(r, 5);
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
 
     CuAssertTrue(tc, 0 == aer.success);
@@ -1149,9 +1149,9 @@ void TestRaft_follower_recv_appendentries_does_not_need_node(CuTest * tc)
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
-    msg_appendentries_t ae = {};
+    raft_appendentries_req_t ae = {};
     ae.term = 1;
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     raft_recv_appendentries(r, NULL, &ae, &aer);
     CuAssertTrue(tc, 1 == aer.success);
 }
@@ -1167,8 +1167,8 @@ void TestRaft_follower_recv_appendentries_updates_currentterm_if_term_gt_current
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1178,7 +1178,7 @@ void TestRaft_follower_recv_appendentries_updates_currentterm_if_term_gt_current
     CuAssertTrue(tc, -1 == raft_get_leader_id(r));
 
     /*  newer term for appendentry */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     /* no prev log idx */
     ae.prev_log_idx = 0;
     ae.term = 2;
@@ -1204,8 +1204,8 @@ void TestRaft_follower_recv_appendentries_does_not_log_if_no_entries_are_specifi
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1216,7 +1216,7 @@ void TestRaft_follower_recv_appendentries_does_not_log_if_no_entries_are_specifi
     CuAssertTrue(tc, 0 == raft_get_log_count(r));
 
     /* receive an appendentry with commit */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_term = 1;
     ae.prev_log_idx = 4;
@@ -1236,8 +1236,8 @@ void TestRaft_follower_recv_appendentries_increases_log(CuTest * tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
     char *str = "aaa";
 
     raft_add_node(r, NULL, 1, 1);
@@ -1249,7 +1249,7 @@ void TestRaft_follower_recv_appendentries_increases_log(CuTest * tc)
     CuAssertTrue(tc, 0 == raft_get_log_count(r));
 
     /* receive an appendentry with commit */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 3;
     ae.prev_log_term = 1;
     /* first appendentries msg */
@@ -1280,8 +1280,8 @@ void TestRaft_follower_recv_appendentries_reply_false_if_doesnt_have_log_at_prev
 
     char *str = "aaa";
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1291,7 +1291,7 @@ void TestRaft_follower_recv_appendentries_reply_false_if_doesnt_have_log_at_prev
     // TODO at log manually?
 
     /* log idx that server doesn't have */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 2;
     ae.prev_log_idx = 1;
     /* prev_log_term is less than current term (ie. 2) */
@@ -1347,8 +1347,8 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1359,7 +1359,7 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
     raft_entry_t *ety_appended = __create_mock_entries_for_conflict_tests(tc, r, strs);
 
     /* pass a appendentry that is newer  */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 2;
     /* entries from 2 onwards will be overwritten by this appendentries message */
     ae.prev_log_idx = 1;
@@ -1391,8 +1391,8 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1404,7 +1404,7 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
 
     /* pass a appendentry that is newer  */
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 2;
     /* ALL append entries will be overwritten by this appendentries message */
     ae.prev_log_idx = 0;
@@ -1432,8 +1432,8 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -1446,7 +1446,7 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
     __create_mock_entries_for_conflict_tests(tc, r, strs);
     CuAssertIntEquals(tc, 3, raft_get_log_count(r));
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 2;
     ae.prev_log_idx = 1;
     ae.prev_log_term = 1;
@@ -1477,10 +1477,10 @@ void TestRaft_follower_recv_appendentries_add_new_entries_not_already_in_log(
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 0;
     ae.prev_log_term = 1;
@@ -1507,10 +1507,10 @@ void TestRaft_follower_recv_appendentries_does_not_add_dupe_entries_already_in_l
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 0;
     ae.prev_log_term = 1;
@@ -1596,11 +1596,11 @@ void TestRaft_follower_recv_appendentries_partial_failures(
     __RAFT_APPEND_ENTRY(r, 2, 1, "1bb");
     CuAssertIntEquals(tc, 2, raft_get_current_idx(r));
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     /* To be received: entry 2 and 3 of term 2. */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 2;
     ae.prev_log_idx = 1;
     ae.prev_log_term = 1;
@@ -1658,21 +1658,21 @@ void TestRaft_follower_recv_appendentries_set_commitidx_to_prevLogIdx(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 0;
     ae.prev_log_term = 1;
     /* include entries */
-    msg_entry_t e[4] = {
+    raft_entry_req_t e[4] = {
         { .id = 1, .term = 1 },
         { .id = 2, .term = 1 },
         { .id = 3, .term = 1 },
         { .id = 4, .term = 1 }
     };
-    msg_entry_t *e_array[4] = {
+    raft_entry_req_t *e_array[4] = {
         &e[0], &e[1], &e[2], &e[3]
     };
     ae.entries = e_array;
@@ -1680,7 +1680,7 @@ void TestRaft_follower_recv_appendentries_set_commitidx_to_prevLogIdx(
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
 
     /* receive an appendentry with commit */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_term = 1;
     ae.prev_log_idx = 4;
@@ -1706,21 +1706,21 @@ void TestRaft_follower_recv_appendentries_set_commitidx_to_LeaderCommit(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 0;
     ae.prev_log_term = 1;
     /* include entries */
-    msg_entry_t e[4] = {
+    raft_entry_req_t e[4] = {
         { .id = 1, .term = 1 },
         { .id = 2, .term = 1 },
         { .id = 3, .term = 1 },
         { .id = 4, .term = 1 }
     };
-    msg_entry_t *e_array[4] = {
+    raft_entry_req_t *e_array[4] = {
         &e[0], &e[1], &e[2], &e[3]
     };
 
@@ -1729,7 +1729,7 @@ void TestRaft_follower_recv_appendentries_set_commitidx_to_LeaderCommit(
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
 
     /* receive an appendentry with commit */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_term = 1;
     ae.prev_log_idx = 3;
@@ -1759,14 +1759,14 @@ void TestRaft_follower_recv_appendentries_failure_includes_current_idx(
     __RAFT_APPEND_ENTRY(r, 1, 1, "aaa");
 
     /* receive an appendentry with commit */
-    msg_appendentries_t ae;
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    raft_appendentries_req_t ae;
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     /* lower term means failure */
     ae.term = 0;
     ae.prev_log_term = 0;
     ae.prev_log_idx = 0;
     ae.leader_commit = 0;
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
 
     CuAssertTrue(tc, 0 == aer.success);
@@ -1809,8 +1809,8 @@ void TestRaft_follower_becomes_precandidate_when_election_timeout_occurs(
 void TestRaft_follower_dont_grant_vote_if_candidate_has_a_less_complete_log(
     CuTest * tc)
 {
-    msg_requestvote_t rv;
-    msg_requestvote_response_t rvr;
+    raft_requestvote_req_t rv;
+    raft_requestvote_resp_t rvr;
 
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
@@ -1825,7 +1825,7 @@ void TestRaft_follower_dont_grant_vote_if_candidate_has_a_less_complete_log(
 
     /*  request vote */
     /*  vote indicates candidate's log is not complete compared to follower */
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     rv.term = 1;
     rv.candidate_id = 1;
     rv.last_log_idx = 1;
@@ -1843,7 +1843,7 @@ void TestRaft_follower_dont_grant_vote_if_candidate_has_a_less_complete_log(
 
     /* approve vote, because last_log_term is higher */
     raft_set_current_term(r, 2);
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     rv.term = 2;
     rv.candidate_id = 1;
     rv.last_log_idx = 1;
@@ -1865,10 +1865,10 @@ void TestRaft_follower_recv_appendentries_heartbeat_does_not_overwrite_logs(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 0;
     ae.prev_log_term = 1;
@@ -1880,7 +1880,7 @@ void TestRaft_follower_recv_appendentries_heartbeat_does_not_overwrite_logs(
     /* The server sends a follow up AE
      * NOTE: the server has received a response from the last AE so
      * prev_log_idx has been incremented */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 1;
     ae.prev_log_term = 1;
@@ -1892,7 +1892,7 @@ void TestRaft_follower_recv_appendentries_heartbeat_does_not_overwrite_logs(
     /* receive a heartbeat
      * NOTE: the leader hasn't received the response to the last AE so it can
      * only assume prev_Log_idx is still 1 */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_term = 1;
     ae.prev_log_idx = 1;
@@ -1916,10 +1916,10 @@ void TestRaft_follower_recv_appendentries_does_not_deleted_commited_entries(
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 0;
     ae.prev_log_term = 1;
@@ -1929,7 +1929,7 @@ void TestRaft_follower_recv_appendentries_does_not_deleted_commited_entries(
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
 
     /* Follow up AE. Node responded with success */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 1;
     ae.prev_log_term = 1;
@@ -1940,7 +1940,7 @@ void TestRaft_follower_recv_appendentries_does_not_deleted_commited_entries(
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
 
     /* The server sends a follow up AE */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 1;
     ae.prev_log_term = 1;
@@ -1957,7 +1957,7 @@ void TestRaft_follower_recv_appendentries_does_not_deleted_commited_entries(
     /* The server sends a follow up AE.
      * This appendentry forces the node to check if it's going to delete
      * commited logs */
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.prev_log_idx = 3;
     ae.prev_log_term = 1;
@@ -2061,10 +2061,10 @@ void TestRaft_follower_recv_appendentries_resets_election_timeout(
 
     raft_periodic(r, 900);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     raft_recv_appendentries(r, raft_get_node(r, 1), &ae, &aer);
     CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
@@ -2079,7 +2079,7 @@ void TestRaft_follower_becoming_candidate_requests_votes_from_other_servers(
         .persist_vote = __raft_persist_vote,
         .send_requestvote = sender_requestvote,
     };
-    msg_requestvote_t* rv;
+    raft_requestvote_req_t * rv;
 
     void *sender = sender_new(NULL);
     void *r = raft_new();
@@ -2131,7 +2131,7 @@ void TestRaft_candidate_election_timeout_and_no_leader_results_in_new_election(
     CuAssertTrue(tc, 1 == raft_get_current_term(r));
     CuAssertIntEquals(tc, RAFT_STATE_PRECANDIDATE, raft_get_state(r));
 
-    msg_requestvote_response_t vr0 = {
+    raft_requestvote_resp_t vr0 = {
         .prevote = 1,
         .request_term = raft_get_current_term(r) + 1,
         .term = 0,
@@ -2141,7 +2141,7 @@ void TestRaft_candidate_election_timeout_and_no_leader_results_in_new_election(
     raft_recv_requestvote_response(r, raft_get_node(r, 2), &vr0);
     CuAssertIntEquals(tc, RAFT_STATE_CANDIDATE, raft_get_state(r));
 
-    msg_requestvote_response_t vr1 = {
+    raft_requestvote_resp_t vr1 = {
         .request_term = 2,
         .term = 2,
         .vote_granted = 1
@@ -2155,7 +2155,7 @@ void TestRaft_candidate_election_timeout_and_no_leader_results_in_new_election(
 /* Candidate 5.2 */
 void TestRaft_candidate_receives_majority_of_votes_becomes_leader(CuTest * tc)
 {
-    msg_requestvote_response_t vr;
+    raft_requestvote_resp_t vr;
 
     raft_cbs_t funcs = {
         .persist_term = __raft_persist_term,
@@ -2180,7 +2180,7 @@ void TestRaft_candidate_receives_majority_of_votes_becomes_leader(CuTest * tc)
     CuAssertTrue(tc, 1 == raft_get_nvotes_for_me(r));
 
     /* a vote for us */
-    memset(&vr, 0, sizeof(msg_requestvote_response_t));
+    memset(&vr, 0, sizeof(raft_requestvote_resp_t));
     vr.request_term = 1;
     vr.term = 1;
     vr.vote_granted = 1;
@@ -2207,15 +2207,15 @@ void TestRaft_candidate_will_not_respond_to_voterequest_if_it_has_already_voted(
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_requestvote_t rv;
-    msg_requestvote_response_t rvr;
+    raft_requestvote_req_t rv;
+    raft_requestvote_resp_t rvr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
 
     raft_vote(r, raft_get_node(r, 1));
 
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
 
     /* we've vote already, so won't respond with a vote granted... */
@@ -2246,7 +2246,7 @@ void TestRaft_candidate_requestvote_includes_logidx(CuTest * tc)
     __RAFT_APPEND_ENTRY(r, 102, 3, "aaa");
     raft_send_requestvote(r, raft_get_node(r, 2));
 
-    msg_requestvote_t* rv = sender_poll_msg_data(sender);
+    raft_requestvote_req_t * rv = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != rv);
     CuAssertIntEquals(tc, 3, rv->last_log_idx);
     CuAssertIntEquals(tc, 5, rv->term);
@@ -2275,8 +2275,8 @@ void TestRaft_candidate_recv_requestvote_response_becomes_follower_if_current_te
     CuAssertTrue(tc, -1 == raft_get_leader_id(r));
     CuAssertTrue(tc, 1 == raft_get_current_term(r));
 
-    msg_requestvote_response_t rvr;
-    memset(&rvr, 0, sizeof(msg_requestvote_response_t));
+    raft_requestvote_resp_t rvr;
+    memset(&rvr, 0, sizeof(raft_requestvote_resp_t));
     rvr.request_term = 2;
     rvr.term = 2;
     rvr.vote_granted = 0;
@@ -2308,10 +2308,10 @@ void TestRaft_candidate_recv_appendentries_frm_leader_results_in_follower(
     CuAssertTrue(tc, 0 == raft_get_current_term(r));
 
     /* receive recent appendentries */
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 1;
     ae.leader_id = 2;
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
@@ -2335,8 +2335,8 @@ void TestRaft_candidate_recv_appendentries_from_same_term_results_in_step_down(
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2346,7 +2346,7 @@ void TestRaft_candidate_recv_appendentries_from_same_term_results_in_step_down(
     CuAssertTrue(tc, 0 == raft_is_follower(r));
     CuAssertIntEquals(tc, 1, raft_get_voted_for(r));
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 2;
     ae.prev_log_idx = 1;
     ae.prev_log_term = 1;
@@ -2443,7 +2443,7 @@ void TestRaft_leader_when_it_becomes_a_leader_sends_empty_appendentries(
     raft_become_leader(r);
 
     /* receive appendentries messages for both nodes */
-    msg_appendentries_t* ae = sender_poll_msg_data(sender);
+    raft_appendentries_req_t * ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
     ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
@@ -2460,7 +2460,7 @@ void TestRaft_leader_responds_to_entry_msg_when_entry_is_committed(CuTest * tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2470,7 +2470,7 @@ void TestRaft_leader_responds_to_entry_msg_when_entry_is_committed(CuTest * tc)
     CuAssertTrue(tc, 0 == raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
     raft_recv_entry(r, ety, &cr);
@@ -2482,7 +2482,7 @@ void TestRaft_leader_responds_to_entry_msg_when_entry_is_committed(CuTest * tc)
 
 void TestRaft_non_leader_recv_entry_msg_fails(CuTest * tc)
 {
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     void *r = raft_new();
     raft_add_node(r, NULL, 1, 1);
@@ -2521,7 +2521,7 @@ void TestRaft_leader_sends_appendentries_with_NextIdx_when_PrevIdx_gt_NextIdx(
 
     /* receive appendentries messages */
     raft_send_appendentries(r, p);
-    msg_appendentries_t* ae = sender_poll_msg_data(sender);
+    raft_appendentries_req_t * ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
 }
 
@@ -2554,7 +2554,7 @@ void TestRaft_leader_sends_appendentries_with_leader_commit(
 
     /* receive appendentries messages */
     raft_send_appendentries(r, raft_get_node(r, 2));
-    msg_appendentries_t*  ae = sender_poll_msg_data(sender);
+    raft_appendentries_req_t *  ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
     CuAssertTrue(tc, ae->leader_commit == 10);
 }
@@ -2579,7 +2579,7 @@ void TestRaft_leader_sends_appendentries_with_prevLogIdx(
 
     /* receive appendentries messages */
     raft_send_appendentries(r, raft_get_node(r, 2));
-    msg_appendentries_t*  ae = sender_poll_msg_data(sender);
+    raft_appendentries_req_t *  ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
     CuAssertIntEquals(tc, 0, ae->prev_log_idx);
 
@@ -2626,7 +2626,7 @@ void TestRaft_leader_sends_appendentries_when_node_has_next_idx_of_0(
 
     /* receive appendentries messages */
     raft_send_appendentries(r, raft_get_node(r, 2));
-    msg_appendentries_t*  ae = sender_poll_msg_data(sender);
+    raft_appendentries_req_t *  ae = sender_poll_msg_data(sender);
 
     /* add an entry */
     /* receive appendentries messages */
@@ -2659,7 +2659,7 @@ void TestRaft_leader_updates_next_idx_on_send_ae(CuTest *tc)
     /* receive appendentries messages */
     raft_node_t* n = raft_get_node(r, 2);
     raft_send_appendentries(r, n);
-    msg_appendentries_t*  ae = sender_poll_msg_data(sender);
+    raft_appendentries_req_t *  ae = sender_poll_msg_data(sender);
 
     raft_node_set_next_idx(n, 1);
     __RAFT_APPEND_ENTRY(r, 100, 1, "aaa");
@@ -2700,7 +2700,7 @@ void TestRaft_leader_retries_appendentries_with_decremented_NextIdx_log_inconsis
 
     /* receive appendentries messages */
     raft_send_appendentries(r, raft_get_node(r, 2));
-    msg_appendentries_t* ae = sender_poll_msg_data(sender);
+    raft_appendentries_req_t * ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
 }
 
@@ -2717,8 +2717,8 @@ void TestRaft_leader_append_entry_to_log_increases_idxno(CuTest * tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_resp_t cr;
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -2742,7 +2742,7 @@ void T_estRaft_leader_doesnt_append_entry_if_unique_id_is_duplicate(CuTest * tc)
         { NULL     }
     };
 
-    msg_entry_t ety;
+    raft_entry_req_t ety;
     ety.id = 1;
     ety.data = "entry";
     ety.data.len = strlen("entry");
@@ -2770,7 +2770,7 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_when_majori
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
 
     void *sender = sender_new(NULL);
     void *r = raft_new();
@@ -2792,7 +2792,7 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_when_majori
     __RAFT_APPEND_ENTRY(r, 1, 1, "aaa");
     __RAFT_APPEND_ENTRY(r, 2, 1, "bbb");
 
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
 
     /* FIRST entry log application */
     /* send appendentries -
@@ -2838,7 +2838,7 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_for_nod
         .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
         .log                         = NULL
     };
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
 
     void *r = raft_new();
     raft_add_node(r, NULL, 1, 1);
@@ -2861,7 +2861,7 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_for_nod
     __RAFT_APPEND_ENTRY(r, 1, 1, "aaa");
     __RAFT_APPEND_ENTRY(r, 2, 1, "bbb");
 
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
 
     raft_send_appendentries(r, raft_get_node(r, 5));
     aer.term = 1;
@@ -2886,7 +2886,7 @@ void TestRaft_leader_recv_appendentries_response_fail_set_has_sufficient_logs_fo
             .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
             .log                         = NULL
     };
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
 
     void *r = raft_new();
     raft_add_node(r, NULL, 1, 1);
@@ -2908,7 +2908,7 @@ void TestRaft_leader_recv_appendentries_response_fail_set_has_sufficient_logs_fo
     /* append entries - we need two */
     __RAFT_APPEND_ENTRIES_SEQ_ID(r, 3, 1, 1, "aaaa");
 
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
 
     raft_send_appendentries(r, raft_get_node(r, 5));
     aer.term = 1;
@@ -2929,7 +2929,7 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_using_votin
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
 
     void *sender = sender_new(NULL);
     void *r = raft_new();
@@ -2950,7 +2950,7 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_using_votin
     /* append entries - we need two */
     __RAFT_APPEND_ENTRY(r, 1, 1, "aaaa");
 
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
 
     /* FIRST entry log application */
     /* send appendentries -
@@ -2975,7 +2975,7 @@ void TestRaft_leader_recv_appendentries_response_duplicate_does_not_decrement_ma
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
 
     void *sender = sender_new(NULL);
     void *r = raft_new();
@@ -2995,7 +2995,7 @@ void TestRaft_leader_recv_appendentries_response_duplicate_does_not_decrement_ma
     __RAFT_APPEND_ENTRY(r, 1, 1, "aaa");
     __RAFT_APPEND_ENTRY(r, 2, 1, "bbb");
 
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
 
     /* receive msg 1 */
     aer.term = 1;
@@ -3028,7 +3028,7 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
 
     void *sender = sender_new(NULL);
     void *r = raft_new();
@@ -3050,7 +3050,7 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
     __RAFT_APPEND_ENTRY(r, 2, 1, "bbb");
     __RAFT_APPEND_ENTRY(r, 3, 2, "aaaa");
 
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
 
     /* FIRST entry log application */
     /* send appendentries -
@@ -3108,7 +3108,7 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
 
     void *sender = sender_new(NULL);
     void *r = raft_new();
@@ -3122,7 +3122,7 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
     /* append entries */
     __RAFT_APPEND_ENTRIES_SEQ_ID_TERM(r, 4, 1, 1, "aaaa");
 
-    msg_appendentries_t* ae;
+    raft_appendentries_req_t * ae;
 
     /* become leader sets next_idx to current_idx
      * it also appends a NO_OP, and as raft_send_appendentries()
@@ -3137,7 +3137,7 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
     CuAssertIntEquals(tc, 4, ae->prev_log_idx);
 
     /* receive mock success responses */
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
     aer.term = 4;
     aer.success = 0;
     aer.current_idx = 1;
@@ -3153,7 +3153,7 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
     CuAssertIntEquals(tc, 4, ae->n_entries);
 
     /* receive mock success responses */
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
     aer.term = 4;
     aer.success = 1;
     aer.current_idx = 5;
@@ -3195,8 +3195,8 @@ void TestRaft_leader_recv_appendentries_response_retry_only_if_leader(CuTest * t
     raft_become_follower(r);
 
     /* receive mock success responses */
-    msg_appendentries_response_t aer;
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    raft_appendentries_resp_t aer;
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
     aer.term = 1;
     aer.success = 1;
     aer.current_idx = 1;
@@ -3222,8 +3222,8 @@ void TestRaft_leader_recv_appendentries_response_without_node_fails(CuTest * tc)
     raft_set_current_term(r, 1);
 
     /* receive mock success responses */
-    msg_appendentries_response_t aer;
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    raft_appendentries_resp_t aer;
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
     aer.term = 1;
     aer.success = 1;
     aer.current_idx = 0;
@@ -3241,10 +3241,10 @@ void TestRaft_leader_recv_entry_resets_election_timeout(
     raft_periodic(r, 900);
 
     /* entry message */
-    msg_entry_t *mety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *mety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
     raft_recv_entry(r, mety, &cr);
     CuAssertTrue(tc, 0 == raft_get_timeout_elapsed(r));
 }
@@ -3267,10 +3267,10 @@ void TestRaft_leader_recv_entry_is_committed_returns_0_if_not_committed(CuTest *
     raft_set_commit_idx(r, 0);
 
     /* entry message */
-    msg_entry_t *mety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *mety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
     raft_recv_entry(r, mety, &cr);
     CuAssertTrue(tc, 0 == raft_msg_entry_response_committed(r, &cr));
 
@@ -3296,10 +3296,10 @@ void TestRaft_leader_recv_entry_is_committed_returns_neg_1_if_invalidated(CuTest
     raft_set_commit_idx(r, 0);
 
     /* entry message */
-    msg_entry_t *mety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *mety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
     raft_recv_entry(r, mety, &cr);
     CuAssertTrue(tc, 0 == raft_msg_entry_response_committed(r, &cr));
     CuAssertTrue(tc, cr.term == 1);
@@ -3308,13 +3308,13 @@ void TestRaft_leader_recv_entry_is_committed_returns_neg_1_if_invalidated(CuTest
     CuAssertTrue(tc, 0 == raft_get_commit_idx(r));
 
     /* append entry that invalidates entry message */
-    msg_appendentries_t ae;
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    raft_appendentries_req_t ae;
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.leader_commit = 1;
     ae.term = 2;
     ae.prev_log_idx = 0;
     ae.prev_log_term = 0;
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     ae.entries = __MAKE_ENTRY_ARRAY(999, 2, "aaa");
     ae.n_entries = 1;
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
@@ -3342,10 +3342,10 @@ void TestRaft_leader_recv_entry_fails_if_prevlogidx_less_than_commit(CuTest * tc
     raft_set_commit_idx(r, 0);
 
     /* entry message */
-    msg_entry_t *mety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *mety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
     raft_recv_entry(r, mety, &cr);
     CuAssertTrue(tc, 0 == raft_msg_entry_response_committed(r, &cr));
     CuAssertTrue(tc, cr.term == 2);
@@ -3356,13 +3356,13 @@ void TestRaft_leader_recv_entry_fails_if_prevlogidx_less_than_commit(CuTest * tc
     raft_set_commit_idx(r, 1);
 
     /* append entry that invalidates entry message */
-    msg_appendentries_t ae;
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    raft_appendentries_req_t ae;
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.leader_commit = 1;
     ae.term = 2;
     ae.prev_log_idx = 1;
     ae.prev_log_term = 1;
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     ae.entries = __MAKE_ENTRY_ARRAY(999, 2, "aaa");
     ae.n_entries = 1;
     raft_recv_appendentries(r, raft_get_node(r, 2), &ae, &aer);
@@ -3400,14 +3400,14 @@ void TestRaft_leader_recv_entry_does_not_send_new_appendentries_to_slow_nodes(Cu
     __RAFT_APPEND_ENTRY(r, 1, 1, "aaaa");
 
     /* entry message */
-    msg_entry_t *mety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *mety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
     raft_recv_entry(r, mety, &cr);
 
     /* check if the slow node got sent this appendentries */
-    msg_appendentries_t* ae;
+    raft_appendentries_req_t * ae;
     ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL == ae);
 }
@@ -3440,8 +3440,8 @@ void TestRaft_leader_recv_appendentries_response_failure_does_not_set_node_nexti
     raft_send_appendentries(r, raft_get_node(r, 2));
 
     /* receive mock success response */
-    msg_appendentries_response_t aer;
-    memset(&aer, 0, sizeof(msg_appendentries_response_t));
+    raft_appendentries_resp_t aer;
+    memset(&aer, 0, sizeof(raft_appendentries_resp_t));
     aer.term = 1;
     aer.success = 0;
     aer.current_idx = 0;
@@ -3475,7 +3475,7 @@ void TestRaft_leader_recv_appendentries_response_increment_idx_of_node(
     CuAssertTrue(tc, 1 == raft_node_get_next_idx(p));
 
     /* receive mock success responses */
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     aer.term = 1;
     aer.success = 1;
     aer.current_idx = 0;
@@ -3506,7 +3506,7 @@ void TestRaft_leader_recv_appendentries_response_drop_message_if_term_is_old(
     CuAssertTrue(tc, 1 == raft_node_get_next_idx(p));
 
     /* receive OLD mock success responses */
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     aer.term = 1;
     aer.success = 1;
     aer.current_idx = 1;
@@ -3536,7 +3536,7 @@ void TestRaft_leader_recv_appendentries_response_steps_down_if_term_is_newer(
     CuAssertTrue(tc, 1 == raft_node_get_next_idx(p));
 
     /* receive NEW mock failed responses */
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     aer.term = 3;
     aer.success = 0;
     aer.current_idx = 2;
@@ -3555,8 +3555,8 @@ void TestRaft_leader_recv_appendentries_steps_down_if_newer(
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -3567,7 +3567,7 @@ void TestRaft_leader_recv_appendentries_steps_down_if_newer(
     CuAssertTrue(tc, 1 == raft_is_leader(r));
     CuAssertTrue(tc, 1 == raft_get_leader_id(r));
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 6;
     ae.leader_id = 2;
     ae.prev_log_idx = 6;
@@ -3590,8 +3590,8 @@ void TestRaft_leader_recv_appendentries_steps_down_if_newer_term(
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -3599,7 +3599,7 @@ void TestRaft_leader_recv_appendentries_steps_down_if_newer_term(
     raft_set_state(r, RAFT_STATE_LEADER);
     raft_set_current_term(r, 5);
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 6;
     ae.prev_log_idx = 5;
     ae.prev_log_term = 5;
@@ -3631,7 +3631,7 @@ void TestRaft_leader_sends_empty_appendentries_every_request_timeout(
     raft_become_leader(r);
 
     /* receive appendentries messages for both nodes */
-    msg_appendentries_t* ae;
+    raft_appendentries_req_t * ae;
     ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
     ae = sender_poll_msg_data(sender);
@@ -3672,7 +3672,7 @@ void TestRaft_leader_recv_requestvote_responds_without_granting(CuTest * tc)
 
     raft_election_start(r, 0);
 
-    msg_requestvote_response_t rvr = {
+    raft_requestvote_resp_t rvr = {
         .prevote = 1,
         .request_term = raft_get_current_term(r) + 1,
         .term = 0,
@@ -3682,7 +3682,7 @@ void TestRaft_leader_recv_requestvote_responds_without_granting(CuTest * tc)
     raft_recv_requestvote_response(r, raft_get_node(r, 2), &rvr);
     CuAssertTrue(tc, 1 == raft_is_candidate(r));
 
-    msg_requestvote_response_t rvr1 = {
+    raft_requestvote_resp_t rvr1 = {
         .request_term = 1,
         .term = 1,
         .vote_granted = 1
@@ -3692,7 +3692,7 @@ void TestRaft_leader_recv_requestvote_responds_without_granting(CuTest * tc)
     CuAssertTrue(tc, 1 == raft_is_leader(r));
 
     /* receive request vote from node 3 */
-    msg_requestvote_t rv = {
+    raft_requestvote_req_t rv = {
         .term = 1
     };
 
@@ -3733,8 +3733,8 @@ void T_estRaft_leader_recv_requestvote_responds_with_granting_if_term_is_higher(
     CuAssertTrue(tc, 1 == raft_is_leader(r));
 
     /* receive request vote from node 3 */
-    msg_requestvote_t rv;
-    memset(&rv, 0, sizeof(msg_requestvote_t));
+    raft_requestvote_req_t rv;
+    memset(&rv, 0, sizeof(raft_requestvote_req_t));
     rv.term = 2;
     raft_recv_requestvote(r, raft_get_node(r, 3), &rv, &rvr);
     CuAssertTrue(tc, 1 == raft_is_follower(r));
@@ -3772,7 +3772,7 @@ void TestRaft_leader_recv_entry_add_nonvoting_node_remove_and_revert(CuTest *tc)
     /* Add the non-voting node */
     raft_entry_t *ety = __MAKE_ENTRY(1, 1, "3");
     ety->type = RAFT_LOGTYPE_ADD_NONVOTING_NODE;
-    msg_entry_response_t etyr;
+    raft_entry_resp_t etyr;
     CuAssertIntEquals(tc, 0, raft_recv_entry(r, ety, &etyr));
     CuAssertIntEquals(tc, 1, raft_node_is_active(raft_get_node(r, 3)));
     CuAssertIntEquals(tc, 0, raft_node_is_voting(raft_get_node(r, 3)));
@@ -3818,14 +3818,14 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_after_v
     /* Add two non-voting nodes */
     raft_entry_t *ety = __MAKE_ENTRY(1, 1, "2");
     ety->type = RAFT_LOGTYPE_ADD_NONVOTING_NODE;
-    msg_entry_response_t etyr;
+    raft_entry_resp_t etyr;
     CuAssertIntEquals(tc, 0, raft_recv_entry(r, ety, &etyr));
 
     ety = __MAKE_ENTRY(2, 1, "3");
     ety->type = RAFT_LOGTYPE_ADD_NONVOTING_NODE;
     CuAssertIntEquals(tc, 0, raft_recv_entry(r, ety, &etyr));
 
-    msg_appendentries_response_t aer = {
+    raft_appendentries_resp_t aer = {
         .term = 1, .success = 1, .current_idx = 2
     };
 
@@ -3894,7 +3894,7 @@ void TestRaft_read_action_callback(
     CuAssertIntEquals(tc, 0, ra.calls);
 
     /* acked by node 2 - enough for quorum */
-    msg_appendentries_response_t aer = { .msg_id = 1, .term = 1, .success = 1, .current_idx = 1 };
+    raft_appendentries_resp_t aer = { .msg_id = 1, .term = 1, .success = 1, .current_idx = 1 };
     CuAssertIntEquals(tc, 0, raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer));
 
     raft_periodic(r, 1);
@@ -3986,14 +3986,14 @@ void TestRaft_server_recv_requestvote_with_transfer_node(CuTest * tc)
     raft_set_state(r, RAFT_STATE_LEADER);
 
     /* setup requestvote struct */
-    msg_requestvote_t rv = {
+    raft_requestvote_req_t rv = {
             .prevote = 1,
             .term = 2,
             .candidate_id = 2,
             .last_log_idx = 0,
             .last_log_term = 1
     };
-    msg_requestvote_response_t rvr;
+    raft_requestvote_resp_t rvr;
 
     /* test #1: try to request a vote with prevote flag */
     raft_recv_requestvote(r, raft_get_node(r, 2), &rv, &rvr);
@@ -4152,7 +4152,7 @@ void TestRaft_callback_timeoutnow_at_send_appendentries_response_if_up_to_date(C
     CuAssertIntEquals(tc, 0, ret);
     CuAssertTrue(tc, 0 == timeoutnow_sent);
 
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     aer.term = 2;
     aer.success = 1;
     aer.current_idx = 2;
@@ -4213,9 +4213,9 @@ void TestRaft_vote_for_unknown_node(CuTest * tc)
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
 
-    msg_requestvote_response_t resp;
+    raft_requestvote_resp_t resp;
 
-    msg_requestvote_t req = {
+    raft_requestvote_req_t req = {
         .term = 2,
         .last_log_idx = 1,
         .last_log_term = 1,
@@ -4239,9 +4239,9 @@ void TestRaft_recv_appendreq_from_unknown_node(CuTest * tc)
     raft_set_current_term(r, 1);
     raft_become_leader(r);
 
-    msg_appendentries_response_t resp;
+    raft_appendentries_resp_t resp;
 
-    msg_appendentries_t req = {
+    raft_appendentries_req_t req = {
         .term = 1,
 
         // not part of the configuration
@@ -4257,7 +4257,7 @@ void TestRaft_recv_appendreq_from_unknown_node(CuTest * tc)
     CuAssertPtrEquals(tc, NULL, raft_get_leader_node(r));
 
     // Receive it again to verify everything is ok
-    resp = (msg_appendentries_response_t){0};
+    resp = (raft_appendentries_resp_t){0};
     raft_recv_appendentries(r, NULL, &req, &resp);
 
     CuAssertTrue(tc, resp.success == 1);
@@ -4279,12 +4279,12 @@ void TestRaft_unknown_node_can_become_leader(CuTest * tc)
     raft_add_node(r, NULL, 2, 0);
     raft_set_current_term(r, 1);
 
-    msg_appendentries_response_t resp;
+    raft_appendentries_resp_t resp;
 
     raft_entry_t **entries = __MAKE_ENTRY_ARRAY(1, 1, "100");
     entries[0]->type = RAFT_LOGTYPE_ADD_NONVOTING_NODE;
 
-    msg_appendentries_t req_append = {
+    raft_appendentries_req_t req_append = {
         .term = 1,
         .prev_log_idx = 0,
         .prev_log_term = 0,
@@ -4300,7 +4300,7 @@ void TestRaft_unknown_node_can_become_leader(CuTest * tc)
     CuAssertTrue(tc, resp.success == 1);
 
     // Send another req with incremented leader_commit to commit the addition
-    msg_appendentries_t req_commit = {
+    raft_appendentries_req_t req_commit = {
         .term = 1,
         .prev_log_idx = 1,
         .prev_log_term = 1,
@@ -4329,7 +4329,7 @@ void TestRaft_unknown_node_can_become_leader(CuTest * tc)
     entries = __MAKE_ENTRY_ARRAY(1, 1, "100");
     entries[0]->type = RAFT_LOGTYPE_ADD_NODE;
 
-    msg_appendentries_t req_add_node = {
+    raft_appendentries_req_t req_add_node = {
         .term = 1,
         .leader_id = 100,
         .msg_id = 1,
@@ -4370,7 +4370,7 @@ void TestRaft_removed_node_starts_election(CuTest * tc)
     raft_set_current_term(r, 1);
     raft_become_leader(r);
 
-    msg_entry_response_t entry_resp;
+    raft_entry_resp_t entry_resp;
     raft_entry_t *entry = __MAKE_ENTRY(1, 1, "1");
     entry->type = RAFT_LOGTYPE_REMOVE_NODE;
 
@@ -4385,7 +4385,7 @@ void TestRaft_removed_node_starts_election(CuTest * tc)
     raft_periodic(r, 2000);
     raft_become_candidate(r);
 
-    msg_requestvote_response_t reqresp = {
+    raft_requestvote_resp_t reqresp = {
         .request_term = 2,
         .vote_granted = 1,
         .term = 2
@@ -4400,7 +4400,8 @@ void TestRaft_removed_node_starts_election(CuTest * tc)
 }
 
 int cb_send_appendentries(raft_server_t* raft,
-                         void* udata, raft_node_t* node, msg_appendentries_t* msg)
+                         void* udata, raft_node_t* node,
+                          raft_appendentries_req_t * msg)
 {
     CuTest * tc = udata;
     CuAssertIntEquals(tc, raft_get_nodeid(raft), msg->leader_id);
@@ -4491,8 +4492,8 @@ void Test_transfer_leader_success(CuTest *tc)
     int ret = raft_transfer_leader(r, 2, 0);
     CuAssertIntEquals(tc, 0, ret);
 
-    msg_appendentries_t ae = { 0 };
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae = { 0 };
+    raft_appendentries_resp_t aer;
     ae.term = 1;
     ae.leader_id = 2;
 
@@ -4518,8 +4519,8 @@ void Test_transfer_leader_unexpected(CuTest *tc)
     int ret = raft_transfer_leader(r, 3, 0);
     CuAssertIntEquals(tc, 0, ret);
 
-    msg_appendentries_t ae = { 0 };
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae = { 0 };
+    raft_appendentries_resp_t aer;
     ae.term = 1;
     ae.leader_id = 2;
 

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -45,7 +45,7 @@ static int __raft_applylog(
 static int __raft_send_requestvote(raft_server_t* raft,
                             void* udata,
                             raft_node_t* node,
-                            msg_requestvote_t* msg)
+                            raft_requestvote_req_t* msg)
 {
     return 0;
 }
@@ -53,7 +53,7 @@ static int __raft_send_requestvote(raft_server_t* raft,
 static int __raft_send_appendentries(raft_server_t* raft,
                               void* udata,
                               raft_node_t* node,
-                              msg_appendentries_t* msg)
+                              raft_appendentries_req_t* msg)
 {
     return 0;
 }
@@ -61,16 +61,16 @@ static int __raft_send_appendentries(raft_server_t* raft,
 static int __raft_send_appendentries_capture(raft_server_t* raft,
                               void* udata,
                               raft_node_t* node,
-                              msg_appendentries_t* msg)
+                              raft_appendentries_req_t* msg)
 {
-    *((msg_appendentries_t*)udata) = *msg;
+    *((raft_appendentries_req_t*)udata) = *msg;
     return 0;
 }
 
 static int __raft_send_snapshot_increment(raft_server_t* raft,
         void* udata,
         raft_node_t* node,
-        msg_snapshot_t *msg)
+        raft_snapshot_req_t *msg)
 {
     int *counter = udata;
 
@@ -122,7 +122,7 @@ struct test_data
 static int test_send_snapshot_increment(raft_server_t* raft,
                                           void* udata,
                                           raft_node_t* node,
-                                          msg_snapshot_t *msg)
+                                          raft_snapshot_req_t *msg)
 {
     struct test_data *t = udata;
 
@@ -208,7 +208,7 @@ void TestRaft_leader_begin_snapshot_fails_if_no_logs_to_compact(CuTest * tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -218,7 +218,7 @@ void TestRaft_leader_begin_snapshot_fails_if_no_logs_to_compact(CuTest * tc)
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
     raft_recv_entry(r, ety, &cr);
@@ -241,7 +241,7 @@ void TestRaft_leader_will_not_apply_entry_if_snapshot_is_in_progress(CuTest * tc
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -251,7 +251,7 @@ void TestRaft_leader_will_not_apply_entry_if_snapshot_is_in_progress(CuTest * tc
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
     raft_recv_entry(r, ety, &cr);
@@ -293,7 +293,7 @@ void TestRaft_leader_snapshot_begin_fails_if_less_than_2_logs_to_compact(CuTest 
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -303,7 +303,7 @@ void TestRaft_leader_snapshot_begin_fails_if_less_than_2_logs_to_compact(CuTest 
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
     raft_recv_entry(r, ety, &cr);
@@ -322,7 +322,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     raft_server_t *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -333,7 +333,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
     raft_recv_entry(r, ety, &cr);
@@ -387,7 +387,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted2(CuTest * tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -398,7 +398,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted2(CuTest * tc)
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
     raft_recv_entry(r, ety, &cr);
@@ -428,7 +428,7 @@ void TestRaft_joinee_needs_to_get_snapshot(CuTest * tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -438,7 +438,7 @@ void TestRaft_joinee_needs_to_get_snapshot(CuTest * tc)
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
     raft_recv_entry(r, ety, &cr);
@@ -469,7 +469,7 @@ void TestRaft_follower_load_from_snapshot(CuTest * tc)
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
     CuAssertIntEquals(tc, 0, raft_begin_load_snapshot(r, 5, 5));
@@ -623,7 +623,7 @@ void TestRaft_leader_sends_snapshot_when_node_next_index_was_compacted(CuTest* t
         .send_appendentries = __raft_send_appendentries_capture,
     };
 
-    msg_appendentries_t ae;
+    raft_appendentries_req_t ae;
     raft_set_callbacks(r, &funcs, &ae);
 
     /* node wants an entry just one after the snapshot index */
@@ -644,7 +644,7 @@ void TestRaft_recv_entry_fails_if_snapshot_in_progress(CuTest* tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -654,7 +654,7 @@ void TestRaft_recv_entry_fails_if_snapshot_in_progress(CuTest* tc)
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
     raft_recv_entry(r, ety, &cr);
@@ -679,7 +679,7 @@ void TestRaft_recv_entry_succeeds_if_snapshot_nonblocking_apply_is_set(CuTest* t
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -689,7 +689,7 @@ void TestRaft_recv_entry_succeeds_if_snapshot_nonblocking_apply_is_set(CuTest* t
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* entry message */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     /* receive entry */
     raft_recv_entry(r, ety, &cr);
@@ -722,10 +722,10 @@ void TestRaft_follower_recv_appendentries_is_successful_when_previous_log_idx_eq
     CuAssertIntEquals(tc, 0, raft_begin_load_snapshot(r, 2, 2));
     CuAssertIntEquals(tc, 0, raft_end_load_snapshot(r));
 
-    msg_appendentries_t ae;
-    msg_appendentries_response_t aer;
+    raft_appendentries_req_t ae;
+    raft_appendentries_resp_t aer;
 
-    memset(&ae, 0, sizeof(msg_appendentries_t));
+    memset(&ae, 0, sizeof(raft_appendentries_req_t));
     ae.term = 3;
     ae.prev_log_idx = 2;
     ae.prev_log_term = 2;
@@ -765,7 +765,7 @@ void TestRaft_leader_sends_appendentries_with_correct_prev_log_idx_when_snapshot
 
     /* receive appendentries messages */
     raft_send_appendentries(r, p);
-    msg_appendentries_t* ae = sender_poll_msg_data(sender);
+    raft_appendentries_req_t* ae = sender_poll_msg_data(sender);
     CuAssertTrue(tc, NULL != ae);
     CuAssertIntEquals(tc, 2, ae->prev_log_term);
     CuAssertIntEquals(tc, 4, ae->prev_log_idx);
@@ -780,7 +780,7 @@ void TestRaft_cancel_snapshot_restores_state(CuTest* tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    msg_entry_response_t cr;
+    raft_entry_resp_t cr;
 
     raft_add_node(r, NULL, 1, 1);
     raft_add_node(r, NULL, 2, 0);
@@ -790,7 +790,7 @@ void TestRaft_cancel_snapshot_restores_state(CuTest* tc)
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
 
     /* single entry */
-    msg_entry_t *ety = __MAKE_ENTRY(1, 1, "entry");
+    raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
     raft_recv_entry(r, ety, &cr);
 
     ety = __MAKE_ENTRY(2, 1, "entry");
@@ -869,7 +869,7 @@ void TestRaft_leader_sends_snapshot_if_log_was_compacted(CuTest* tc)
     raft_node_set_match_idx(node, 1);
     raft_node_set_next_idx(node, 2);
 
-    msg_appendentries_response_t aer;
+    raft_appendentries_resp_t aer;
     aer.term = 1;
     aer.success = 0;
     aer.current_idx = 1;
@@ -895,7 +895,7 @@ void TestRaft_clear_snapshot_on_leader_change(CuTest * tc)
     raft_set_callbacks(r, &funcs, &data);
     raft_add_node(r, NULL, 1, 1);
 
-    msg_snapshot_t msg = {
+    raft_snapshot_req_t msg = {
         .leader_id = 2,
         .snapshot_index = 1,
         .snapshot_term = 1,
@@ -905,7 +905,7 @@ void TestRaft_clear_snapshot_on_leader_change(CuTest * tc)
         .chunk.last_chunk = 0,
     };
 
-    msg_snapshot_response_t resp = {0};
+    raft_snapshot_resp_t resp = {0};
 
     raft_recv_snapshot(r, NULL, &msg, &resp);
     CuAssertIntEquals(tc, 1, data.store_chunk);
@@ -935,7 +935,7 @@ void TestRaft_reject_wrong_offset(CuTest * tc)
     raft_set_callbacks(r, &funcs, &data);
     raft_add_node(r, NULL, 1, 1);
 
-    msg_snapshot_t msg = {
+    raft_snapshot_req_t msg = {
         .leader_id = 2,
         .snapshot_index = 1,
         .snapshot_term = 1,
@@ -946,7 +946,7 @@ void TestRaft_reject_wrong_offset(CuTest * tc)
         .chunk.last_chunk = 0,
     };
 
-    msg_snapshot_response_t resp = {0};
+    raft_snapshot_resp_t resp = {0};
 
     raft_recv_snapshot(r, NULL, &msg, &resp);
     CuAssertIntEquals(tc, 1, data.store_chunk);
@@ -975,7 +975,7 @@ void TestRaft_set_last_chunk_on_duplicate(CuTest * tc)
     raft_set_callbacks(r, &funcs, &data);
     raft_add_node(r, NULL, 1, 1);
 
-    msg_snapshot_t msg = {
+    raft_snapshot_req_t msg = {
         .term = 1,
         .leader_id = 2,
         .snapshot_index = 5,
@@ -987,13 +987,13 @@ void TestRaft_set_last_chunk_on_duplicate(CuTest * tc)
         .chunk.last_chunk = 1,
     };
 
-    msg_snapshot_response_t resp = {0};
+    raft_snapshot_resp_t resp = {0};
 
     raft_recv_snapshot(r, NULL, &msg, &resp);
     CuAssertIntEquals(tc, 1, data.store_chunk);
     CuAssertIntEquals(tc, 1, data.load);
 
-    msg_snapshot_t msg2 = {
+    raft_snapshot_req_t msg2 = {
         .term = 1,
         .leader_id = 2,
         .snapshot_index = 4,

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -530,7 +530,7 @@ class Network(object):
         new_msg = ffi.cast(ffi.typeof(msg), lib.malloc(msg_size))
         ffi.memmove(new_msg, msg, msg_size)
 
-        if msg_type == 'msg_appendentries_t *':
+        if msg_type == 'raft_appendentries_req_t *':
             new_msg.entries = lib.raft_entry_array_deepcopy(msg.entries, msg.n_entries)
 
         self.messages.append(Message(new_msg, sendor, sendee))
@@ -540,9 +540,9 @@ class Network(object):
 
         logger.debug(f"poll_message: {msg.sendor.id} -> {msg.sendee.id} ({msg_type}")
 
-        if msg_type == 'msg_appendentries_t *':
+        if msg_type == 'raft_appendentries_req_t *':
             node = lib.raft_get_node(msg.sendee.raft, msg.sendor.id)
-            response = ffi.new('msg_appendentries_response_t*')
+            response = ffi.new('raft_appendentries_resp_t*')
             e = lib.raft_recv_appendentries(msg.sendee.raft, node, msg.data, response)
             if lib.RAFT_ERR_SHUTDOWN == e:
                 logger.error('Catastrophic')
@@ -553,27 +553,27 @@ class Network(object):
             else:
                 self.enqueue_msg(response, msg.sendee, msg.sendor)
 
-        elif msg_type == 'msg_appendentries_response_t *':
+        elif msg_type == 'raft_appendentries_resp_t *':
             node = lib.raft_get_node(msg.sendee.raft, msg.sendor.id)
             lib.raft_recv_appendentries_response(msg.sendee.raft, node, msg.data)
 
-        elif msg_type == 'msg_snapshot_t *':
-            response = ffi.new('msg_snapshot_response_t *')
+        elif msg_type == 'raft_snapshot_req_t *':
+            response = ffi.new('raft_snapshot_resp_t *')
             node = lib.raft_get_node(msg.sendee.raft, msg.sendor.id)
             lib.raft_recv_snapshot(msg.sendee.raft, node, msg.data, response)
             self.enqueue_msg(response, msg.sendee, msg.sendor)
 
-        elif msg_type == 'msg_snapshot_response_t *':
+        elif msg_type == 'raft_snapshot_resp_t *':
             node = lib.raft_get_node(msg.sendee.raft, msg.sendor.id)
             lib.raft_recv_snapshot_response(msg.sendee.raft, node, msg.data)
 
-        elif msg_type == 'msg_requestvote_t *':
-            response = ffi.new('msg_requestvote_response_t*')
+        elif msg_type == 'raft_requestvote_req_t *':
+            response = ffi.new('raft_requestvote_resp_t*')
             node = lib.raft_get_node(msg.sendee.raft, msg.sendor.id)
             lib.raft_recv_requestvote(msg.sendee.raft, node, msg.data, response)
             self.enqueue_msg(response, msg.sendee, msg.sendor)
 
-        elif msg_type == 'msg_requestvote_response_t *':
+        elif msg_type == 'raft_requestvote_resp_t *':
             node = lib.raft_get_node(msg.sendee.raft, msg.sendor.id)
             e = lib.raft_recv_requestvote_response(msg.sendee.raft, node, msg.data)
             if lib.RAFT_ERR_SHUTDOWN == e:
@@ -941,9 +941,9 @@ class RaftServer(object):
         self.network = network
 
     def load_callbacks(self):
-        self.raft_send_requestvote = ffi.callback("int(raft_server_t*, void*, raft_node_t*, msg_requestvote_t*)", raft_send_requestvote)
-        self.raft_send_appendentries = ffi.callback("int(raft_server_t*, void*, raft_node_t*, msg_appendentries_t*)", raft_send_appendentries)
-        self.raft_send_snapshot = ffi.callback("int(raft_server_t*, void* , raft_node_t*, msg_snapshot_t*)", raft_send_snapshot)
+        self.raft_send_requestvote = ffi.callback("int(raft_server_t*, void*, raft_node_t*, raft_requestvote_req_t*)", raft_send_requestvote)
+        self.raft_send_appendentries = ffi.callback("int(raft_server_t*, void*, raft_node_t*, raft_appendentries_req_t*)", raft_send_appendentries)
+        self.raft_send_snapshot = ffi.callback("int(raft_server_t*, void* , raft_node_t*, raft_snapshot_req_t*)", raft_send_snapshot)
         self.raft_load_snapshot = ffi.callback("int(raft_server_t*, void*, raft_index_t, raft_term_t)", raft_load_snapshot)
         self.raft_clear_snapshot = ffi.callback("int(raft_server_t*, void*)", raft_clear_snapshot)
         self.raft_get_snapshot_chunk = ffi.callback("int(raft_server_t*, void*, raft_node_t*, raft_size_t offset, raft_snapshot_chunk_t*)", raft_get_snapshot_chunk)
@@ -962,7 +962,7 @@ class RaftServer(object):
 
     def recv_entry(self, ety):
         # FIXME: leak
-        response = ffi.new('msg_entry_response_t*')
+        response = ffi.new('raft_entry_resp_t*')
         return lib.raft_recv_entry(self.raft, ety, response)
 
     def get_entry(self, idx):


### PR DESCRIPTION
Added `raft_` prefix for exported symbols.

- Renamed `func_foo_f` function pointer typedefs to `raft_foo_f`.
- Renamed `msg_foo_t` message struct definitions to `raft_foo_t`.
    - Used `req` and `resp` suffix for requests and responses e.g: `raft_snapshot_req_t`, `raft_snapshot_resp_t`.

Fixes: https://github.com/RedisLabs/raft/issues/30