### PR TITLE
Use int instead of short for entry type

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -95,7 +95,7 @@ typedef struct raft_entry
     raft_entry_id_t id;
 
     /** type of entry */
-    short type;
+    int type;
 
     /** number of references */
     unsigned short refs;


### PR DESCRIPTION
In C, enum constants are `int` but currently, `type` variable in entry
struct is `short`. 

Changed it to `int` to provide type-safety. 