### PR TITLE
Do not execute operations in periodic when auto_flush is off

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -645,7 +645,11 @@ int raft_periodic_internal(raft_server_t *me,
             return e;
     }
 
-    return raft_exec_operations(me);
+    if (me->auto_flush) {
+        return raft_exec_operations(me);
+    }
+
+    return 0;
 }
 
 raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, raft_index_t etyidx)


### PR DESCRIPTION
Do not execute operations in periodic() when auto_flush is off

Introduced `auto_flush` config in https://github.com/RedisLabs/raft/pull/81. If `auto_flush` is off, application is supposed to call `raft_flush()` manually. This function increments commit index, applies entries and sends appendentries requests.

Currently, we execute operations in `raft_periodic()` and `raft_flush()` both. When `auto_flush` is off, it makes sense to leave execution to `raft_flush()`  to do it in a single place.