### PR TITLE
Improve snapshot support

### DIFF
--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -166,11 +166,13 @@ void raft_node_free(raft_node_t* me);
 
 void raft_node_set_match_idx(raft_node_t* node, raft_index_t idx);
 
+void raft_node_clear_flags(raft_node_t *me);
+
 void raft_node_vote_for_me(raft_node_t* me, int vote);
 
 int raft_node_has_vote_for_me(raft_node_t* me);
 
-void raft_node_set_has_sufficient_logs(raft_node_t* me);
+void raft_node_set_has_sufficient_logs(raft_node_t *me, int has_sufficient_log);
 
 int raft_is_single_node_voting_cluster(raft_server_t *me);
 

--- a/src/raft_node.c
+++ b/src/raft_node.c
@@ -125,6 +125,11 @@ void raft_node_set_udata(raft_node_t* me, void* udata)
     me->udata = udata;
 }
 
+void raft_node_clear_flags(raft_node_t *me)
+{
+    me->flags = 0;
+}
+
 void raft_node_vote_for_me(raft_node_t* me, const int vote)
 {
     if (vote)
@@ -138,16 +143,11 @@ int raft_node_has_vote_for_me(raft_node_t* me)
     return (me->flags & RAFT_NODE_VOTED_FOR_ME) != 0;
 }
 
-void raft_node_set_voting(raft_node_t* me, int voting)
+void raft_node_set_voting(raft_node_t *me, int voting)
 {
-    if (voting)
-    {
-        assert(!raft_node_is_voting(me));
+    if (voting) {
         me->flags |= RAFT_NODE_VOTING;
-    }
-    else
-    {
-        assert(raft_node_is_voting(me));
+    } else {
         me->flags &= ~RAFT_NODE_VOTING;
     }
 }
@@ -162,9 +162,13 @@ int raft_node_has_sufficient_logs(raft_node_t* me)
     return (me->flags & RAFT_NODE_HAS_SUFFICIENT_LOG) != 0;
 }
 
-void raft_node_set_has_sufficient_logs(raft_node_t* me)
+void raft_node_set_has_sufficient_logs(raft_node_t *me, int has_sufficient_log)
 {
-    me->flags |= RAFT_NODE_HAS_SUFFICIENT_LOG;
+    if (has_sufficient_log) {
+        me->flags |= RAFT_NODE_HAS_SUFFICIENT_LOG;
+    } else {
+        me->flags &= ~RAFT_NODE_HAS_SUFFICIENT_LOG;
+    }
 }
 
 void raft_node_set_active(raft_node_t* me, int active)

--- a/tests/test_snapshotting.c
+++ b/tests/test_snapshotting.c
@@ -174,8 +174,8 @@ static int test_clear_snapshot(raft_server_t* raft,
 
 static int test_load_snapshot(raft_server_t* raft,
                                void *user_data,
-                              raft_index_t snapshot_index,
-                              raft_term_t snapshot_term)
+                              raft_term_t snapshot_term,
+                              raft_index_t snapshot_index)
 {
     struct test_data *t = user_data;
     t->load++;
@@ -487,7 +487,7 @@ void TestRaft_follower_load_from_snapshot(CuTest * tc)
     ety = __MAKE_ENTRY(3, 1, "entry");
     raft_append_entry(r, ety);
     raft_set_commit_idx(r, 7);
-    CuAssertIntEquals(tc, -1, raft_begin_load_snapshot(r, 6, 5));
+    CuAssertIntEquals(tc, RAFT_ERR_MISUSE, raft_begin_load_snapshot(r, 6, 5));
     CuAssertIntEquals(tc, 7, raft_get_commit_idx(r));
 }
 
@@ -504,7 +504,7 @@ void TestRaft_follower_load_from_snapshot_fails_if_term_is_0(CuTest * tc)
 
     raft_set_state(r, RAFT_STATE_FOLLOWER);
     CuAssertIntEquals(tc, 0, raft_get_log_count(r));
-    CuAssertIntEquals(tc, -1, raft_begin_load_snapshot(r, 0, 5));
+    CuAssertIntEquals(tc, RAFT_ERR_MISUSE, raft_begin_load_snapshot(r, 0, 5));
 }
 
 void TestRaft_follower_load_from_snapshot_fails_if_already_loaded(CuTest * tc)
@@ -553,7 +553,7 @@ void TestRaft_follower_load_from_snapshot_does_not_break_cluster_safety(CuTest *
     __RAFT_APPEND_ENTRY(r, 2, 1, "entry");
     __RAFT_APPEND_ENTRY(r, 3, 1, "entry");
 
-    CuAssertIntEquals(tc, -1, raft_begin_load_snapshot(r, 2, 2));
+    CuAssertIntEquals(tc, RAFT_ERR_MISUSE, raft_begin_load_snapshot(r, 2, 2));
 }
 
 void TestRaft_follower_load_from_snapshot_fails_if_log_is_newer(CuTest * tc)
@@ -572,7 +572,7 @@ void TestRaft_follower_load_from_snapshot_fails_if_log_is_newer(CuTest * tc)
 
     raft_set_last_applied_idx(r, 5);
 
