### PR TITLE
Fix next_idx and next_msgid usages

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -2151,7 +2151,7 @@ int raft_flush(raft_server_t* me, raft_index_t sync_index)
         if (me->node == me->nodes[i])
             continue;
 
-        if (raft_node_get_next_msgid(me->nodes[i]) >= last &&
+        if (raft_node_get_next_msgid(me->nodes[i]) > last &&
             raft_node_get_next_idx(me->nodes[i]) > raft_get_current_idx(me))
             continue;
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -713,14 +713,12 @@ int raft_recv_appendentries_response(raft_server_t* me,
     raft_index_t match_idx = raft_node_get_match_idx(node);
     if (r->current_idx > match_idx) {
         raft_node_set_match_idx(node, r->current_idx);
-        raft_node_set_next_idx(node, r->current_idx + 1);
     }
     assert(r->current_idx <= raft_get_current_idx(me));
 
     raft_msg_id_t match_msgid = raft_node_get_match_msgid(node);
     if (r->msg_id > match_msgid) {
         raft_node_set_match_msgid(node, r->msg_id);
-        raft_node_set_next_msgid(node, r->msg_id + 1);
     }
     assert(r->msg_id <= me->msg_id);
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -673,16 +673,11 @@ int raft_recv_appendentries_response(raft_server_t* me,
     else if (me->current_term != r->term)
         return 0;
 
-    /* If we got here, it means that the follower has acked us as a leader,
-     * even if it cant accept the append_entry */
-    raft_node_set_match_msgid(node, r->msg_id);
-
-    raft_index_t match_idx = raft_node_get_match_idx(node);
 
     if (0 == r->success)
     {
         /* Stale response -- ignore */
-        if (r->current_idx < match_idx)
+        if (r->current_idx < raft_node_get_match_idx(node))
             return 0;
 
         raft_index_t next = min(r->current_idx + 1, raft_get_current_idx(me));
@@ -715,13 +710,19 @@ int raft_recv_appendentries_response(raft_server_t* me,
             raft_node_set_has_sufficient_logs(node);
     }
 
-    if (r->current_idx <= match_idx)
-        return 0;
-
+    raft_index_t match_idx = raft_node_get_match_idx(node);
+    if (r->current_idx > match_idx) {
+        raft_node_set_match_idx(node, r->current_idx);
+        raft_node_set_next_idx(node, r->current_idx + 1);
+    }
     assert(r->current_idx <= raft_get_current_idx(me));
 
-    raft_node_set_next_idx(node, r->current_idx + 1);
-    raft_node_set_match_idx(node, r->current_idx);
+    raft_msg_id_t match_msgid = raft_node_get_match_msgid(node);
+    if (r->msg_id > match_msgid) {
+        raft_node_set_match_msgid(node, r->msg_id);
+        raft_node_set_next_msgid(node, r->msg_id + 1);
+    }
+    assert(r->msg_id <= me->msg_id);
 
     if (me->auto_flush)
         return raft_flush(me, 0);

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -4720,6 +4720,9 @@ void TestRaft_flush_sends_msg(CuTest *tc)
     raft_become_leader(r);
 
     raft_queue_read_request(r, NULL, NULL);
+
+    /* Verify that we send appendentries if the next msgid of a node equals
+     * to the last read request's msgid. */
     raft_node_set_match_msgid(node, r->msg_id - 1);
     raft_node_set_next_msgid(node, r->msg_id);
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -4172,10 +4172,12 @@ void TestRaft_callback_timeoutnow_at_send_appendentries_response_if_up_to_date(C
     CuAssertIntEquals(tc, 0, ret);
     CuAssertTrue(tc, 0 == timeoutnow_sent);
 
-    raft_appendentries_resp_t aer;
-    aer.term = 2;
-    aer.success = 1;
-    aer.current_idx = 2;
+    raft_appendentries_resp_t aer = {
+        .term = 2,
+        .success = 1,
+        .current_idx = 2
+    };
+
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertTrue(tc, 1 == timeoutnow_sent);
 }


### PR DESCRIPTION
Fix next_idx and next_msgid usages:

- Previously, we were updating `next_idx` of the node inside `raft_recv_appendentries()`. This was wrong. Assume, you send 5 appendreqs with 10 entries each and you set `next_idx` to 51. Then, when you receive the response for the first message, if you update `next_idx` , you'll set it to `11`. This will cause duplicate messages in some cases. We should just update match indexes and call `raft_flush()` as the last thing inside `raft_recv_appendentries()`. 

- `raft_flush()` has an off-by-one bug. We wouldn't send appendreq if node's `next_msgid` equals to the last read request's msgid in the queue. In a rare situation, this would extend latency of the operation. (We would wait until we send appendreq in raft_periodic()). 