### PR TITLE
Refactor

### DIFF
--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -195,7 +195,7 @@ int raft_node_is_voting_committed(raft_node_t* me)
 
 raft_node_id_t raft_node_get_id(raft_node_t* me)
 {
-    return me != NULL ? me->id : -1;
+    return me != NULL ? me->id : RAFT_NODE_ID_NONE;
 }
 
 void raft_node_set_addition_committed(raft_node_t* me, int committed)

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -113,9 +113,9 @@ raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
     me->node_transferring_leader_to = RAFT_NODE_ID_NONE;
     me->auto_flush = 1;
 
-    raft_update_quorum_meta((raft_server_t*)me, me->msg_id);
+    raft_update_quorum_meta(me, me->msg_id);
 
-    raft_randomize_election_timeout((raft_server_t*)me);
+    raft_randomize_election_timeout(me);
     me->log_impl = log_impl;
     me->log = me->log_impl->init(me, log_arg);
     if (!me->log) {
@@ -124,13 +124,13 @@ raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
     }
 
     me->voting_cfg_change_log_idx = -1;
-    raft_set_state((raft_server_t*)me, RAFT_STATE_FOLLOWER);
+    raft_set_state(me, RAFT_STATE_FOLLOWER);
     me->leader_id = RAFT_NODE_ID_NONE;
 
     me->snapshot_in_progress = 0;
-    raft_set_snapshot_metadata((raft_server_t*)me, 0, 0);
+    raft_set_snapshot_metadata(me, 0, 0);
 
-    return (raft_server_t*)me;
+    return me;
 }
 
 raft_server_t* raft_new(void)
@@ -140,7 +140,7 @@ raft_server_t* raft_new(void)
 
 void raft_set_callbacks(raft_server_t* me, raft_cbs_t* funcs, void* udata)
 {
-    memcpy(&me->cb, funcs, sizeof(raft_cbs_t));
+    me->cb = *funcs;
     me->udata = udata;
 }
 
@@ -157,7 +157,7 @@ void raft_clear(raft_server_t* me)
     me->timeout_elapsed = 0;
     raft_randomize_election_timeout(me);
     me->voting_cfg_change_log_idx = -1;
-    raft_set_state((raft_server_t*)me, RAFT_STATE_FOLLOWER);
+    raft_set_state(me, RAFT_STATE_FOLLOWER);
     me->leader_id = RAFT_NODE_ID_NONE;
     me->commit_idx = 0;
     me->last_applied_idx = 0;
@@ -1748,7 +1748,7 @@ int raft_begin_load_snapshot(
         me->current_term = last_included_term;
     }
 
-    raft_set_state((raft_server_t*)me, RAFT_STATE_FOLLOWER);
+    raft_set_state(me, RAFT_STATE_FOLLOWER);
     me->leader_id = RAFT_NODE_ID_NONE;
 
     me->log_impl->reset(me->log, last_included_index + 1, last_included_term);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1187,11 +1187,7 @@ int raft_apply_entry(raft_server_t* me)
         }
     }
 
-    /* voting cfg change is now complete.
-     * TODO: there seem to be a possible off-by-one bug hidden here, requiring
-     * checking log_idx >= voting_cfg_change_log_idx rather than plain ==.
-     */
-    if (log_idx >= me->voting_cfg_change_log_idx)
+    if (log_idx == me->voting_cfg_change_log_idx)
         me->voting_cfg_change_log_idx = -1;
 
     if (!raft_entry_is_cfg_change(ety))

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -33,8 +33,6 @@ void raft_set_log_enabled(raft_server_t* me, int enable)
 
 raft_node_id_t raft_get_nodeid(raft_server_t* me)
 {
-    if (!me->node)
-        return -1;
     return raft_node_get_id(me->node);
 }
 
@@ -81,15 +79,14 @@ int raft_set_current_term(raft_server_t* me, const raft_term_t term)
 {
     if (me->current_term < term)
     {
-        int voted_for = -1;
         if (me->cb.persist_term)
         {
-            int e = me->cb.persist_term(me, me->udata, term, voted_for);
+            int e = me->cb.persist_term(me, me->udata, term, RAFT_NODE_ID_NONE);
             if (0 != e)
                 return e;
         }
         me->current_term = term;
-        me->voted_for = voted_for;
+        me->voted_for = RAFT_NODE_ID_NONE;
     }
     return 0;
 }


### PR DESCRIPTION
- Use RAFT_NODE_ID_NONE instead of -1
- Delete unnecessary checks around `raft_apply_all()` (Same checks are already inside of it)
- Delete obsolete comment for voting change (Probably, fixed by https://github.com/RedisLabs/raft/commit/a02be774d520406bd8821d49a91358f24b540edc)
- Delete unnecessary pointer casts