### PR TITLE
Throttle applying entries and processing read requests

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -55,13 +55,22 @@ struct raft_server {
     raft_state_e state;
 
     /* amount of time left till timeout */
-    int timeout_elapsed;
+    raft_time_t timeout_elapsed;
+
+    /* timestamp in milliseconds */
+    raft_time_t timestamp;
+
+    /* deadline to stop executing operations */
+    raft_time_t exec_deadline;
+
+    /* non-zero if there are ready to be executed operations. */
+    int pending_operations;
 
     raft_node_t** nodes;
     int num_nodes;
 
     /* timer interval to check if we still have quorum */
-    long quorum_timeout;
+    raft_time_t quorum_timeout;
 
     /* latest quorum id for the previous quorum_timeout round */
     raft_msg_id_t last_acked_msg_id;
@@ -104,9 +113,9 @@ struct raft_server {
     raft_read_request_t *read_queue_head;
     raft_read_request_t *read_queue_tail;
 
-    raft_node_id_t node_transferring_leader_to; // the node we are targeting for leadership
-    long transfer_leader_time; // how long we should wait for leadership transfer to take, before aborting
-    int sent_timeout_now; // if we've already sent a leadership transfer signal
+    raft_node_id_t node_transferring_leader_to; /* Leader transfer target.  */
+    raft_time_t transfer_leader_time;           /* Leader transfer timeout. */
+    int sent_timeout_now;     /* If we've already sent timeout_now message. */
 
 
     /* Index of the log entry that need to be written to the disk. Only useful
@@ -117,8 +126,8 @@ struct raft_server {
 
     /* Configuration parameters */
 
-    int election_timeout;  /* Timeout for a follower to start an election   */
-    int request_timeout;   /* Heartbeat timeout */
+    raft_time_t election_timeout; /* Timeout for a node to start an election */
+    raft_time_t request_timeout;  /* Heartbeat timeout */
     int nonblocking_apply; /* Apply entries even when snapshot is in progress */
     int auto_flush;        /* Automatically call raft_flush() */
     int log_enabled;       /* Enable library logs */
@@ -193,5 +202,9 @@ void raft_reset_transfer_leader(raft_server_t* me, int timed_out);
 raft_size_t raft_node_get_snapshot_offset(raft_node_t *me);
 
 void raft_node_set_snapshot_offset(raft_node_t *me, raft_size_t snapshot_offset);
+
+int raft_periodic_internal(raft_server_t *me, raft_time_t milliseconds);
+
+int raft_exec_operations(raft_server_t *me);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -35,4 +35,9 @@ typedef int raft_node_id_t;
  */
 typedef unsigned long raft_msg_id_t;
 
+/**
+ * Time type.
+ */
+typedef long long raft_time_t;
+
 #endif  /* RAFT_DEFS_H_ */

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -14,6 +14,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <stdarg.h>
+#include <limits.h>
 
 #include "raft.h"
 #include "raft_private.h"
@@ -112,6 +113,7 @@ raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
     me->election_timeout = 1000;
     me->node_transferring_leader_to = RAFT_NODE_ID_NONE;
     me->auto_flush = 1;
+    me->exec_deadline = LLONG_MAX;
 
     raft_update_quorum_meta(me, me->msg_id);
 
@@ -360,7 +362,7 @@ int raft_delete_entry_from_idx(raft_server_t* me, raft_index_t idx)
 int raft_election_start(raft_server_t* me, int skip_precandidate)
 {
     raft_log(me,
-        "election starting: %d %d, term: %ld ci: %ld",
+        "election starting: %d %lld, term: %ld ci: %ld",
         me->election_timeout_rand, me->timeout_elapsed, me->current_term,
         raft_get_current_idx(me));
 
@@ -549,9 +551,29 @@ static raft_msg_id_t quorum_msg_id(raft_server_t* me)
     return msg_ids[num_voters / 2];
 }
 
-int raft_periodic(raft_server_t* me, int msec_since_last_period)
+static raft_time_t raft_time_millis(raft_server_t *me)
 {
-    me->timeout_elapsed += msec_since_last_period;
+    return me->cb.timestamp ? me->cb.timestamp(me, me->udata) / 1000 : 0;
+}
+
+int raft_periodic(raft_server_t *me)
+{
+    return raft_periodic_internal(me, -1);
+}
+
+int raft_periodic_internal(raft_server_t *me, raft_time_t milliseconds)
+{
+    if (milliseconds < 0) {
+        raft_time_t timestamp = raft_time_millis(me);
+        assert(timestamp >= me->timestamp);
+
+        /* If this is the first call, previous timestamp will be zero. In this
+         * case, we just assume `0` millisecond has passed. */
+        milliseconds = me->timestamp == 0 ? 0 : timestamp - me->timestamp;
+        me->timestamp = timestamp;
+    }
+
+    me->timeout_elapsed += milliseconds;
 
     /* Only one voting node means it's safe for us to become the leader */
     if (raft_is_single_node_voting_cluster(me) && !raft_is_leader(me)) {
@@ -569,7 +591,7 @@ int raft_periodic(raft_server_t* me, int msec_since_last_period)
 
     /* needs to be outside state check, as can become a followr and still timeout */
     if (me->node_transferring_leader_to != RAFT_NODE_ID_NONE) {
-        me->transfer_leader_time -= msec_since_last_period;
+        me->transfer_leader_time -= milliseconds;
         if (me->transfer_leader_time < 0) {
             raft_reset_transfer_leader(me, 1);
         }
@@ -584,7 +606,7 @@ int raft_periodic(raft_server_t* me, int msec_since_last_period)
             raft_send_appendentries_all(me);
         }
 
-        me->quorum_timeout -= msec_since_last_period;
+        me->quorum_timeout -= milliseconds;
         if (me->quorum_timeout < 0)
         {
             /**
@@ -617,14 +639,7 @@ int raft_periodic(raft_server_t* me, int msec_since_last_period)
             return e;
     }
 
-    int e = raft_apply_all(me);
-    if (e != 0) {
-        return e;
-    }
-
-    raft_process_read_queue(me);
-
-    return 0;
+    return raft_exec_operations(me);
 }
 
 raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, raft_index_t etyidx)
@@ -1612,16 +1627,22 @@ int raft_msg_entry_response_committed(raft_server_t* me,
     return r->idx <= raft_get_commit_idx(me);
 }
 
-int raft_apply_all(raft_server_t* me)
+int raft_apply_all(raft_server_t *me)
 {
-    if (!raft_is_apply_allowed(me))
+    if (!raft_is_apply_allowed(me)) {
         return 0;
+    }
 
-    while (me->commit_idx > me->last_applied_idx)
-    {
+    while (me->commit_idx > me->last_applied_idx) {
+        if (raft_time_millis(me) > me->exec_deadline) {
+            me->pending_operations = 1;
+            return 0;
+        }
+
         int e = raft_apply_entry(me);
-        if (0 != e)
+        if (e != 0) {
             return e;
+        }
     }
 
     return 0;
@@ -1927,10 +1948,10 @@ static void pop_read_queue(raft_server_t *me, int can_read)
     raft_free(p);
 }
 
-void raft_process_read_queue(raft_server_t* me)
+int raft_process_read_queue(raft_server_t *me)
 {
     if (!me->read_queue_head) {
-        return;
+        return 0;
     }
 
     /* If not the leader, we drop all queued read requests */
@@ -1938,6 +1959,7 @@ void raft_process_read_queue(raft_server_t* me)
         while (me->read_queue_head) {
             pop_read_queue(me, 0);
         }
+        return 0;
     }
 
     /* As a leader we can process requests that fulfill these conditions:
@@ -1946,7 +1968,7 @@ void raft_process_read_queue(raft_server_t* me)
      * 3) State machine has advanced enough.
      */
     if (me->last_applied_term < me->current_term) {
-        return;
+        return 0;
     }
 
     raft_msg_id_t last_acked_msgid = quorum_msg_id(me);
@@ -1954,8 +1976,16 @@ void raft_process_read_queue(raft_server_t* me)
     while (me->read_queue_head &&
            me->read_queue_head->msg_id <= last_acked_msgid &&
            me->read_queue_head->read_idx <= me->last_applied_idx) {
+
+        if (raft_time_millis(me) > me->exec_deadline) {
+            me->pending_operations = 1;
+            return 0;
+        }
+
         pop_read_queue(me, 1);
     }
+
+    return 0;
 }
 
 int raft_transfer_leader(raft_server_t* me, raft_node_id_t node_id, long timeout)
@@ -2124,14 +2154,8 @@ int raft_flush(raft_server_t* me, raft_index_t sync_index)
         raft_send_appendentries(me, me->nodes[i]);
     }
 
-    int e = raft_apply_all(me);
-    if (e != 0) {
-        return e;
-    }
-
 out:
-    raft_process_read_queue(me);
-    return 0;
+    return raft_exec_operations(me);
 }
 
 int raft_config(raft_server_t *me, int set, raft_config_e config, ...)
@@ -2144,18 +2168,18 @@ int raft_config(raft_server_t *me, int set, raft_config_e config, ...)
     switch (config) {
         case RAFT_CONFIG_ELECTION_TIMEOUT:
             if (set) {
-                me->election_timeout = va_arg(va, int);
+                me->election_timeout = va_arg(va, raft_time_t);
                 raft_update_quorum_meta(me, me->last_acked_msg_id);
                 raft_randomize_election_timeout(me);
             } else {
-                *(va_arg(va, int*)) = me->election_timeout;
+                *(va_arg(va, raft_time_t*)) = me->election_timeout;
             }
             break;
         case RAFT_CONFIG_REQUEST_TIMEOUT:
             if (set) {
-                me->request_timeout = va_arg(va, int);
+                me->request_timeout = va_arg(va, raft_time_t);
             } else {
-                *(va_arg(va, int*)) = me->request_timeout;
+                *(va_arg(va, raft_time_t*)) = me->request_timeout;
             }
             break;
         case RAFT_CONFIG_AUTO_FLUSH:
@@ -2195,3 +2219,23 @@ int raft_config(raft_server_t *me, int set, raft_config_e config, ...)
     return ret;
 }
 
+int raft_pending_operations(raft_server_t *me)
+{
+    return me->pending_operations;
+}
+
+int raft_exec_operations(raft_server_t *me)
+{
+    me->pending_operations = 0;
+    me->exec_deadline = raft_time_millis(me) + me->request_timeout;
+
+    int e = raft_apply_all(me);
+    if (e == 0) {
+        e = raft_process_read_queue(me);
+    }
+
+    /* Set deadline to MAX to prevent raft_apply_all() to return early if this
+     * function is called manually or inside raft_begin_snapshot() */
+    me->exec_deadline = LLONG_MAX;
+    return e;
+}

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -32,7 +32,7 @@ int raft_get_num_voting_nodes(raft_server_t* me)
     return num;
 }
 