-    CuAssertIntEquals(tc, -1, raft_begin_load_snapshot(r, 2, 2));
+    CuAssertIntEquals(tc, RAFT_ERR_MISUSE, raft_begin_load_snapshot(r, 2, 2));
 }
 
 void TestRaft_leader_sends_snapshot_when_node_next_index_was_compacted(CuTest* tc)
@@ -1012,6 +1012,23 @@ void TestRaft_set_last_chunk_on_duplicate(CuTest * tc)
     CuAssertIntEquals(tc, 1, resp.last_chunk);
 }
 
+void TestRaft_restore_after_restart(CuTest * tc)
+{
+    raft_server_t *r = raft_new();
+    raft_add_node(r, NULL, 1, 1);
+
+    /* Restore should fail if the term is not 0 */
+    raft_set_current_term(r, 10);
+    CuAssertIntEquals(tc, RAFT_ERR_MISUSE, raft_restore_snapshot(r, -1, 3));
+    CuAssertIntEquals(tc, RAFT_ERR_MISUSE, raft_restore_snapshot(r, 11, 5));
+
+    r = raft_new();
+    raft_add_node(r, NULL, 1, 1);
+
+    /* Restore should work on start-up */
+    CuAssertIntEquals(tc, 0, raft_restore_snapshot(r, 11, 5));
+}
+
 int main(void)
 {
     CuString *output = CuStringNew();
@@ -1039,6 +1056,7 @@ int main(void)
     SUITE_ADD_TEST(suite, TestRaft_clear_snapshot_on_leader_change);
     SUITE_ADD_TEST(suite, TestRaft_reject_wrong_offset);
     SUITE_ADD_TEST(suite, TestRaft_set_last_chunk_on_duplicate);
+    SUITE_ADD_TEST(suite, TestRaft_restore_after_restart);
 
     CuSuiteRun(suite);
     CuSuiteDetails(suite, output);

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -189,8 +189,8 @@ def raft_send_snapshot(raft, udata, node, msg):
     return 0
 
 
-def raft_load_snapshot(raft, udata, index, term):
-    return ffi.from_handle(udata).load_snapshot(index, term)
+def raft_load_snapshot(raft, udata, term, index):
+    return ffi.from_handle(udata).load_snapshot(term, index)
 
 
 def raft_clear_snapshot(raft, udata):
@@ -949,7 +949,7 @@ class RaftServer(object):
         self.raft_send_requestvote = ffi.callback("int(raft_server_t*, void*, raft_node_t*, raft_requestvote_req_t*)", raft_send_requestvote)
         self.raft_send_appendentries = ffi.callback("int(raft_server_t*, void*, raft_node_t*, raft_appendentries_req_t*)", raft_send_appendentries)
         self.raft_send_snapshot = ffi.callback("int(raft_server_t*, void* , raft_node_t*, raft_snapshot_req_t*)", raft_send_snapshot)
-        self.raft_load_snapshot = ffi.callback("int(raft_server_t*, void*, raft_index_t, raft_term_t)", raft_load_snapshot)
+        self.raft_load_snapshot = ffi.callback("int(raft_server_t*, void*, raft_term_t, raft_index_t)", raft_load_snapshot)
         self.raft_clear_snapshot = ffi.callback("int(raft_server_t*, void*)", raft_clear_snapshot)
         self.raft_get_snapshot_chunk = ffi.callback("int(raft_server_t*, void*, raft_node_t*, raft_size_t offset, raft_snapshot_chunk_t*)", raft_get_snapshot_chunk)
         self.raft_store_snapshot_chunk = ffi.callback("int(raft_server_t*, void*, raft_index_t index, raft_size_t offset, raft_snapshot_chunk_t*)", raft_store_snapshot_chunk)
@@ -1087,7 +1087,7 @@ class RaftServer(object):
 
         return 0
 
-    def load_snapshot(self, index, term):
+    def load_snapshot(self, term, index):
         logger.debug('{} loading snapshot'.format(self))
 
         leader = find_leader()


### PR DESCRIPTION
Changes:
- `raft_load_snapshot_f()`: Changed order of arguments `term` and `index` to be inline with `raft_begin_load_snapshot()`.
- Refactored `raft_begin_load_snapshot()`. Now, inside this function, current server's node flags are cleared. Previously, application had to take care of it. e.g Application had to clear `inactive` flag on a snapshot. 
- Added `raft_restore_snapshot()` to let libraft know that application has loaded a snapshot. 

After these changes, snapshot sequence is:

- When application wants to take a snapshot, it stores each node's `id` and `raft_node_is_voting()` data to the snapshot.
- After the restart, application:
  - Loads snapshot data.
  - Configures nodes by either calling `raft_add_node()` or `raft_add_non_voting_node()` depending on the `voting` info.
  - Calls `raft_restore_snapshot()`. Libraft makes necessary adjustments of the node flags. 
  - Loads log entries.
  - Restores `vote` and `term` from the metadata file. 
   