### PR TITLE
Simplify read request processing

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1538,7 +1538,7 @@ extern const raft_log_impl_t raft_log_internal_impl;
 
 void raft_handle_append_cfg_change(raft_server_t* me, raft_entry_t* ety, raft_index_t idx);
 
-int raft_queue_read_request(raft_server_t* me, raft_read_request_callback_f cb, void *cb_arg);
+int raft_recv_read_request(raft_server_t* me, raft_read_request_callback_f cb, void *cb_arg);
 
 /** Attempt to process read queue.
  */
@@ -1591,7 +1591,7 @@ raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
  *        HandleNetworkOperations();
  *
  *         for (int i = 0; i < new_readreq_count; i++)
- *             raft_queue_read_request(raft, read_requests[i]);
+ *             raft_recv_read_request(raft, read_requests[i]);
  *
  *         for (int i = 0; i < new_requests_count; i++)
  *             raft_recv_entry(raft, new_requests[i]);

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -48,6 +48,9 @@ struct raft_server {
     /* idx of highest log entry applied to state machine */
     raft_index_t last_applied_idx;
 
+    /* term of the highest log entry applied to the state machine */
+    raft_term_t last_applied_term;
+
     /* follower/leader/candidate indicator */
     raft_state_e state;
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -433,7 +433,7 @@ int raft_become_leader(raft_server_t* me)
         }
 
         raft_node_set_snapshot_offset(node, 0);
-        raft_node_set_next_idx(node, current_idx + 1);
+        raft_node_set_next_idx(node, current_idx);
         raft_node_set_match_idx(node, 0);
         raft_send_appendentries(me, node);
     }

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -161,6 +161,7 @@ void raft_clear(raft_server_t* me)
     me->leader_id = RAFT_NODE_ID_NONE;
     me->commit_idx = 0;
     me->last_applied_idx = 0;
+    me->last_applied_term = 0;
     me->num_nodes = 0;
     me->node = NULL;
     me->log_impl->reset(me->log, 1, 1);
@@ -1168,19 +1169,18 @@ int raft_apply_entry(raft_server_t* me)
     if (me->last_applied_idx == raft_get_commit_idx(me))
         return -1;
 
-    raft_index_t log_idx = me->last_applied_idx + 1;
+    raft_index_t idx = me->last_applied_idx + 1;
 
-    raft_entry_t* ety = raft_get_entry_from_idx(me, log_idx);
+    raft_entry_t* ety = raft_get_entry_from_idx(me, idx);
     if (!ety)
         return -1;
 
     raft_log(me, "applying log: %ld, id: %d size: %d",
-          log_idx, ety->id, ety->data_len);
+             idx, ety->id, ety->data_len);
 
-    me->last_applied_idx++;
     if (me->cb.applylog)
     {
-        int e = me->cb.applylog(me, me->udata, ety, me->last_applied_idx);
+        int e = me->cb.applylog(me, me->udata, ety, idx);
         assert(e == 0 || e == RAFT_ERR_SHUTDOWN);
         if (RAFT_ERR_SHUTDOWN == e) {
             raft_entry_release(ety);
@@ -1188,13 +1188,16 @@ int raft_apply_entry(raft_server_t* me)
         }
     }
 
-    if (log_idx == me->voting_cfg_change_log_idx)
+    me->last_applied_idx = idx;
+    me->last_applied_term = ety->term;
+
+    if (idx == me->voting_cfg_change_log_idx)
         me->voting_cfg_change_log_idx = -1;
 
     if (!raft_entry_is_cfg_change(ety))
         goto exit;
 
