### PR TITLE
Add #include stddef.h to raft.h for size_t

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -10,6 +10,8 @@
 #ifndef RAFT_H_
 #define RAFT_H_
 
+#include <stddef.h>
+
 #include "raft_types.h"
 
 typedef enum {


### PR DESCRIPTION
Add `#include stddef.h` to raft.h for size_t

`raft.h` was using `size_t` without including `stddef.h`. Adding that include introduces another problem. Looks like cffi cannot parse standard library headers. So, I added another step in `cffi` build to strip C standard library headers from these include files.
