### PR TITLE
Delete leftover variable in struct raft_read_request_t

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -16,7 +16,6 @@ struct raft_log_impl;
 
 typedef struct raft_read_request {
     raft_index_t read_idx;
-    raft_term_t read_term;
 
     raft_msg_id_t msg_id;
     raft_read_request_callback_f cb;

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1921,7 +1921,6 @@ int raft_recv_read_request(raft_server_t* me, raft_read_request_callback_f cb, v
     raft_read_request_t *req = raft_malloc(sizeof(*req));
 
     req->read_idx = raft_get_current_idx(me);
-    req->read_term = me->current_term;
     req->msg_id = ++me->msg_id;
     req->cb = cb;
     req->cb_arg = cb_arg;


### PR DESCRIPTION
Delete leftover variable in struct raft_read_request_t

It is unused after https://github.com/RedisLabs/raft/pull/105