### PR TITLE
Revert changes

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -1360,6 +1360,11 @@ void raft_node_set_voting_committed(raft_node_t *node, int voting);
  * @param[in] committed Whether this node's membership is committed or not */
 void raft_node_set_addition_committed(raft_node_t *node, int committed);
 
+/** Set next entry index to deliver
+ * @param[in] node The node
+ * @param[in] idx Next entry index to deliver */
+void raft_node_set_next_idx(raft_node_t *node, raft_index_t idx);
+
 /** Check if a node's voting status has been committed.
  * This should be used for creating the membership snapshot.
  **/

--- a/include/raft.h
+++ b/include/raft.h
@@ -1166,6 +1166,10 @@ raft_node_t *raft_get_node(raft_server_t *me, raft_node_id_t id);
  * @return node pointed to by node idx */
 raft_node_t *raft_get_node_from_idx(raft_server_t *me, raft_index_t idx);
 
+/**
+ * @return node ID of who I voted for */
+raft_node_id_t raft_get_voted_for(raft_server_t *me);
+
 /** Get what this node thinks the node ID of the leader is.
  * @return node of what this node thinks is the valid leader;
  *   RAFT_NODE_ID_NONE if there is no leader */
@@ -1325,6 +1329,36 @@ raft_index_t raft_get_snapshot_last_idx(raft_server_t *me);
 
 /** Return last applied entry term that snapshot includes. */
 raft_term_t raft_get_snapshot_last_term(raft_server_t *me);
+
+/** Turn a node into a voting node.
+ * Voting nodes can take part in elections and in-regards to committing entries,
+ * are counted in majorities. */
+void raft_node_set_voting(raft_node_t *node, int voting);
+
+/** Tell if a node is a voting node or not.
+ * @return 1 if this is a voting node. Otherwise 0. */
+int raft_node_is_voting(raft_node_t *node);
+
+/** Check if a node is active.
+ * Active nodes could become voting nodes.
+ * This should be used for creating the membership snapshot.
+ **/
+int raft_node_is_active(raft_node_t *node);
+
+/** Make the node active.
+ * @param[in] active Set a node as active if this is 1
+ **/
+void raft_node_set_active(raft_node_t *node, int active);
+
+/** Confirm that a node's voting status is final
+ * @param[in] node The node
+ * @param[in] voting Whether this node's voting status is committed or not */
+void raft_node_set_voting_committed(raft_node_t *node, int voting);
+
+/** Confirm that a node's voting status is final
+ * @param[in] node The node
+ * @param[in] committed Whether this node's membership is committed or not */
+void raft_node_set_addition_committed(raft_node_t *node, int committed);
 
 /** Check if a node's voting status has been committed.
  * This should be used for creating the membership snapshot.

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -180,37 +180,11 @@ int raft_node_has_vote_for_me(raft_node_t *node);
 
 void raft_node_set_has_sufficient_logs(raft_node_t *node, int sufficient_logs);
 
-void raft_node_set_voting_committed(raft_node_t *node, int voting);
 
-/** Check if a node is active.
- * Active nodes could become voting nodes.
- * This should be used for creating the membership snapshot.
- **/
-int raft_node_is_active(raft_node_t *node);
-
-/** Make the node active.
- *
- * The user sets this to 1 between raft_begin_load_snapshot and
- * raft_end_load_snapshot.
- *
- * @param[in] active Set a node as active if this is 1
- **/
-void raft_node_set_active(raft_node_t *node, int active);
-
-/** Turn a node into a voting node.
- * Voting nodes can take part in elections and in-regards to committing entries,
- * are counted in majorities. */
-void raft_node_set_voting(raft_node_t *node, int voting);
-
-/** Tell if a node is a voting node or not.
- * @return 1 if this is a voting node. Otherwise 0. */
-int raft_node_is_voting(raft_node_t *node);
 
 /** Check if a node has sufficient logs to be able to join the cluster.
  **/
 int raft_node_has_sufficient_logs(raft_node_t *node);
-
-void raft_node_set_addition_committed(raft_node_t *node, int committed);
 
 int raft_is_single_node_voting_cluster(raft_server_t *me);
 
@@ -289,10 +263,6 @@ int raft_vote_for_nodeid(raft_server_t* me, raft_node_id_t nodeid);
 /**
  * @return number of votes this server has received this election */
 int raft_get_nvotes_for_me(raft_server_t* me);
-
-/**
- * @return node ID of who I voted for */
-raft_node_id_t raft_get_voted_for(raft_server_t *me);
 
 /**
  * @return currently elapsed timeout in milliseconds */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -168,8 +168,6 @@ void raft_node_set_match_idx(raft_node_t *node, raft_index_t idx);
 
 raft_index_t raft_node_get_match_idx(raft_node_t *node);
 
-void raft_node_set_next_idx(raft_node_t *node, raft_index_t idx);
-
 raft_index_t raft_node_get_next_idx(raft_node_t *node);
 
 void raft_node_clear_flags(raft_node_t *node);


### PR DESCRIPTION
Revert some changes from https://github.com/RedisLabs/raft/pull/141

I've realized these functions might be required, either for snapshotting process or testing. 
e.g: `raft_node_set_voting()` is required after snapshot:  https://github.com/RedisLabs/raft/blame/master/docs/Using.md#L306

For now, we can keep them in raft.h . Over time, we can revisit this decision and move into raft_private.h if necessary. 
