### PR TITLE
Use assert instead of RAFT_ERR_SHUTDOWN

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -681,8 +681,7 @@ typedef struct
     raft_clear_snapshot_f clear_snapshot;
 
     /** Callback for finite state machine application
-     * Return 0 on success.
-     * Return RAFT_ERR_SHUTDOWN if you want the server to shutdown. */
+     * Return 0 on success. */
     raft_logentry_event_f applylog;
 
     /** Callback for persisting term and vote data
@@ -794,7 +793,6 @@ typedef struct raft_log_impl
      * @param[in] entry Entry to append.
      * @return
      *  0 on success;
-     *  RAFT_ERR_SHUTDOWN server should shutdown;
      *  RAFT_ERR_NOMEM memory allocation failure.
      *
      * @note
@@ -973,9 +971,8 @@ void raft_remove_node(raft_server_t* me, raft_node_t* node);
 
 /** Process events that are dependent on time passing.
  * @return
- *  0 on success;
- *  -1 on failure;
- *  RAFT_ERR_SHUTDOWN when server MUST shutdown */
+ *  0 on success
+ *  -1 on failure */
 int raft_periodic(raft_server_t *me);
 
 /** Receive an appendentries message.
@@ -1043,8 +1040,7 @@ int raft_recv_requestvote(raft_server_t *me,
  * @param[in] node The node this response was sent by
  * @param[in] resp The requestvote response message
  * @return
- *  0 on success;
- *  RAFT_ERR_SHUTDOWN server MUST shutdown; */
+ *  0 on success */
 int raft_recv_requestvote_response(raft_server_t *me,
                                    raft_node_t *node,
                                    raft_requestvote_resp_t *resp);
@@ -1069,7 +1065,6 @@ int raft_recv_requestvote_response(raft_server_t *me,
  * @return
  *  0 on success;
  *  RAFT_ERR_NOT_LEADER server is not the leader;
- *  RAFT_ERR_SHUTDOWN server MUST shutdown;
  *  RAFT_ERR_ONE_VOTING_CHANGE_ONLY there is a non-voting change inflight;
  *  RAFT_ERR_NOMEM memory allocation failure
  */
@@ -1530,7 +1525,6 @@ raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
  *                       updating persisted index.
  * @return
  *   0 on success
- *   RAFT_ERR_SHUTDOWN when server MUST shutdown
  */
 int raft_flush(raft_server_t* me, raft_index_t sync_index);
 

--- a/include/raft_log.h
+++ b/include/raft_log.h
@@ -8,8 +8,7 @@
 typedef struct {
     /** Callback for adding an entry to the log
      * For safety reasons this callback MUST flush the change to disk.
-     * Return 0 on success.
-     * Return RAFT_ERR_SHUTDOWN if you want the server to shutdown. */
+     * Return 0 on success. */
 
     raft_logentry_event_f log_offer;
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -234,8 +234,7 @@ int raft_entry_is_cfg_change(raft_entry_t* ety);
 
 /** Apply all entries up to the commit index
  * @return
- *  0 on success;
- *  RAFT_ERR_SHUTDOWN when server MUST shutdown */
+ *  0 on success */
 int raft_apply_all(raft_server_t* me);
 
 /** Set the commit idx.
@@ -271,7 +270,6 @@ raft_time_t raft_get_timeout_elapsed(raft_server_t *me);
  * @param[in] ety The entry to be appended
  * @return
  *  0 on success;
- *  RAFT_ERR_SHUTDOWN server should shutdown
  *  RAFT_ERR_NOMEM memory allocation failure */
 int raft_append_entry(raft_server_t* me, raft_entry_t* ety);
 


### PR DESCRIPTION
Inside `raft_recv_appendentries()`, libraft returns `RAFT_ERR_SHUTDOWN`
in some cases. This error code indicates serious bugs in the cluster.
Application has nothing to do other than halting the process. 

There are two issues with that. First, it is easy to miss if you don't 
check the return value of the all API calls. Second, there is not much 
point in returning this error code when the application cannot do 
anything but abort. 

This PR changes these error cases to `assert()` inside the library. 
Libraft will not return `RAFT_ERR_SHUTDOWN` anymore. 

Leaving `RAFT_ERR_SHUTDOWN` definition itself untouched though, as it 
can be used by the application. e.g virtraft uses it. 

Also, added `raft_assert()` as `assert()` can be omitted from the
build depending on the compiler flag. `raft_assert()` guarantees 
that the check will be present in the optimized builds. 

Note: Deleted a test case that expected this error code before. We can
not test it as it triggers `assert()` now.