### PR TITLE
Simplify entry removal

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -726,24 +726,6 @@ typedef struct
     raft_timestamp_f timestamp;
 } raft_cbs_t;
 
-/** A generic notification callback used to allow Raft to notify caller
- * on certain log operations.
- *
- * @param[in] arg Argument passed by Raft in the original call.
- * @param[in] entry Entry for which notification is generated.
- * @param[in] entry_idx Index of entry.
- *
- * The callback *must not* modify the entry or perform any preemptive
- * log operation until it returns.
- */
-typedef void (
-*raft_entry_notify_f
-)   (
-    void* arg,
-    raft_entry_t *entry,
-    raft_index_t entry_idx
-    );
-
 /** A callback used to notify when queued read requests can be processed.
  *
  * @param[in] arg Argument passed in the original call.
@@ -852,13 +834,11 @@ typedef struct raft_log_impl
      *
      * @param[in] from_idx Index of first entry to be removed.  All entries
      *  starting from and including this index shall be removed.
-     * @param[in] cb Optional callback to execute for every removed entry.
-     * @param[in] cb_arg Argument to pass to callback.
      * @return
      *  0 on success;
      *  -1 on error.
      */
-    int (*pop) (void *log, raft_index_t from_idx, raft_entry_notify_f cb, void *cb_arg);
+    int (*pop) (void *log, raft_index_t from_idx);
 
     /** Get a single entry from the log.
      *
@@ -1257,13 +1237,6 @@ void raft_set_commit_idx(raft_server_t* me, raft_index_t commit_idx);
  *  RAFT_ERR_SHUTDOWN server should shutdown
  *  RAFT_ERR_NOMEM memory allocation failure */
 int raft_append_entry(raft_server_t* me, raft_entry_t* ety);
-
-/** Remove the last entry from the server's log.
- * This should only be used when reloading persistent state from an append log
- * store, where removed entries are still in the log but followed by a pop
- * action.
- */
-int raft_pop_entry(raft_server_t* me);
 
 /** Confirm if a msg_entry_response has been committed.
  * @param[in] r The response we want to check */

--- a/src/raft_log.c
+++ b/src/raft_log.c
@@ -208,7 +208,7 @@ raft_index_t raft_log_count(raft_log_t *me)
     return me->count;
 }
 
-static int log_delete(raft_log_t* me, raft_index_t idx, raft_entry_notify_f cb, void *cb_arg)
+static int log_delete(raft_log_t *me, raft_index_t idx)
 {
     if (0 == idx)
         return -1;
@@ -229,9 +229,6 @@ static int log_delete(raft_log_t* me, raft_index_t idx, raft_entry_notify_f cb, 
                 return e;
         }
 
-        if (cb)
-            cb(cb_arg, me->entries[back], idx_tmp);
-
         raft_entry_release(me->entries[back]);
 
         me->back = back;
@@ -242,7 +239,7 @@ static int log_delete(raft_log_t* me, raft_index_t idx, raft_entry_notify_f cb, 
 
 int raft_log_delete(raft_log_t *me, raft_index_t idx)
 {
-    return log_delete(me, idx, NULL, NULL);
+    return log_delete(me, idx);
 }
 
 int raft_log_poll(raft_log_t *me, raft_entry_t **etyp)
@@ -379,9 +376,9 @@ static raft_index_t log_get_batch(void *log,
     return n;
 }
 
-static int log_pop(void *log, raft_index_t from_idx, raft_entry_notify_f cb, void *cb_arg)
+static int log_pop(void *log, raft_index_t from_idx)
 {
-    return log_delete(log, from_idx, cb, cb_arg);
+    return log_delete(log, from_idx);
 }
 
 static int log_poll(void *log, raft_index_t first_idx)

--- a/tests/test_log_impl.c
+++ b/tests/test_log_impl.c
@@ -141,16 +141,17 @@ void TestLogImpl_pop(CuTest * tc)
     CuAssertIntEquals(tc, 3, impl->count(l));
     CuAssertIntEquals(tc, 3, impl->current_idx(l));
 
-    impl->pop(l, 3, event_entry_enqueue, queue);
+    event_entry_enqueue(queue, impl->get(l, 3), 3);
+    impl->pop(l, 3);
     CuAssertIntEquals(tc, 2, impl->count(l));
     CuAssertIntEquals(tc, 3, ((raft_entry_t*)llqueue_poll(queue))->id);
     CuAssertTrue(tc, NULL == impl->get(l, 3));
 
-    impl->pop(l, 2, NULL, NULL);
+    impl->pop(l, 2);
     CuAssertIntEquals(tc, 1, impl->count(l));
     CuAssertTrue(tc, NULL == impl->get(l, 2));
 
-    impl->pop(l, 1, NULL, NULL);
+    impl->pop(l, 1);
     CuAssertIntEquals(tc, 0, impl->count(l));
     CuAssertTrue(tc, NULL == impl->get(l, 1));
 }
@@ -166,7 +167,7 @@ void TestLogImpl_pop_onwards(CuTest * tc)
     CuAssertIntEquals(tc, 3, impl->count(l));
 
     /* even 3 gets deleted */
-    impl->pop(l, 2, NULL, NULL);
+    impl->pop(l, 2);
     CuAssertIntEquals(tc, 1, impl->count(l));
     CuAssertIntEquals(tc, 1, impl->get(l, 1)->id);
     CuAssertTrue(tc, NULL == impl->get(l, 2));
@@ -182,7 +183,7 @@ void TestLogImpl_pop_fails_for_idx_zero(CuTest * tc)
 
     l = impl->init(r, NULL);
     __LOGIMPL_APPEND_ENTRIES_SEQ_ID(l, 4, 1, 0, NULL);
-    CuAssertIntEquals(tc, impl->pop(l, 0, NULL, NULL), -1);
+    CuAssertIntEquals(tc, impl->pop(l, 0), -1);
 }
 
 void TestLogImpl_poll(CuTest * tc)
@@ -290,7 +291,7 @@ void TestLogImpl_pop_after_polling(CuTest * tc)
     CuAssertIntEquals(tc, 2, impl->current_idx(l));
 
     /* poll */
-    CuAssertIntEquals(tc, impl->pop(l, 1, NULL, NULL), 0);
+    CuAssertIntEquals(tc, impl->pop(l, 1), 0);
     CuAssertIntEquals(tc, 0, impl->count(l));
     CuAssertIntEquals(tc, 1, impl->current_idx(l));
 }
@@ -316,7 +317,7 @@ void TestLogImpl_pop_after_polling_from_double_append(CuTest * tc)
     CuAssertIntEquals(tc, 2, impl->count(l));
 
     /* pop */
-    CuAssertIntEquals(tc, impl->pop(l, 1, NULL, NULL), 0);
+    CuAssertIntEquals(tc, impl->pop(l, 1), 0);
     CuAssertIntEquals(tc, 0, impl->count(l));
 }
 


### PR DESCRIPTION
Simplied `pop` callback. 

Previously, libraft was passing a callback(`raft_entry_notify_f`) to the `pop` callback. 
The application was supposed to call that callback for each removed entry.

Libraft can loop over the entries and call the required functions itself. 
So, we can delete `raft_entry_notify_f` from the `pop` callback just to
simplify API. 

In addition to that, this PR removes `raft_pop_entry()` function which doesn't have 
a use-case, as far as I can see.  
We can use `raft_delete_entry_from_idx(me, raft_get_current_idx())` instead if required. 