### PR TITLE
Revert change for timeout message

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -747,7 +747,8 @@ int raft_recv_appendentries_response(raft_server_t *me,
         return 0;
     }
 
-    if (raft_get_transfer_leader(me) == raft_node_get_id(node) &&
+    if (!me->sent_timeout_now &&
+        raft_get_transfer_leader(me) == raft_node_get_id(node) &&
         raft_get_current_idx(me) == resp->current_idx) {
 
         me->cb.send_timeoutnow(me, me->udata, node);

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -4066,7 +4066,7 @@ int timeoutnow_sent = 0;
 
 int cb_timeoutnow(raft_server_t* raft, void *udata, raft_node_t* node)
 {
-    timeoutnow_sent = 1;
+    timeoutnow_sent++;
 
     return 0;
 }
@@ -4138,6 +4138,10 @@ void TestRaft_callback_timeoutnow_at_send_appendentries_response_if_up_to_date(C
         .current_idx = 2
     };
 
+    raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
+    CuAssertTrue(tc, 1 == timeoutnow_sent);
+
+    /* Verify we won't send timeout now message twice. */
     raft_recv_appendentries_response(r, raft_get_node(r, 2), &aer);
     CuAssertTrue(tc, 1 == timeoutnow_sent);
 }


### PR DESCRIPTION
Looks like I misunderstood this comment completely: https://github.com/RedisLabs/raft/pull/127/files#r956684475

`sent_timeout_now` is a variable, `send_timeout_now` is a callback. I deleted the variable check by mistake (sorry). 
Reverting it and also adding a test for it.

Without the check, we are sending timeout message more than once. 