### PR TITLE
Add raft_persist_metadata callback

### DIFF
--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -49,17 +49,20 @@ int raft_get_voted_for(raft_server_t* me)
 
 int raft_set_current_term(raft_server_t* me, const raft_term_t term)
 {
-    if (me->current_term < term)
-    {
-        if (me->cb.persist_term)
-        {
-            int e = me->cb.persist_term(me, me->udata, term, RAFT_NODE_ID_NONE);
-            if (0 != e)
-                return e;
-        }
-        me->current_term = term;
-        me->voted_for = RAFT_NODE_ID_NONE;
+    if (me->current_term >= term) {
+        return 0;
     }
+
+    if (me->cb.persist_metadata) {
+        int e = me->cb.persist_metadata(me, me->udata, term, RAFT_NODE_ID_NONE);
+        if (e != 0) {
+            return e;
+        }
+    }
+
+    me->current_term = term;
+    me->voted_for = RAFT_NODE_ID_NONE;
+
     return 0;
 }
 

--- a/tests/test_scenario.c
+++ b/tests/test_scenario.c
@@ -12,7 +12,7 @@
 #include "mock_send_functions.h"
 
 static int __raft_persist_metadata(
-    raft_server_t* raft,
+    raft_server_t *raft,
     void *udata,
     raft_term_t term,
     raft_node_id_t vote

--- a/tests/test_scenario.c
+++ b/tests/test_scenario.c
@@ -11,20 +11,11 @@
 #include "raft_private.h"
 #include "mock_send_functions.h"
 
-static int __raft_persist_term(
+static int __raft_persist_metadata(
     raft_server_t* raft,
     void *udata,
     raft_term_t term,
-    int vote
-    )
-{
-    return 0;
-}
-
-static int __raft_persist_vote(
-    raft_server_t* raft,
-    void *udata,
-    int vote
+    raft_node_id_t vote
     )
 {
     return 0;
@@ -53,8 +44,7 @@ void TestRaft_scenario_leader_appears(CuTest * tc)
                            &((raft_cbs_t) {
                                  .send_requestvote = sender_requestvote,
                                  .send_appendentries = sender_appendentries,
-                                 .persist_term = __raft_persist_term,
-                                 .persist_vote = __raft_persist_vote,
+                                 .persist_metadata = __raft_persist_metadata,
                                  .log = NULL
                              }), sender[j]);
     }

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -433,7 +433,7 @@ void TestRaft_user_applylog_error_propogates_to_periodic(
     CuTest* tc)
 {
     raft_cbs_t funcs = {
-            .persist_metadata = __raft_persist_metadata,
+        .persist_metadata = __raft_persist_metadata,
         .applylog = __raft_applylog_shutdown,
     };
 

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -15,20 +15,11 @@
 
 // TODO: leader doesn't timeout and cause election
 
-static int __raft_persist_term(
+static int __raft_persist_metadata(
     raft_server_t* raft,
     void *udata,
     raft_term_t term,
-    int vote
-    )
-{
-    return 0;
-}
-
-static int __raft_persist_vote(
-    raft_server_t* raft,
-    void *udata,
-    int vote
+    raft_node_id_t vote
     )
 {
     return 0;
@@ -97,8 +88,7 @@ static int __raft_node_has_sufficient_logs(
 }
 
 raft_cbs_t generic_funcs = {
-    .persist_term = __raft_persist_term,
-    .persist_vote = __raft_persist_vote,
+    .persist_metadata = __raft_persist_metadata,
 };
 
 static int max_election_timeout(int election_timeout)
@@ -415,7 +405,7 @@ void TestRaft_server_increment_lastApplied_when_lastApplied_lt_commitidx(
     CuTest* tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .applylog = __raft_applylog,
     };
 
@@ -443,7 +433,7 @@ void TestRaft_user_applylog_error_propogates_to_periodic(
     CuTest* tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+            .persist_metadata = __raft_persist_metadata,
         .applylog = __raft_applylog_shutdown,
     };
 
@@ -501,8 +491,7 @@ void TestRaft_server_periodic_elapses_election_timeout(CuTest * tc)
 void TestRaft_server_election_timeout_does_not_promote_us_to_leader_if_there_is_are_more_than_1_nodes(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
     };
 
@@ -668,8 +657,7 @@ void TestRaft_server_recv_requestvote_response_dont_increase_votes_for_me_when_n
     )
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -694,8 +682,7 @@ void TestRaft_server_recv_requestvote_response_dont_increase_votes_for_me_when_t
     )
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -719,8 +706,7 @@ void TestRaft_server_recv_requestvote_response_increase_votes_for_me(
     )
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = __raft_send_appendentries,
     };
@@ -753,8 +739,7 @@ void TestRaft_server_recv_requestvote_response_must_be_candidate_to_receive(
     )
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries = __raft_send_appendentries,
     };
 
@@ -782,8 +767,7 @@ void TestRaft_server_recv_requestvote_reply_false_if_term_less_than_current_term
     )
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -809,8 +793,7 @@ void TestRaft_leader_recv_requestvote_does_not_step_down(
     )
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries = __raft_send_appendentries,
     };
 
