### PR TITLE
Assign random id automatically to the entries

### DIFF
--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1905,6 +1905,7 @@ raft_entry_t *raft_entry_new(unsigned int data_len)
     raft_entry_t *ety = raft_calloc(1, sizeof(raft_entry_t) + data_len);
     ety->data_len = data_len;
     ety->refs = 1;
+    ety->id = rand();
 
     return ety;
 }

--- a/tests/virtraft2.py
+++ b/tests/virtraft2.py
@@ -1171,30 +1171,37 @@ class RaftServer(object):
         This is a virtraft specific check to make sure entry passing is
         working correctly.
         """
+        def get_last_user_entry(idx):
+            while True:
+                if idx == lib.raft_get_snapshot_last_idx(self.raft):
+                    return None
+
+                prev_ety = lib.raft_get_entry_from_idx(self.raft, idx)
+                assert prev_ety
+
+                if prev_ety.type == lib.RAFT_LOGTYPE_NO_OP:
+                    lib.raft_entry_release(prev_ety)
+                    idx = idx - 1
+                    continue
+
+                return prev_ety
+
         if ety.type == lib.RAFT_LOGTYPE_NO_OP:
             return
 
-        ci = lib.raft_get_current_idx(self.raft)
-        if 0 < ci and not lib.raft_get_snapshot_last_idx(self.raft) == ci:
-            other_id = None
-            try:
-                prev_ety = lib.raft_get_entry_from_idx(self.raft, ci)
-                assert prev_ety
-                if prev_ety.type == lib.RAFT_LOGTYPE_NO_OP:
-                    if lib.raft_get_snapshot_last_idx(self.raft) != ci - 1:
-                        lib.raft_entry_release(prev_ety)
-                        prev_ety = lib.raft_get_entry_from_idx(self.raft, ci - 1)
-                        assert prev_ety
-                    else:
-                        lib.raft_entry_release(prev_ety)
-                        return
-                other_id = prev_ety.id
-                assert other_id < ety.id
-                lib.raft_entry_release(prev_ety)
-            except Exception as e:
-                logger.error(other_id, ety.id)
-                self.abort_exception = e
-                raise
+        last_ety = None
+
+        try:
+            ci = lib.raft_get_current_idx(self.raft)
+            last_ety = get_last_user_entry(ci)
+            if not last_ety:
+                return
+
+            assert ety.id > last_ety.id
+        except Exception as e:
+            logger.error("ids", last_ety.id, ety.id)
+            self.abort_exception = e
+            raise
 
     def entry_append(self, ety, ety_idx):
         try:


### PR DESCRIPTION
`raft_entry_t` has `id` field which is used for debugging purposes. 
Currently, it has the value of zero but we can assign a random value by default. 
User might override it if required.