-int raft_get_timeout_elapsed(raft_server_t* me)
+raft_time_t raft_get_timeout_elapsed(raft_server_t* me)
 {
     return me->timeout_elapsed;
 }

--- a/tests/test_scenario.c
+++ b/tests/test_scenario.c
@@ -60,7 +60,7 @@ void TestRaft_scenario_leader_appears(CuTest * tc)
     }
 
     /* NOTE: important for 1st node to send vote request before others */
-    raft_periodic(r[0], 1000);
+    raft_periodic_internal(r[0], 1000);
 
     for (i = 0; i < 20; i++)
     {
@@ -74,7 +74,7 @@ one_more_time:
                 goto one_more_time;
 
         for (j = 0; j < 3; j++)
-            raft_periodic(r[j], 100);
+            raft_periodic_internal(r[j], 100);
     }
 
     int leaders = 0;

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -353,7 +353,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     CuAssertIntEquals(tc, 2, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 2, raft_get_last_applied_idx(r));
     CuAssertIntEquals(tc, 1, raft_get_last_log_term(r));
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    CuAssertIntEquals(tc, 0, raft_periodic_internal(r, 1000));
 
 
     /* the above test returns correct term as didn't snapshot all entries, makes sure works if we snapshot all */
@@ -363,7 +363,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     raft_recv_entry(r, ety, &cr);
 
     raft_set_commit_idx(r, 4);
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    CuAssertIntEquals(tc, 0, raft_periodic_internal(r, 1000));
     CuAssertIntEquals(tc, 2, raft_get_log_count(r));
     CuAssertIntEquals(tc, 4, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 3, r->log_impl->first_idx(r->log));
