### PR TITLE
Refactor higher term handling

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -24,9 +24,8 @@ typedef enum {
     RAFT_ERR_INVALID_NODEID              = -8,
     RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS = -9,
     RAFT_ERR_DONE                        = -10,
-    RAFT_ERR_STALE_TERM                  = -11,
-    RAFT_ERR_NOTFOUND                    = -12,
-    RAFT_ERR_MISUSE                      = -13,
+    RAFT_ERR_NOTFOUND                    = -11,
+    RAFT_ERR_MISUSE                      = -12,
 } raft_error_e;
 
 typedef enum {

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -436,6 +436,8 @@ void raft_accept_leader(raft_server_t* me, raft_node_id_t leader)
 
     me->timeout_elapsed = 0;
     me->leader_id = leader;
+
+    raft_reset_transfer_leader(me, 0);
 }
 
 int raft_become_leader(raft_server_t *me)
@@ -812,30 +814,6 @@ int raft_recv_appendentries_response(raft_server_t *me,
     return 0;
 }
 
-static int raft_receive_term(raft_server_t* me, raft_term_t term)
-{
-    int e;
-
-    if (raft_is_candidate(me) && me->current_term == term)
-    {
-        raft_become_follower(me);
-    }
-    else if (me->current_term < term)
-    {
-        e = raft_set_current_term(me, term);
-        if (0 != e)
-            return e;
-
-        raft_become_follower(me);
-    }
-    else if (term < me->current_term)
-    {
-        return RAFT_ERR_STALE_TERM;
-    }
-
-    return 0;
-}
-
 int raft_recv_appendentries(raft_server_t *me,
                             raft_node_t *node,
                             raft_appendentries_req_t *req,
@@ -852,21 +830,22 @@ int raft_recv_appendentries(raft_server_t *me,
     resp->msg_id = req->msg_id;
     resp->success = 0;
 
-    e = raft_receive_term(me, req->term);
-    if (e != 0) {
-        if (e == RAFT_ERR_STALE_TERM) {
-            /* 1. Reply false if term < currentTerm (§5.1) */
-            raft_log(me, "AE term:%ld is less than current term:%ld",
-                     req->term, me->current_term);
-            e = 0;
-        }
-
+    if (req->term < me->current_term) {
+        /* 1. Reply false if term < currentTerm (§5.1) */
+        raft_log(me, "AE term:%ld is less than current term:%ld",
+                 req->term, me->current_term);
         goto out;
+    }
+
+    if (req->term > me->current_term) {
+        e = raft_set_current_term(me, req->term);
+        if (e != 0) {
+            goto out;
+        }
     }
 
     /* update current leader because ae->term is up to date */
     raft_accept_leader(me, req->leader_id);
-    raft_reset_transfer_leader(me, 0);
 
     /* Not the first appendentries we've received */
     /* NOTE: the log starts at 1 */
@@ -1407,7 +1386,7 @@ int raft_recv_snapshot(raft_server_t *me,
                        raft_snapshot_req_t *req,
                        raft_snapshot_resp_t *resp)
 {
-    int e;
+    int e = 0;
 
     raft_log(me, "%d <-- %d, recv snapshot_req "
              "t:%ld, lead:%d, id:%ld, si:%ld, st:%ld, o:%llu len:%llu lc:%d",
@@ -1421,19 +1400,20 @@ int raft_recv_snapshot(raft_server_t *me,
     resp->offset = 0;
     resp->success = 0;
 
-    e = raft_receive_term(me, req->term);
-    if (e != 0) {
-        if (e == RAFT_ERR_STALE_TERM) {
-            raft_log(me, "Snapshot req term:%ld is less than current term:%ld",
-                     req->term, me->current_term);
-            e = 0;
-        }
-
+    if (req->term < me->current_term) {
+        raft_log(me, "Snapshot req term:%ld is less than current term:%ld",
+                 req->term, me->current_term);
         goto out;
     }
 
+    if (req->term > me->current_term) {
+        e = raft_set_current_term(me, req->term);
+        if (e != 0) {
+            goto out;
+        }
+    }
+
     raft_accept_leader(me, req->leader_id);
-    raft_reset_transfer_leader(me, 0);
 
     /** If we already have the snapshot or the log entries in this snapshot,
      * inform the leader. */

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -157,8 +157,6 @@ const char *raft_get_error_str(int err)
             return "leader transfer is in progress";
         case RAFT_ERR_DONE:
             return "done";
-        case RAFT_ERR_STALE_TERM:
-            return "stale term";
         case RAFT_ERR_NOTFOUND:
             return "not found";
         case RAFT_ERR_MISUSE:


### PR DESCRIPTION
This PR refactors code regarding `term` handling inside 
`raft_recv_appendentries()` and `raft_recv_snapshot()` without 
introducing any logic changes. 

- Deleted `raft_receive_term()` function:
    This function sets the node as follower in certain cases. Although,
    it misses the pre-candidate state.
     
    We already set the node as follower inside `raft_accept_leader()`.
    (With the correct check that also handles pre-candidate state). 

- Moved `raft_reset_transfer_leader()` into `raft_accept_leader()`. 
    Leader transfer is completed when we accept a leader. So, it makes
    sense to move it into `raft_accept_leader()`.
    
- Added some tests to verify node becomes follower even on a
     pre-candidate state when a request is received with the same or
     higher term.