### PR TITLE
Add raft_get_state_str() to get state as string

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -32,8 +32,7 @@ typedef enum {
 } raft_membership_e;
 
 typedef enum {
-    RAFT_STATE_NONE,
-    RAFT_STATE_FOLLOWER,
+    RAFT_STATE_FOLLOWER = 1,
     RAFT_STATE_PRECANDIDATE,
     RAFT_STATE_CANDIDATE,
     RAFT_STATE_LEADER,
@@ -1248,6 +1247,9 @@ raft_node_id_t raft_node_get_id(raft_node_t* me);
 /** Tell if we are a leader, candidate or follower.
  * @return get state of type raft_state_e. */
 int raft_get_state(raft_server_t* me);
+
+/* @return state string */
+const char *raft_get_state_str(raft_server_t* me);
 
 /** Get the most recent log's term
  * @return the last log term */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -49,7 +49,7 @@ struct raft_server {
     raft_index_t last_applied_idx;
 
     /* follower/leader/candidate indicator */
-    int state;
+    raft_state_e state;
 
     /* amount of time left till timeout */
     int timeout_elapsed;

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -139,6 +139,22 @@ int raft_get_state(raft_server_t* me)
     return me->state;
 }
 
+const char *raft_get_state_str(raft_server_t* me)
+{
+    switch (me->state) {
+        case RAFT_STATE_FOLLOWER:
+            return "follower";
+        case RAFT_STATE_PRECANDIDATE:
+            return "pre-candidate";
+        case RAFT_STATE_CANDIDATE:
+            return "candidate";
+        case RAFT_STATE_LEADER:
+            return "leader";
+        default:
+            return "unknown";
+    }
+}
+
 raft_node_t* raft_get_node(raft_server_t *me, raft_node_id_t nodeid)
 {
     int i;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -240,6 +240,19 @@ void TestRaft_set_state(CuTest * tc)
     void *r = raft_new();
     raft_set_state(r, RAFT_STATE_LEADER);
     CuAssertTrue(tc, RAFT_STATE_LEADER == raft_get_state(r));
+    CuAssertStrEquals(tc, "leader", raft_get_state_str(r));
+
+    raft_set_state(r, RAFT_STATE_CANDIDATE);
+    CuAssertTrue(tc, RAFT_STATE_CANDIDATE == raft_get_state(r));
+    CuAssertStrEquals(tc, "candidate", raft_get_state_str(r));
+
+    raft_set_state(r, RAFT_STATE_PRECANDIDATE);
+    CuAssertTrue(tc, RAFT_STATE_PRECANDIDATE == raft_get_state(r));
+    CuAssertStrEquals(tc, "pre-candidate", raft_get_state_str(r));
+
+    raft_set_state(r, RAFT_STATE_FOLLOWER);
+    CuAssertTrue(tc, RAFT_STATE_FOLLOWER == raft_get_state(r));
+    CuAssertStrEquals(tc, "follower", raft_get_state_str(r));
 }
 
 void TestRaft_server_starts_as_follower(CuTest * tc)


### PR DESCRIPTION
Helper function `raft_get_state_str()` returns state as string.