@@ -416,7 +416,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted2(CuTest * tc)
     CuAssertIntEquals(tc, 1, raft_get_log_count(r));
     CuAssertIntEquals(tc, 2, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 2, raft_get_last_applied_idx(r));
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    CuAssertIntEquals(tc, 0, raft_periodic_internal(r, 1000));
 }
 
 void TestRaft_joinee_needs_to_get_snapshot(CuTest * tc)
@@ -479,7 +479,7 @@ void TestRaft_follower_load_from_snapshot(CuTest * tc)
     CuAssertIntEquals(tc, 5, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 5, raft_get_last_applied_idx(r));
 
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    CuAssertIntEquals(tc, 0, raft_periodic_internal(r, 1000));
 
     /* current idx means snapshot was unnecessary */
     ety = __MAKE_ENTRY(2, 1, "entry");

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -925,7 +925,7 @@ class RaftServer(object):
         if self.network.random.randint(1, 100000) < self.network.compaction_rate:
             self.do_compaction()
 
-        e = lib.raft_periodic(self.raft, msec)
+        e = lib.raft_periodic_internal(self.raft, msec)
         if lib.RAFT_ERR_SHUTDOWN == e:
             self.shutdown()
 
@@ -1091,6 +1091,9 @@ class RaftServer(object):
         logger.debug('{} loading snapshot'.format(self))
 
         leader = find_leader()
+        if not leader:
+            return 0
+
         leader_snapshot = leader.snapshot_buf
 
         # Copy received snapshot as our snapshot and clear the temp buf


### PR DESCRIPTION
We apply batch of entries or process batch of read requests in a loop. If loop takes longer than election timeout, leader can lose leadership. To optimize that, adding support to return early if we spend more time than "request timeout" while applying entries. By doing that, leader can apply entries and still be able to send heartbeat messages/recieve heartbeat responses without losing leadership. 

- Added a callback to retrieve timestamp: `raft_timestamp_f`
- Previously, `raft_periodic()` used to get "time passed since the last periodic call" as a parameter. This is useful for deterministic tests. I renamed this function as `raft_periodic_internal()` which still gets time passed as a parameter. 
- As we now have `timestamp` callback, new `raft_periodic()` does not need `time passed` parameter.  
- After `raft_flush()` call, `raft_pending_operations()` returns 1 if we returned early while applying entries/processing read requests. In that case, application should call `raft_flush()` later to continue executing operations.

