### PR TITLE
Fix memory leak in raft_restore_log()

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -2317,6 +2317,7 @@ int raft_restore_log(raft_server_t *me)
             raft_handle_append_cfg_change(me, ety, i);
         }
 
+        raft_entry_release(ety);
         i++;
     }
 


### PR DESCRIPTION
Introduced by https://github.com/RedisLabs/raft/pull/125

We should decrement refcount of the entry at the end. 