### PR TITLE
Move internal functions to the private API

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1477,15 +1477,12 @@ void raft_entry_release(raft_entry_t *ety);
  *
  * @note The array itself is not freed.
  */
-
 void raft_entry_release_list(raft_entry_t **ety_list, size_t len);
 
 /** Log Implementation callbacks structure for the default in-memory
  * log implementation.
  */
 extern const raft_log_impl_t raft_log_internal_impl;
-
-void raft_handle_append_cfg_change(raft_server_t* me, raft_entry_t* ety, raft_index_t idx);
 
 int raft_recv_read_request(raft_server_t* me, raft_read_request_callback_f cb, void *cb_arg);
 
@@ -1505,8 +1502,6 @@ raft_node_id_t raft_get_transfer_leader(raft_server_t *me);
 
 /* cause this server to force an election. */
 int raft_timeout_now(raft_server_t* me);
-
-raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
 
 /**
  *  Library can be used in two modes:

--- a/include/raft.h
+++ b/include/raft.h
@@ -1186,16 +1186,6 @@ void *raft_get_udata(raft_server_t *me);
  *  0 on success */
 int raft_set_current_term(raft_server_t *me, raft_term_t term);
 
-
-/** Add an entry to the server's log.
- * This should be used to reload persistent state, ie. the commit log.
- * @param[in] ety The entry to be appended
- * @return
- *  0 on success;
- *  RAFT_ERR_SHUTDOWN server should shutdown
- *  RAFT_ERR_NOMEM memory allocation failure */
-int raft_append_entry(raft_server_t* me, raft_entry_t* ety);
-
 /** Confirm if a msg_entry_response has been committed.
  * @param[in] r The response we want to check */
 int raft_msg_entry_response_committed(raft_server_t* me,

--- a/include/raft.h
+++ b/include/raft.h
@@ -1125,10 +1125,6 @@ int raft_is_precandidate(raft_server_t *me);
 int raft_is_candidate(raft_server_t *me);
 
 /**
- * @return currently elapsed timeout in milliseconds */
-raft_time_t raft_get_timeout_elapsed(raft_server_t *me);
-
-/**
  * @return index of last applied entry */
 raft_index_t raft_get_last_applied_idx(raft_server_t *me);
 
@@ -1168,14 +1164,6 @@ raft_node_t *raft_get_node(raft_server_t *me, raft_node_id_t id);
  * @return node pointed to by node idx */
 raft_node_t *raft_get_node_from_idx(raft_server_t *me, raft_index_t idx);
 
-/**
- * @return number of votes this server has received this election */
-int raft_get_nvotes_for_me(raft_server_t* me);
-
-/**
- * @return node ID of who I voted for */
-raft_node_id_t raft_get_voted_for(raft_server_t *me);
-
 /** Get what this node thinks the node ID of the leader is.
  * @return node of what this node thinks is the valid leader;
  *   RAFT_NODE_ID_NONE if there is no leader */
@@ -1191,20 +1179,6 @@ raft_node_t *raft_get_leader_node(raft_server_t *me);
  * @return callback user data */
 void *raft_get_udata(raft_server_t *me);
 
-/** Vote for a server.
- * This should be used to reload persistent state, ie. the voted-for field.
- * @param[in] node The server to vote for
- * @return
- *  0 on success */
-int raft_vote(raft_server_t* me, raft_node_t* node);
-
-/** Vote for a server.
- * This should be used to reload persistent state, ie. the voted-for field.
- * @param[in] nodeid The server to vote for by nodeid
- * @return
- *  0 on success */
-int raft_vote_for_nodeid(raft_server_t* me, raft_node_id_t nodeid);
-
 /** Set the current term.
  * This should be used to reload persistent state, ie. the current_term field.
  * @param[in] term The new current term
@@ -1212,10 +1186,6 @@ int raft_vote_for_nodeid(raft_server_t* me, raft_node_id_t nodeid);
  *  0 on success */
 int raft_set_current_term(raft_server_t *me, raft_term_t term);
 
-/** Set the commit idx.
- * This should be used to reload persistent state, ie. the commit_idx field.
- * @param[in] commit_idx The new commit index. */
-void raft_set_commit_idx(raft_server_t *me, raft_index_t commit_idx);
 
 /** Add an entry to the server's log.
  * This should be used to reload persistent state, ie. the commit log.

--- a/include/raft.h
+++ b/include/raft.h
@@ -1400,6 +1400,8 @@ raft_node_id_t raft_get_transfer_leader(raft_server_t *me);
 /* cause this server to force an election. */
 int raft_timeout_now(raft_server_t* me);
 
+raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
+
 /**
  *  Library can be used in two modes:
  *

--- a/include/raft.h
+++ b/include/raft.h
@@ -1463,44 +1463,6 @@ int raft_voting_change_is_in_progress(raft_server_t *me);
  */
 void *raft_get_log(raft_server_t* me);
 
-/** Backward compatible callbacks for log events, implemented by the
- * default in-memory log implementation.
- *
- */
-
-typedef struct {
-    /** Callback for adding an entry to the log
-     * For safety reasons this callback MUST flush the change to disk.
-     * Return 0 on success.
-     * Return RAFT_ERR_SHUTDOWN if you want the server to shutdown. */
-
-    raft_logentry_event_f log_offer;
-
-    /** Callback for removing the oldest entry from the log
-     * For safety reasons this callback MUST flush the change to disk.
-     * @note The callback does not need to call raft_entry_release() as
-     *   no references are implicitly held.  If access to the entry is
-     *   desired after the callback returns, raft_entry_hold() should be
-     *   used.
-     */
-    raft_logentry_event_f log_poll;
-
-    /** Callback for removing the youngest entry from the log
-     * For safety reasons this callback MUST flush the change to disk.
-     * @note The callback does not need to call raft_entry_release() as
-     *   no references are implicitly held.  If access to the entry is
-     *   desired after the callback returns, raft_entry_hold() should be
-     *   used.
-     */
-    raft_logentry_event_f log_pop;
-
-    /** Callback called for every existing log entry when clearing the log.
-     * If memory was malloc'd in log_offer and the entry doesn't get a chance
-     * to go through log_poll or log_pop, this is the last chance to free it.
-     */
-    raft_logentry_event_f log_clear;
-} raft_log_cbs_t;
-
 /** Allocate a new Raft Log entry.
  *
  * @param[in] data_len Length of user-supplied data for which additional

--- a/include/raft.h
+++ b/include/raft.h
@@ -1249,19 +1249,6 @@ const char *raft_get_error_str(int err);
  * @return the last log term */
 raft_term_t raft_get_last_log_term(raft_server_t *me);
 
-/** Turn a node into a voting node.
- * Voting nodes can take part in elections and in-regards to committing entries,
- * are counted in majorities. */
-void raft_node_set_voting(raft_node_t *node, int voting);
-
-/** Tell if a node is a voting node or not.
- * @return 1 if this is a voting node. Otherwise 0. */
-int raft_node_is_voting(raft_node_t *node);
-
-/** Check if a node has sufficient logs to be able to join the cluster.
- **/
-int raft_node_has_sufficient_logs(raft_node_t *node);
-
 /** Apply all entries up to the commit index
  * @return
  *  0 on success;
@@ -1395,21 +1382,6 @@ raft_index_t raft_get_snapshot_last_idx(raft_server_t *me);
 
 raft_term_t raft_get_snapshot_last_term(raft_server_t *me);
 
-/** Check if a node is active.
- * Active nodes could become voting nodes.
- * This should be used for creating the membership snapshot.
- **/
-int raft_node_is_active(raft_node_t *node);
-
-/** Make the node active.
- *
- * The user sets this to 1 between raft_begin_load_snapshot and
- * raft_end_load_snapshot.
- *
- * @param[in] active Set a node as active if this is 1
- **/
-void raft_node_set_active(raft_node_t *node, int active);
-
 /** Check if a node's voting status has been committed.
  * This should be used for creating the membership snapshot.
  **/
@@ -1428,16 +1400,6 @@ void raft_set_heap_functions(void *(*_malloc)(size_t),
                              void *(*_calloc)(size_t, size_t),
                              void *(*_realloc)(void *, size_t),
                              void (*_free)(void *));
-
-/** Confirm that a node's voting status is final
- * @param[in] node The node
- * @param[in] voting Whether this node's voting status is committed or not */
-void raft_node_set_voting_committed(raft_node_t *node, int voting);
-
-/** Confirm that a node's voting status is final
- * @param[in] node The node
- * @param[in] committed Whether this node's membership is committed or not */
-void raft_node_set_addition_committed(raft_node_t *node, int committed);
 
 /** Check if a voting change is in progress
  * @param[in] raft The Raft server

--- a/include/raft.h
+++ b/include/raft.h
@@ -1137,27 +1137,12 @@ raft_index_t raft_get_last_applied_idx(raft_server_t *me);
 raft_term_t raft_get_last_applied_term(raft_server_t *me);
 
 /**
- * @return the node's next index */
-raft_index_t raft_node_get_next_idx(raft_node_t *node);
-
-/**
- * @return this node's user data */
-raft_index_t raft_node_get_match_idx(raft_node_t *node);
-
-/**
  * @return this node's user data */
 void* raft_node_get_udata(raft_node_t *node);
 
 /**
  * Set this node's user data */
 void raft_node_set_udata(raft_node_t *node, void *user_data);
-
-/**
- * After sending the snapshot, user can set the next index for the node
- *
- * @param[in] node node
- * @param[in] idx next entry index */
-void raft_node_set_next_idx(raft_node_t *node, raft_index_t idx);
 
 /**
  * @param[in] idx The entry's index

--- a/include/raft.h
+++ b/include/raft.h
@@ -1341,11 +1341,6 @@ void raft_set_heap_functions(void *(*_malloc)(size_t),
                              void *(*_realloc)(void *, size_t),
                              void (*_free)(void *));
 
-/** Check if a voting change is in progress
- * @param[in] raft The Raft server
- * @return 1 if a voting change is in progress */
-int raft_voting_change_is_in_progress(raft_server_t *me);
-
 /** Get the log implementation handle in use.
  */
 void *raft_get_log(raft_server_t* me);

--- a/include/raft.h
+++ b/include/raft.h
@@ -1249,30 +1249,10 @@ const char *raft_get_error_str(int err);
  * @return the last log term */
 raft_term_t raft_get_last_log_term(raft_server_t *me);
 
-/** Apply all entries up to the commit index
- * @return
- *  0 on success;
- *  RAFT_ERR_SHUTDOWN when server MUST shutdown */
-int raft_apply_all(raft_server_t* me);
-
 /** Become leader
  * WARNING: this is a dangerous function call. It could lead to your cluster
  * losing it's consensus guarantees. */
 int raft_become_leader(raft_server_t *me);
-
-/** Become follower. This may be used to give up leadership. It does not change
- * currentTerm. */
-void raft_become_follower(raft_server_t *me);
-
-/** Determine if entry is voting configuration change.
- * @param[in] ety The entry to query.
- * @return 1 if this is a voting configuration change. */
-int raft_entry_is_voting_cfg_change(raft_entry_t* ety);
-
-/** Determine if entry is configuration change.
- * @param[in] ety The entry to query.
- * @return 1 if this is a configuration change. */
-int raft_entry_is_cfg_change(raft_entry_t* ety);
 
 /** Begin snapshotting.
  *

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -3,6 +3,41 @@
 
 #include "raft_types.h"
 
+/** Backward compatible callbacks for log events */
+
+typedef struct {
+    /** Callback for adding an entry to the log
+     * For safety reasons this callback MUST flush the change to disk.
+     * Return 0 on success.
+     * Return RAFT_ERR_SHUTDOWN if you want the server to shutdown. */
+
+    raft_logentry_event_f log_offer;
+
+    /** Callback for removing the oldest entry from the log
+     * For safety reasons this callback MUST flush the change to disk.
+     * @note The callback does not need to call raft_entry_release() as
+     *   no references are implicitly held.  If access to the entry is
+     *   desired after the callback returns, raft_entry_hold() should be
+     *   used.
+     */
+    raft_logentry_event_f log_poll;
+
+    /** Callback for removing the youngest entry from the log
+     * For safety reasons this callback MUST flush the change to disk.
+     * @note The callback does not need to call raft_entry_release() as
+     *   no references are implicitly held.  If access to the entry is
+     *   desired after the callback returns, raft_entry_hold() should be
+     *   used.
+     */
+    raft_logentry_event_f log_pop;
+
+    /** Callback called for every existing log entry when clearing the log.
+     * If memory was malloc'd in log_offer and the entry doesn't get a chance
+     * to go through log_poll or log_pop, this is the last chance to free it.
+     */
+    raft_logentry_event_f log_clear;
+} raft_log_cbs_t;
+
 typedef struct raft_log raft_log_t;
 
 raft_log_t *raft_log_new(void);

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -246,8 +246,6 @@ int raft_periodic_internal(raft_server_t *me, raft_time_t milliseconds);
 
 int raft_exec_operations(raft_server_t *me);
 
-raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
-
 /** Become follower. This may be used to give up leadership. It does not change
  * currentTerm. */
 void raft_become_follower(raft_server_t *me);

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -248,4 +248,25 @@ int raft_exec_operations(raft_server_t *me);
 
 raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
 
+/** Become follower. This may be used to give up leadership. It does not change
+ * currentTerm. */
+void raft_become_follower(raft_server_t *me);
+
+/** Determine if entry is voting configuration change.
+ * @param[in] ety The entry to query.
+ * @return 1 if this is a voting configuration change. */
+int raft_entry_is_voting_cfg_change(raft_entry_t* ety);
+
+/** Determine if entry is configuration change.
+ * @param[in] ety The entry to query.
+ * @return 1 if this is a configuration change. */
+int raft_entry_is_cfg_change(raft_entry_t* ety);
+
+
+/** Apply all entries up to the commit index
+ * @return
+ *  0 on success;
+ *  RAFT_ERR_SHUTDOWN when server MUST shutdown */
+int raft_apply_all(raft_server_t* me);
+
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -300,4 +300,14 @@ raft_node_id_t raft_get_voted_for(raft_server_t *me);
  * @return currently elapsed timeout in milliseconds */
 raft_time_t raft_get_timeout_elapsed(raft_server_t *me);
 
+/** Add an entry to the server's log.
+ * This should be used to reload persistent state, ie. the commit log.
+ * @param[in] ety The entry to be appended
+ * @return
+ *  0 on success;
+ *  RAFT_ERR_SHUTDOWN server should shutdown
+ *  RAFT_ERR_NOMEM memory allocation failure */
+int raft_append_entry(raft_server_t* me, raft_entry_t* ety);
+
+
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -262,11 +262,42 @@ int raft_entry_is_voting_cfg_change(raft_entry_t* ety);
  * @return 1 if this is a configuration change. */
 int raft_entry_is_cfg_change(raft_entry_t* ety);
 
-
 /** Apply all entries up to the commit index
  * @return
  *  0 on success;
  *  RAFT_ERR_SHUTDOWN when server MUST shutdown */
 int raft_apply_all(raft_server_t* me);
+
+/** Set the commit idx.
+ * This should be used to reload persistent state, ie. the commit_idx field.
+ * @param[in] commit_idx The new commit index. */
+void raft_set_commit_idx(raft_server_t *me, raft_index_t commit_idx);
+
+/** Vote for a server.
+ * This should be used to reload persistent state, ie. the voted-for field.
+ * @param[in] node The server to vote for
+ * @return
+ *  0 on success */
+int raft_vote(raft_server_t* me, raft_node_t* node);
+
+/** Vote for a server.
+ * This should be used to reload persistent state, ie. the voted-for field.
+ * @param[in] nodeid The server to vote for by nodeid
+ * @return
+ *  0 on success */
+int raft_vote_for_nodeid(raft_server_t* me, raft_node_id_t nodeid);
+
+
+/**
+ * @return number of votes this server has received this election */
+int raft_get_nvotes_for_me(raft_server_t* me);
+
+/**
+ * @return node ID of who I voted for */
+raft_node_id_t raft_get_voted_for(raft_server_t *me);
+
+/**
+ * @return currently elapsed timeout in milliseconds */
+raft_time_t raft_get_timeout_elapsed(raft_server_t *me);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -166,6 +166,12 @@ void raft_node_free(raft_node_t *node);
 
 void raft_node_set_match_idx(raft_node_t *node, raft_index_t idx);
 
+raft_index_t raft_node_get_match_idx(raft_node_t *node);
+
+void raft_node_set_next_idx(raft_node_t *node, raft_index_t idx);
+
+raft_index_t raft_node_get_next_idx(raft_node_t *node);
+
 void raft_node_clear_flags(raft_node_t *node);
 
 void raft_node_vote_for_me(raft_node_t *node, int vote);

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -180,6 +180,38 @@ int raft_node_has_vote_for_me(raft_node_t *node);
 
 void raft_node_set_has_sufficient_logs(raft_node_t *node, int sufficient_logs);
 
+void raft_node_set_voting_committed(raft_node_t *node, int voting);
+
+/** Check if a node is active.
+ * Active nodes could become voting nodes.
+ * This should be used for creating the membership snapshot.
+ **/
+int raft_node_is_active(raft_node_t *node);
+
+/** Make the node active.
+ *
+ * The user sets this to 1 between raft_begin_load_snapshot and
+ * raft_end_load_snapshot.
+ *
+ * @param[in] active Set a node as active if this is 1
+ **/
+void raft_node_set_active(raft_node_t *node, int active);
+
+/** Turn a node into a voting node.
+ * Voting nodes can take part in elections and in-regards to committing entries,
+ * are counted in majorities. */
+void raft_node_set_voting(raft_node_t *node, int voting);
+
+/** Tell if a node is a voting node or not.
+ * @return 1 if this is a voting node. Otherwise 0. */
+int raft_node_is_voting(raft_node_t *node);
+
+/** Check if a node has sufficient logs to be able to join the cluster.
+ **/
+int raft_node_has_sufficient_logs(raft_node_t *node);
+
+void raft_node_set_addition_committed(raft_node_t *node, int committed);
+
 int raft_is_single_node_voting_cluster(raft_server_t *me);
 
 int raft_votes_is_majority(int nnodes, int nvotes);

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -309,5 +309,9 @@ raft_time_t raft_get_timeout_elapsed(raft_server_t *me);
  *  RAFT_ERR_NOMEM memory allocation failure */
 int raft_append_entry(raft_server_t* me, raft_entry_t* ety);
 
+/** Check if a voting change is in progress
+ * @param[in] raft The Raft server
+ * @return 1 if a voting change is in progress */
+int raft_voting_change_is_in_progress(raft_server_t *me);
 
 #endif /* RAFT_PRIVATE_H_ */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -214,4 +214,6 @@ int raft_periodic_internal(raft_server_t *me, raft_time_t milliseconds);
 
 int raft_exec_operations(raft_server_t *me);
 
+raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
+
 #endif /* RAFT_PRIVATE_H_ */


### PR DESCRIPTION
Moved some functions from raft.h to raft_internal.h to minimize API. 

Still, application can include `raft_private.h` use internal 
functions (not suggested).