### PR TITLE
Revert election and request timeout config type

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1660,23 +1660,22 @@ raft_index_t raft_get_index_to_sync(raft_server_t *me);
  * disable-apply      : Skip applying entries. Useful for testing.
  *
  *
- * | Enum                          | Type         | Valid values | Default     |
- * | ----------------------------- | ------------ | ------------ | ----------- |
- * | RAFT_CONFIG_ELECTION_TIMEOUT  | raft_time_t  | > 0          | 1000 millis |
- * | RAFT_CONFIG_REQUEST_TIMEOUT   | raft_time_t  | > 0          | 200 millis  |
- * | RAFT_CONFIG_AUTO_FLUSH        | int          | 0 or 1       | 0           |
- * | RAFT_CONFIG_LOG_ENABLED       | int          | 0 or 1       | 0           |
- * | RAFT_CONFIG_NONBLOCKING_APPLY | int          | 0 or 1       | 0           |
- * | RAFT_CONFIG_DISABLE_APPLY     | int          | 0 or 1       | 0           |
+ * | Enum                          | Type | Valid values     | Default value   |
+ * | ----------------------------- | ---- | ---------------- | --------------- |
+ * | RAFT_CONFIG_ELECTION_TIMEOUT  | int  | Positive integer | 1000 millis     |
+ * | RAFT_CONFIG_REQUEST_TIMEOUT   | int  | Positive integer | 200 millis      |
+ * | RAFT_CONFIG_AUTO_FLUSH        | int  | 0 or 1           | 0               |
+ * | RAFT_CONFIG_LOG_ENABLED       | int  | 0 or 1           | 0               |
+ * | RAFT_CONFIG_NONBLOCKING_APPLY | int  | 0 or 1           | 0               |
+ * | RAFT_CONFIG_DISABLE_APPLY     | int  | 0 or 1           | 0               |
  *
  * Example:
  *
  * - Set
- *      raft_time_t timeout = 4000;
- *      raft_config(raft, 1, RAFT_CONFIG_ELECTION_TIMEOUT, timeout);
+ *      raft_config(raft, 1, RAFT_CONFIG_ELECTION_TIMEOUT, 4000);
  *
  * - Get
- *      raft_time_t election_timeout;
+ *      int election_timeout;
  *      raft_config(raft, 0, RAFT_CONFIG_ELECTION_TIMEOUT, &election_timeout);
  *
  * @param set     1 to set the value, 0 to get the current value.

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -2172,18 +2172,18 @@ int raft_config(raft_server_t *me, int set, raft_config_e config, ...)
     switch (config) {
         case RAFT_CONFIG_ELECTION_TIMEOUT:
             if (set) {
-                me->election_timeout = va_arg(va, raft_time_t);
+                me->election_timeout = va_arg(va, int);
                 raft_update_quorum_meta(me, me->last_acked_msg_id);
                 raft_randomize_election_timeout(me);
             } else {
-                *(va_arg(va, raft_time_t*)) = me->election_timeout;
+                *(va_arg(va, int*)) = (int) me->election_timeout;
             }
             break;
         case RAFT_CONFIG_REQUEST_TIMEOUT:
             if (set) {
-                me->request_timeout = va_arg(va, raft_time_t);
+                me->request_timeout = va_arg(va, int);
             } else {
-                *(va_arg(va, raft_time_t*)) = me->request_timeout;
+                *(va_arg(va, int*)) = (int) me->request_timeout;
             }
             break;
         case RAFT_CONFIG_AUTO_FLUSH:

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -265,7 +265,7 @@ void TestRaft_server_starts_with_election_timeout_of_1000ms(CuTest * tc)
 {
     void *r = raft_new();
 
-    raft_time_t election_timeout;
+    int election_timeout;
     raft_config(r, 0, RAFT_CONFIG_ELECTION_TIMEOUT, &election_timeout);
 
     CuAssertTrue(tc, 1000 == election_timeout);
@@ -275,7 +275,7 @@ void TestRaft_server_starts_with_request_timeout_of_200ms(CuTest * tc)
 {
     void *r = raft_new();
 
-    raft_time_t request_timeout;
+    int request_timeout;
     raft_config(r, 0, RAFT_CONFIG_REQUEST_TIMEOUT, &request_timeout);
 
     CuAssertTrue(tc, 200 == request_timeout);
@@ -4195,7 +4195,7 @@ void TestRaft_leader_steps_down_if_there_is_no_quorum(CuTest * tc)
     raft_config(r, 1, RAFT_CONFIG_REQUEST_TIMEOUT, 1000);
 
     // Quorum timeout is twice the election timeout.
-    raft_time_t election_timeout;
+    int election_timeout;
     raft_config(r, 0, RAFT_CONFIG_ELECTION_TIMEOUT, &election_timeout);
 
     raft_time_t quorum_timeout = election_timeout * 2;
@@ -4220,7 +4220,7 @@ void TestRaft_leader_steps_down_if_there_is_no_quorum(CuTest * tc)
 
     // Trigger new round of append entries
 
-    raft_time_t request_timeout;
+    int request_timeout;
     raft_config(r, 0, RAFT_CONFIG_REQUEST_TIMEOUT, &request_timeout);
 
     raft_periodic_internal(r, request_timeout + 1);
@@ -4602,7 +4602,7 @@ void Test_transfer_automatic(CuTest *tc)
 void TestRaft_config(CuTest *tc)
 {
     int val;
-    raft_time_t time;
+    int time;
     raft_server_t *r = raft_new();
 
     CuAssertIntEquals(tc, 0, raft_config(r, 1, RAFT_CONFIG_ELECTION_TIMEOUT, 566));
@@ -4795,9 +4795,7 @@ void TestRaft_apply_entry_timeout(CuTest *tc)
     raft_add_node(r, NULL, 1, 1);
     raft_set_callbacks(r, &funcs, &ts);
     raft_set_current_term(r, 1);
-
-    raft_time_t timeout = 100;
-    raft_config(r, 1, RAFT_CONFIG_REQUEST_TIMEOUT, timeout);
+    raft_config(r, 1, RAFT_CONFIG_REQUEST_TIMEOUT, 100);
 
     __RAFT_APPEND_ENTRIES_SEQ_ID(r, 21, 0, 1, "");
     raft_set_commit_idx(r, 21);
@@ -4840,9 +4838,7 @@ void TestRaft_apply_read_request_timeout(CuTest *tc)
     raft_set_commit_idx(r, 1);
     raft_apply_all(r);
     raft_config(r, 1, RAFT_CONFIG_AUTO_FLUSH, 0);
-
-    raft_time_t timeout = 100;
-    raft_config(r, 1, RAFT_CONFIG_REQUEST_TIMEOUT, timeout);
+    raft_config(r, 1, RAFT_CONFIG_REQUEST_TIMEOUT, 100);
 
     int remaining = 20;
     for (int i = 0; i < remaining; i++) {


### PR DESCRIPTION
For `election_timeout` and `request_timeout`, we've changed `raft_config()` parameter type to `raft_time_t` in https://github.com/RedisLabs/raft/pull/106. 

As `raft_config()`  is a variadic function, it's better to accept function parameters as `int` for type safety (We can pass decimal integer constants directly). Timeout values can fit into an `int`. So, I've changed config function parameter type back to `int`. `raft_config()` API will use `int` but internally, we'll keep them as `raft_time_t` to make it compatible with other timestamp variables. 