### PR TITLE
Add support to rebuild configuration after a restart

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1701,4 +1701,12 @@ int raft_config(raft_server_t *me, int set, raft_config_e config, ...);
  */
 int raft_pending_operations(raft_server_t *me);
 
+/** Restore log entries after a restart.
+ *
+ * This function should only be called after a restart. After application loads
+ * the snapshot and log entries, this function should be called to rebuild
+ * cluster configuration from the logs.
+ */
+int raft_restore_log(raft_server_t *me);
+
 #endif /* RAFT_H_ */

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -4910,7 +4910,7 @@ void TestRaft_rebuild_config_after_restart(CuTest *tc)
      * new server. We are just simulating the restart scenario. Normally, new
      * server would read log entries from the disk. */
     raft_server_t *r2 = raft_new();
-    r2->log = raft_get_log(r2);
+    r2->log = raft_get_log(r);
 
     raft_set_callbacks(r2, &funcs, NULL);
     raft_add_non_voting_node(r2, NULL, 1, 1);


### PR DESCRIPTION
Configuration changes are special in Raft. They take effect whenever the related log entries are appended. On a restart, we should go over the log entries and rebuild the configuration. Adding `raft_restore_log()` function for this purpose. 

Overall, on a restart, application should do:
- Load the snapshot and call `raft_restore_snapshot()`
- Load the log entries and call `raft_restore_log()`
- Read the metadata file and call `raft_restore_metadata()`.