### PR TITLE
[RR-158] add session member to raft_entry_t

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -94,6 +94,9 @@ typedef struct raft_entry
     /** the entry's unique ID */
     raft_entry_id_t id;
 
+    /** session this entry belongs to **/
+    raft_session_t session;
+
     /** type of entry */
     int type;
 

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -23,7 +23,7 @@ typedef long int raft_index_t;
 /**
  * Id used to group entries into sessions
  */
-typedef unsigned long raft_session_t;
+typedef unsigned long long raft_session_t;
 
 /**
  * Size type. This should be at least 64 bits.

--- a/include/raft_types.h
+++ b/include/raft_types.h
@@ -21,6 +21,11 @@ typedef long int raft_term_t;
 typedef long int raft_index_t;
 
 /**
+ * Id used to group entries into sessions
+ */
+typedef unsigned long raft_session_t;
+
+/**
  * Size type. This should be at least 64 bits.
  */
 typedef unsigned long long raft_size_t;


### PR DESCRIPTION
enables users of libraft to group raft entries into sessions.