### PR TITLE
Delete raft_set_snapshot_metadata()

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1431,8 +1431,6 @@ raft_index_t raft_get_snapshot_last_idx(raft_server_t *me);
 
 raft_term_t raft_get_snapshot_last_term(raft_server_t *me);
 
-void raft_set_snapshot_metadata(raft_server_t *me, raft_term_t term, raft_index_t idx);
-
 /** Check if a node is active.
  * Active nodes could become voting nodes.
  * This should be used for creating the membership snapshot.

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -130,7 +130,6 @@ raft_server_t* raft_new_with_log(const raft_log_impl_t *log_impl, void *log_arg)
     me->leader_id = RAFT_NODE_ID_NONE;
 
     me->snapshot_in_progress = 0;
-    raft_set_snapshot_metadata(me, 0, 0);
 
     return me;
 }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -236,14 +236,6 @@ raft_term_t raft_get_snapshot_last_term(raft_server_t *me)
     return me->snapshot_last_term;
 }
 
-void raft_set_snapshot_metadata(raft_server_t *me, raft_term_t term, raft_index_t idx)
-{
-    me->last_applied_term = term;
-    me->last_applied_idx = idx;
-    me->snapshot_last_term = term;
-    me->snapshot_last_idx = idx;
-}
-
 int raft_is_single_node_voting_cluster(raft_server_t *me)
 {
     return (1 == raft_get_num_voting_nodes(me) && raft_node_is_voting(me->node));


### PR DESCRIPTION
In https://github.com/RedisLabs/raft/pull/118, we introduced `raft_restore_snapshot()`  which makes `raft_set_snapshot_metadata()` obsolete. 