### PR TITLE
Make raft_recv_entry()'s response parameter optional

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1090,9 +1090,11 @@ int raft_recv_entry(raft_server_t* me,
     if (0 != e)
         return e;
 
-    r->id = ety->id;
-    r->idx = raft_get_current_idx(me);
-    r->term = me->current_term;
+    if (r) {
+        r->id = ety->id;
+        r->idx = raft_get_current_idx(me);
+        r->term = me->current_term;
+    }
 
     if (me->auto_flush) {
         e = me->log_impl->sync(me->log);

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -2717,7 +2717,6 @@ void TestRaft_leader_append_entry_to_log_increases_idxno(CuTest * tc)
     void *r = raft_new();
     raft_set_callbacks(r, &funcs, NULL);
 
-    raft_entry_resp_t cr;
     raft_entry_req_t *ety = __MAKE_ENTRY(1, 1, "entry");
 
     raft_add_node(r, NULL, 1, 1);
@@ -2725,7 +2724,7 @@ void TestRaft_leader_append_entry_to_log_increases_idxno(CuTest * tc)
     raft_set_state(r, RAFT_STATE_LEADER);
     CuAssertTrue(tc, 0 == raft_get_log_count(r));
 
-    raft_recv_entry(r, ety, &cr);
+    raft_recv_entry(r, ety, NULL);
     CuAssertTrue(tc, 1 == raft_get_log_count(r));
 }
 


### PR DESCRIPTION
If `raft_entry_resp_t` is NULL, skip setting response struct. Simplifies usage if user is not interested in the response.

```c
int raft_recv_entry(raft_server_t* me,
                    raft_entry_req_t* ety,
                    raft_entry_resp_t* r)
```