@@ -843,8 +826,7 @@ void TestRaft_server_recv_requestvote_reply_true_if_term_greater_than_or_equal_t
     raft_requestvote_resp_t rvr;
 
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -871,8 +853,7 @@ void TestRaft_server_recv_requestvote_reset_timeout(
     raft_requestvote_resp_t rvr;
 
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -898,8 +879,7 @@ void TestRaft_server_recv_requestvote_candidate_step_down_if_term_is_higher_than
     )
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
     };
 
@@ -930,8 +910,7 @@ void TestRaft_server_recv_requestvote_depends_on_candidate_id(
     )
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
     };
 
@@ -964,8 +943,7 @@ void TestRaft_server_recv_requestvote_dont_grant_vote_if_we_didnt_vote_for_this_
     )
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1113,8 +1091,7 @@ void TestRaft_follower_becomes_follower_is_follower(CuTest * tc)
 void TestRaft_follower_becomes_follower_does_not_clear_voted_for(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1133,7 +1110,7 @@ void TestRaft_follower_recv_appendentries_reply_false_if_term_less_than_currentt
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1162,7 +1139,7 @@ void TestRaft_follower_recv_appendentries_reply_false_if_term_less_than_currentt
 void TestRaft_follower_recv_appendentries_does_not_need_node(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1182,7 +1159,7 @@ void TestRaft_follower_recv_appendentries_updates_currentterm_if_term_gt_current
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1219,7 +1196,7 @@ void TestRaft_follower_recv_appendentries_does_not_log_if_no_entries_are_specifi
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1251,7 +1228,7 @@ void TestRaft_follower_recv_appendentries_does_not_log_if_no_entries_are_specifi
 void TestRaft_follower_recv_appendentries_increases_log(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1293,7 +1270,7 @@ void TestRaft_follower_recv_appendentries_reply_false_if_doesnt_have_log_at_prev
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1362,7 +1339,7 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1406,7 +1383,7 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1447,7 +1424,7 @@ void TestRaft_follower_recv_appendentries_delete_entries_if_conflict_with_new_en
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1488,7 +1465,7 @@ void TestRaft_follower_recv_appendentries_add_new_entries_not_already_in_log(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1518,7 +1495,7 @@ void TestRaft_follower_recv_appendentries_does_not_add_dupe_entries_already_in_l
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1596,7 +1573,7 @@ void TestRaft_follower_recv_appendentries_partial_failures(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term
+        .persist_metadata = __raft_persist_metadata,
     };
     raft_log_cbs_t log_funcs = {
         .log_offer = __raft_log_offer_error,
@@ -1670,7 +1647,7 @@ void TestRaft_follower_recv_appendentries_set_commitidx_to_prevLogIdx(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1718,7 +1695,7 @@ void TestRaft_follower_recv_appendentries_set_commitidx_to_LeaderCommit(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1767,7 +1744,7 @@ void TestRaft_follower_recv_appendentries_failure_includes_current_idx(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1805,8 +1782,7 @@ void TestRaft_follower_becomes_precandidate_when_election_timeout_occurs(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
     };
 
@@ -1834,8 +1810,7 @@ void TestRaft_follower_dont_grant_vote_if_candidate_has_a_less_complete_log(
     raft_requestvote_resp_t rvr;
 
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1877,7 +1852,7 @@ void TestRaft_follower_recv_appendentries_heartbeat_does_not_overwrite_logs(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1928,7 +1903,7 @@ void TestRaft_follower_recv_appendentries_does_not_deleted_commited_entries(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -1995,8 +1970,7 @@ void TestRaft_follower_recv_appendentries_does_not_deleted_commited_entries(
 void TestRaft_candidate_becomes_candidate_is_candidate(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -2010,8 +1984,7 @@ void TestRaft_candidate_becomes_candidate_is_candidate(CuTest * tc)
 void TestRaft_follower_becoming_candidate_increments_current_term(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -2027,8 +2000,7 @@ void TestRaft_follower_becoming_candidate_increments_current_term(CuTest * tc)
 void TestRaft_follower_becoming_candidate_votes_for_self(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -2045,8 +2017,7 @@ void TestRaft_follower_becoming_candidate_votes_for_self(CuTest * tc)
 void TestRaft_follower_becoming_candidate_resets_election_timeout(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -2069,8 +2040,7 @@ void TestRaft_follower_recv_appendentries_resets_election_timeout(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -2096,8 +2066,7 @@ void TestRaft_follower_becoming_candidate_requests_votes_from_other_servers(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = sender_requestvote,
     };
     raft_requestvote_req_t * rv;
@@ -2131,8 +2100,7 @@ void TestRaft_candidate_election_timeout_and_no_leader_results_in_new_election(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
     };
 
@@ -2179,8 +2147,7 @@ void TestRaft_candidate_receives_majority_of_votes_becomes_leader(CuTest * tc)
     raft_requestvote_resp_t vr;
 
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = __raft_send_appendentries,
     };
@@ -2221,8 +2188,7 @@ void TestRaft_candidate_will_not_respond_to_voterequest_if_it_has_already_voted(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -2249,8 +2215,7 @@ void TestRaft_candidate_requestvote_includes_logidx(CuTest * tc)
     raft_cbs_t funcs = {
         .send_requestvote = sender_requestvote,
         .log              = NULL,
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *sender = sender_new(NULL);
@@ -2279,8 +2244,7 @@ void TestRaft_candidate_recv_requestvote_response_becomes_follower_if_current_te
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -2312,8 +2276,7 @@ void TestRaft_candidate_recv_appendentries_frm_leader_results_in_follower(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -2348,8 +2311,7 @@ void TestRaft_candidate_recv_appendentries_from_same_term_results_in_step_down(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
     };
 
@@ -2402,8 +2364,7 @@ void TestRaft_leader_becomes_leader_is_leader(CuTest * tc)
 void TestRaft_leader_becomes_leader_does_not_clear_voted_for(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
-        .persist_vote = __raft_persist_vote,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -2790,7 +2751,7 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_when_majori
 {
     raft_cbs_t funcs = {
         .applylog = __raft_applylog,
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
@@ -2858,7 +2819,7 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_for_nod
 {
     raft_cbs_t funcs = {
         .applylog = __raft_applylog,
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
         .log                         = NULL
     };
@@ -2906,7 +2867,7 @@ void TestRaft_leader_recv_appendentries_response_fail_set_has_sufficient_logs_fo
 {
     raft_cbs_t funcs = {
             .applylog = __raft_applylog,
-            .persist_term = __raft_persist_term,
+            .persist_metadata = __raft_persist_metadata,
             .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
             .log                         = NULL
     };
@@ -2949,7 +2910,7 @@ void TestRaft_leader_recv_appendentries_response_increase_commit_idx_using_votin
 {
     raft_cbs_t funcs = {
         .applylog = __raft_applylog,
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
@@ -2995,7 +2956,7 @@ void TestRaft_leader_recv_appendentries_response_duplicate_does_not_decrement_ma
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
@@ -3048,7 +3009,7 @@ void TestRaft_leader_recv_appendentries_response_do_not_increase_commit_idx_beca
 {
     raft_cbs_t funcs = {
         .applylog = __raft_applylog,
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
@@ -3128,7 +3089,7 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
@@ -3189,7 +3150,7 @@ void TestRaft_leader_recv_appendentries_response_jumps_to_lower_next_idx(
 void TestRaft_leader_recv_appendentries_response_retry_only_if_leader(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
     };
 
@@ -3231,7 +3192,7 @@ void TestRaft_leader_recv_appendentries_response_retry_only_if_leader(CuTest * t
 void TestRaft_leader_recv_appendentries_response_without_node_fails(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -3276,7 +3237,7 @@ void TestRaft_leader_recv_entry_resets_election_timeout(
 void TestRaft_leader_recv_entry_is_committed_returns_0_if_not_committed(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries = __raft_send_appendentries,
     };
 
@@ -3305,7 +3266,7 @@ void TestRaft_leader_recv_entry_is_committed_returns_0_if_not_committed(CuTest *
 void TestRaft_leader_recv_entry_is_committed_returns_neg_1_if_invalidated(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries = __raft_send_appendentries,
     };
 
@@ -3351,7 +3312,7 @@ void TestRaft_leader_recv_entry_is_committed_returns_neg_1_if_invalidated(CuTest
 void TestRaft_leader_recv_entry_fails_if_prevlogidx_less_than_commit(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries = __raft_send_appendentries,
     };
 
@@ -3405,7 +3366,7 @@ void TestRaft_leader_recv_entry_does_not_send_new_appendentries_to_slow_nodes(Cu
     raft_add_node(r, NULL, 2, 0);
 
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
         .backpressure = backpressure
     };
@@ -3440,7 +3401,7 @@ void TestRaft_leader_recv_appendentries_response_failure_does_not_set_node_nexti
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
@@ -3480,7 +3441,7 @@ void TestRaft_leader_recv_appendentries_response_increment_idx_of_node(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
@@ -3511,7 +3472,7 @@ void TestRaft_leader_recv_appendentries_response_drop_message_if_term_is_old(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries          = sender_appendentries,
         .log                         = NULL
     };
@@ -3573,7 +3534,7 @@ void TestRaft_leader_recv_appendentries_steps_down_if_newer(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -3608,7 +3569,7 @@ void TestRaft_leader_recv_appendentries_steps_down_if_newer_term(
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();
@@ -3678,8 +3639,7 @@ void T_estRaft_leader_sends_appendentries_when_receive_entry_msg(CuTest * tc)
 void TestRaft_leader_recv_requestvote_responds_without_granting(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_vote = __raft_persist_vote,
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = sender_appendentries,
     };
@@ -3731,8 +3691,7 @@ void TestRaft_leader_recv_requestvote_responds_without_granting(CuTest * tc)
 void T_estRaft_leader_recv_requestvote_responds_with_granting_if_term_is_higher(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_vote = __raft_persist_vote,
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_requestvote = __raft_send_requestvote,
         .send_appendentries = sender_appendentries,
     };
@@ -3771,7 +3730,7 @@ void TestRaft_leader_recv_entry_add_nonvoting_node_remove_and_revert(CuTest *tc)
 {
     raft_cbs_t funcs = {
             .applylog = __raft_applylog,
-            .persist_term = __raft_persist_term,
+            .persist_metadata = __raft_persist_metadata,
             .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
             .get_node_id = __raft_get_node_id
     };
@@ -3819,7 +3778,7 @@ void TestRaft_leader_recv_appendentries_response_set_has_sufficient_logs_after_v
 {
     raft_cbs_t funcs = {
         .applylog = __raft_applylog,
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .node_has_sufficient_logs = __raft_node_has_sufficient_logs,
         .get_node_id = __raft_get_node_id};
     raft_log_cbs_t log_funcs = {
@@ -4034,8 +3993,7 @@ void TestRaft_server_recv_requestvote_with_transfer_node(CuTest * tc)
 void TestRaft_targeted_node_becomes_candidate_when_before_real_timeout_occurs(CuTest * tc)
 {
     raft_cbs_t funcs = {
-            .persist_term = __raft_persist_term,
-            .persist_vote = __raft_persist_vote,
+            .persist_metadata = __raft_persist_metadata,
             .send_requestvote = __raft_send_requestvote,
     };
 
@@ -4880,6 +4838,45 @@ void TestRaft_apply_read_request_timeout(CuTest *tc)
     CuAssertIntEquals(tc, 0, remaining);
 }
 
+
+static raft_term_t test_term;
+static raft_node_id_t test_vote;
+
+int persist_metadata(raft_server_t* raft, void *udata, raft_term_t term,
+                     raft_node_id_t vote)
+{
+    test_term = term;
+    test_vote = vote;
+
+    return 0;
+}
+
+void TestRaft_test_metadata_on_restart(CuTest *tc)
+{
+    raft_cbs_t funcs = {
+            .persist_metadata = persist_metadata,
+    };
+
+    raft_server_t *r = raft_new();
+    raft_set_callbacks(r, &funcs, NULL);
+    raft_add_node(r, NULL, 10, 1);
+
+    CuAssertIntEquals(tc, 0, raft_restore_metadata(r, test_term, test_vote));
+
+    raft_become_candidate(r);
+    raft_become_leader(r);
+
+    raft_clear(r);
+    raft_destroy(r);
+
+    r = raft_new();
+    raft_add_node(r, NULL, 10, 1);
+
+    CuAssertIntEquals(tc, 0, raft_restore_metadata(r, test_term, test_vote));
+    CuAssertIntEquals(tc, 1, raft_get_current_term(r));
+    CuAssertIntEquals(tc, 10, raft_get_voted_for(r));
+}
+
 int main(void)
 {
     CuString *output = CuStringNew();
@@ -5030,6 +5027,7 @@ int main(void)
     SUITE_ADD_TEST(suite, TestRaft_recv_appendentries_does_not_change_next_idx);
     SUITE_ADD_TEST(suite, TestRaft_apply_entry_timeout);
     SUITE_ADD_TEST(suite, TestRaft_apply_read_request_timeout);
+    SUITE_ADD_TEST(suite, TestRaft_test_metadata_on_restart);
     CuSuiteRun(suite);
     CuSuiteDetails(suite, output);
     printf("%s\n", output->buffer);

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -13,20 +13,11 @@
 
 #include "helpers.h"
 
-static int __raft_persist_term(
+static int __raft_persist_metadata(
     raft_server_t* raft,
     void *udata,
     raft_term_t term,
-    int vote
-    )
-{
-    return 0;
-}
-
-static int __raft_persist_vote(
-    raft_server_t* raft,
-    void *udata,
-    int vote
+    raft_node_id_t vote
     )
 {
     return 0;
@@ -186,11 +177,6 @@ static int test_load_snapshot(raft_server_t* raft,
     return 0;
 }
 
-/* static raft_cbs_t generic_funcs = { */
-/*     .persist_term = __raft_persist_term, */
-/*     .persist_vote = __raft_persist_vote, */
-/* }; */
-
 static int max_election_timeout(int election_timeout)
 {
 	return 2 * election_timeout;
@@ -315,7 +301,7 @@ void TestRaft_leader_snapshot_begin_fails_if_less_than_2_logs_to_compact(CuTest 
 void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries = __raft_send_appendentries,
     };
 
@@ -380,7 +366,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
 void TestRaft_leader_snapshot_end_succeeds_if_log_compacted2(CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
         .send_appendentries = __raft_send_appendentries,
     };
 
@@ -712,7 +698,7 @@ void TestRaft_follower_recv_appendentries_is_successful_when_previous_log_idx_eq
     CuTest * tc)
 {
     raft_cbs_t funcs = {
-        .persist_term = __raft_persist_term,
+        .persist_metadata = __raft_persist_metadata,
     };
 
     void *r = raft_new();

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -233,12 +233,8 @@ def raft_applylog(raft, udata, ety, idx):
         return lib.RAFT_ERR_SHUTDOWN
 
 
-def raft_persist_vote(raft, udata, voted_for):
-    return ffi.from_handle(udata).persist_vote(voted_for)
-
-
-def raft_persist_term(raft, udata, term, vote):
-    return ffi.from_handle(udata).persist_term(term, vote)
+def raft_persist_metadata(raft, udata, term, vote):
+    return ffi.from_handle(udata).persist_metadata(term, vote)
 
 
 def raft_logentry_offer(raft, udata, ety, ety_idx):
@@ -834,8 +830,7 @@ class RaftServer(object):
         cbs.get_snapshot_chunk = self.raft_get_snapshot_chunk
         cbs.store_snapshot_chunk = self.raft_store_snapshot_chunk
         cbs.applylog = self.raft_applylog
-        cbs.persist_vote = self.raft_persist_vote
-        cbs.persist_term = self.raft_persist_term
+        cbs.persist_metadata = self.raft_persist_metadata
         cbs.get_node_id = self.raft_get_node_id
         cbs.node_has_sufficient_logs = self.raft_node_has_sufficient_logs
         cbs.notify_membership_event = self.raft_notify_membership_event
@@ -954,8 +949,7 @@ class RaftServer(object):
         self.raft_get_snapshot_chunk = ffi.callback("int(raft_server_t*, void*, raft_node_t*, raft_size_t offset, raft_snapshot_chunk_t*)", raft_get_snapshot_chunk)
         self.raft_store_snapshot_chunk = ffi.callback("int(raft_server_t*, void*, raft_index_t index, raft_size_t offset, raft_snapshot_chunk_t*)", raft_store_snapshot_chunk)
         self.raft_applylog = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_applylog)
-        self.raft_persist_vote = ffi.callback("int(raft_server_t*, void*, raft_node_id_t)", raft_persist_vote)
-        self.raft_persist_term = ffi.callback("int(raft_server_t*, void*, raft_term_t, raft_node_id_t)", raft_persist_term)
+        self.raft_persist_metadata = ffi.callback("int(raft_server_t*, void*, raft_term_t, raft_node_id_t)", raft_persist_metadata)
         self.raft_logentry_offer = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_logentry_offer)
         self.raft_logentry_poll = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_logentry_poll)
         self.raft_logentry_pop = ffi.callback("int(raft_server_t*, void*, raft_entry_t*, raft_index_t)", raft_logentry_pop)
@@ -1168,11 +1162,7 @@ class RaftServer(object):
         #     self, snapshot.last_term, snapshot.last_idx))
         return 0
 
-    def persist_vote(self, voted_for):
-        # TODO: add disk simulation
-        return 0
-
-    def persist_term(self, term, vote):
+    def persist_metadata(self, term, vote):
         # TODO: add disk simulation
         return 0
 


### PR DESCRIPTION
Combine `raft_persist_vote_f` and `raft_persist_term_f` into a single callback: `raft_persist_metadata_f`

No need for separate callbacks for persisting term and vote. 
Users can/should persist vote and term into a single file. So, it is natural to have a single callback. 

After a restart, application should call `raft_restore_metadata()` to restore vote and term.

Correct order to restore the state after a restart:
1- Restore snapshot
2- Load log entries
3- Restore metadata

Step 1-2 require some changes to complete a restart correctly. These issues will be addressed in follow-up PRs.  