-    raft_node_id_t node_id = me->cb.get_node_id(me, raft_get_udata(me), ety, log_idx);
+    raft_node_id_t node_id = me->cb.get_node_id(me, me->udata, ety, idx);
     raft_node_t* node = raft_get_node(me, node_id);
 
     switch (ety->type) {
@@ -1671,35 +1674,25 @@ raft_index_t raft_get_num_snapshottable_logs(raft_server_t *me)
 
 int raft_begin_snapshot(raft_server_t *me)
 {
-    if (raft_get_num_snapshottable_logs(me) == 0)
+    raft_index_t entry_count = raft_get_num_snapshottable_logs(me);
+    if (entry_count == 0) {
         return -1;
-
-    raft_index_t snapshot_target = raft_get_commit_idx(me);
-    if (!snapshot_target)
-        return -1;
-
-    raft_entry_t* ety = raft_get_entry_from_idx(me, snapshot_target);
-    if (!ety)
-        return -1;
-    raft_term_t ety_term = ety->term;
-    raft_entry_release(ety);
+    }
 
     /* we need to get all the way to the commit idx */
     int e = raft_apply_all(me);
-    if (e != 0)
+    if (e != 0) {
         return e;
+    }
 
-    assert(raft_get_commit_idx(me) == raft_get_last_applied_idx(me));
+    assert(me->commit_idx == me->last_applied_idx);
 
     me->snapshot_in_progress = 1;
-    me->next_snapshot_last_idx = snapshot_target;
-    me->next_snapshot_last_term = ety_term;
+    me->next_snapshot_last_idx = me->last_applied_idx;
+    me->next_snapshot_last_term = me->last_applied_term;
 
-    raft_log(me,
-        "begin snapshot sli:%ld slt:%ld slogs:%ld",
-        me->snapshot_last_idx,
-        me->snapshot_last_term,
-        raft_get_num_snapshottable_logs(me));
+    raft_log(me, "begin snapshot lai:%ld lat:%ld slogs:%ld",
+             me->last_applied_idx, me->last_applied_term, entry_count);
 
     return 0;
 }
@@ -1793,6 +1786,7 @@ int raft_begin_load_snapshot(
     if (raft_get_commit_idx(me) < last_included_index)
         raft_set_commit_idx(me, last_included_index);
 
+    me->last_applied_term = last_included_term;
     me->last_applied_idx = last_included_index;
     me->next_snapshot_last_term = last_included_term;
     me->next_snapshot_last_idx = last_included_index;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1691,7 +1691,7 @@ int raft_begin_snapshot(raft_server_t *me)
     me->next_snapshot_last_idx = me->last_applied_idx;
     me->next_snapshot_last_term = me->last_applied_term;
 
-    raft_log(me, "begin snapshot lai:%ld lat:%ld slogs:%ld",
+    raft_log(me, "begin snapshot lai:%ld lat:%ld ec:%ld",
              me->last_applied_idx, me->last_applied_term, entry_count);
 
     return 0;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1889,7 +1889,7 @@ void raft_entry_release_list(raft_entry_t **ety_list, size_t len)
     raft_free(ety_list);
 }
 
-int raft_queue_read_request(raft_server_t* me, raft_read_request_callback_f cb, void *cb_arg)
+int raft_recv_read_request(raft_server_t* me, raft_read_request_callback_f cb, void *cb_arg)
 {
     raft_read_request_t *req = raft_malloc(sizeof(raft_read_request_t));
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1883,10 +1883,14 @@ void raft_entry_release_list(raft_entry_t **ety_list, size_t len)
 
 int raft_recv_read_request(raft_server_t* me, raft_read_request_callback_f cb, void *cb_arg)
 {
-    raft_read_request_t *req = raft_malloc(sizeof(raft_read_request_t));
+    if (!raft_is_leader(me)) {
+        return RAFT_ERR_NOT_LEADER;
+    }
+
+    raft_read_request_t *req = raft_malloc(sizeof(*req));
 
     req->read_idx = raft_get_current_idx(me);
-    req->read_term = raft_get_current_term(me);
+    req->read_term = me->current_term;
     req->msg_id = ++me->msg_id;
     req->cb = cb;
     req->cb_arg = cb_arg;

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -234,6 +234,7 @@ raft_term_t raft_get_snapshot_last_term(raft_server_t *me)
 
 void raft_set_snapshot_metadata(raft_server_t *me, raft_term_t term, raft_index_t idx)
 {
+    me->last_applied_term = term;
     me->last_applied_idx = idx;
     me->snapshot_last_term = term;
     me->snapshot_last_idx = idx;

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -3158,7 +3158,7 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
     CuAssertTrue(tc, NULL != (ae = sender_poll_msg_data(sender)));
     // this ae contains the leader no op only, hence prev is the idx 4, term 4
     CuAssertIntEquals(tc, 4, ae->prev_log_term);
-    CuAssertIntEquals(tc, 5, ae->prev_log_idx);
+    CuAssertIntEquals(tc, 4, ae->prev_log_idx);
 
     /* receive mock success responses */
     memset(&aer, 0, sizeof(raft_appendentries_resp_t));

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -3907,7 +3907,7 @@ void TestRaft_read_action_callback(
     __RAFT_APPEND_ENTRY(r, 1, 1, "aaa");
     raft_set_commit_idx(r, 1);
 
-    raft_queue_read_request(r, __read_request_callback, &ra);
+    raft_recv_read_request(r, __read_request_callback, &ra);
 
     /* not acked yet */
     raft_periodic(r, 1);
@@ -3928,7 +3928,7 @@ void TestRaft_read_action_callback(
     /* entry 2 */
     __RAFT_APPEND_ENTRY(r, 2, 1, "aaa");
     ra.calls = 0;
-    raft_queue_read_request(r, __read_request_callback, &ra);
+    raft_recv_read_request(r, __read_request_callback, &ra);
 
     /* election started, nothing should be read */
     raft_become_candidate(r);
@@ -3950,7 +3950,7 @@ void TestRaft_read_action_callback(
     __RAFT_APPEND_ENTRY(r, 3, 1, "aaa");
 
     ra.calls = 0;
-    raft_queue_read_request(r, __read_request_callback, &ra);
+    raft_recv_read_request(r, __read_request_callback, &ra);
 
     /* elections again, we lose */
     raft_become_candidate(r);
@@ -3978,7 +3978,7 @@ void TestRaft_single_node_commits_noop(CuTest * tc)
     raft_set_current_term(r, 2);
     raft_set_commit_idx(r, 0);
     raft_periodic(r, 500);
-    raft_queue_read_request(r, single_node_commits_noop_cb, &str);
+    raft_recv_read_request(r, single_node_commits_noop_cb, &str);
     raft_periodic(r, 500);
 
     CuAssertIntEquals(tc, 1, raft_get_commit_idx(r));
@@ -4069,7 +4069,7 @@ void TestRaft_quorum_msg_id_correctness(CuTest * tc)
     raft_set_commit_idx(r, 1);
 
     raft_periodic(r, 100);
-    raft_queue_read_request(r, quorum_msg_id_correctness_cb, &val);
+    raft_recv_read_request(r, quorum_msg_id_correctness_cb, &val);
     raft_periodic(r, 200);
 
     // Read request is pending as it requires two acks
@@ -4085,7 +4085,7 @@ void TestRaft_quorum_msg_id_correctness(CuTest * tc)
     raft_add_node(r, NULL, 3, 0);
     raft_add_node(r, NULL, 4, 0);
     raft_periodic(r, 100);
-    raft_queue_read_request(r, quorum_msg_id_correctness_cb, &val);
+    raft_recv_read_request(r, quorum_msg_id_correctness_cb, &val);
     raft_periodic(r, 200);
 
     // Read request is pending as it requires three acks
@@ -4719,7 +4719,7 @@ void TestRaft_flush_sends_msg(CuTest *tc)
     raft_set_current_term(r, 1);
     raft_become_leader(r);
 
-    raft_queue_read_request(r, NULL, NULL);
+    raft_recv_read_request(r, NULL, NULL);
 
     /* Verify that we send appendentries if the next msgid of a node equals
      * to the last read request's msgid. */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -3933,7 +3933,8 @@ void TestRaft_read_action_callback(
     /* election started, nothing should be read */
     raft_become_candidate(r);
     raft_periodic(r, 1);
-    CuAssertIntEquals(tc, 0, ra.calls);
+    CuAssertIntEquals(tc, 0, ra.last_cb_safe);
+    CuAssertIntEquals(tc, 1, ra.calls);
 
     /* we win, but for safety we will not process read requests
      * from past terms */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -463,7 +463,7 @@ void TestRaft_user_applylog_error_propogates_to_periodic(
 
     /* let time lapse */
     CuAssertIntEquals(tc, RAFT_ERR_SHUTDOWN, raft_periodic(r, 1));
-    CuAssertIntEquals(tc, 1, raft_get_last_applied_idx(r));
+    CuAssertIntEquals(tc, 0, raft_get_last_applied_idx(r));
 }
 
 void TestRaft_server_apply_entry_increments_last_applied_idx(CuTest* tc)

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -413,7 +413,7 @@ class Network(object):
             if lib.raft_is_leader(sv.raft):
                 msg_id = lib.raft_get_msg_id(sv.raft) + 1
                 arg = sv.id * net.rqm + msg_id
-                lib.raft_queue_read_request(sv.raft, sv.handle_read_queue, ffi.cast("void *", arg))
+                lib.raft_recv_read_request(sv.raft, sv.handle_read_queue, ffi.cast("void *", arg))
 
     def id2server(self, id):
         for server in self.servers:

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -666,7 +666,7 @@ class Network(object):
         e = server.recv_entry(ety)
         assert e == 0
 
-        lib.raft_set_commit_idx(server.raft, 1)
+        lib.raft_set_commit_idx(server.raft, 2)
         e = lib.raft_apply_all(server.raft)
         assert e == 0
 


### PR DESCRIPTION
- Renamed `raft_queue_read_request()` to `raft_recv_read_request()` just be in line with `recv_` family functions.
- `raft_recv_read_request()` will reject the request if the node is not the leader. Same as `raft_recv_entry()`.
- Added `last_applied_term` variable to track latest applied entry term. 
- Commit NOOP entry even if the term is 1. With this change, we avoid handling the special case of reading before commiting an entry. 
- Simplify checks inside `raft_process_read_queue()`. 