### PR TITLE
RR-238 - Recording and Retrieving of RAFT RPC stats

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -86,16 +86,38 @@ typedef enum {
 } raft_logtype_e;
 
 typedef struct raft_server_stats {
-    unsigned long long appendreq_received;
-    unsigned long long appendreq_with_entry_received;
-    unsigned long long appendreq_failed;
+    /** Miscellaneous */
+    unsigned long long appendentries_req_with_entry;
     unsigned long long snapshots_created;
     unsigned long long snapshots_received;
-    unsigned long long snapshotreq_received;
-    unsigned long long reqvote_prevote_received;
-    unsigned long long reqvote_prevote_granted;
-    unsigned long long reqvote_received;
-    unsigned long long reqvote_granted;
+    unsigned long long exec_throttled;
+
+    /** Message types */
+    unsigned long long appendentries_req_sent;           /* Sender side metric */
+    unsigned long long appendentries_req_received;       /* Receiver side metric */
+    unsigned long long appendentries_req_failed;         /* Sender side metric */
+
+    unsigned long long appendentries_resp_received;      /* Sender side metric */
+
+    /* --------------------------- */
+
+    unsigned long long snapshot_req_sent;
+    unsigned long long snapshot_req_received;
+    unsigned long long snapshot_req_failed;
+
+    unsigned long long snapshot_resp_received;
+
+    /* --------------------------- */
+    unsigned long long requestvote_prevote_req_sent;
+    unsigned long long requestvote_req_sent;
+    unsigned long long requestvote_prevote_req_received;
+    unsigned long long requestvote_req_received;
+    unsigned long long requestvote_prevote_req_granted;  /* receive side metric */
+    unsigned long long requestvote_req_granted;          /* receive side metric */
+
+    unsigned long long requestvote_prevote_resp_received;
+    unsigned long long requestvote_resp_received;
+    /** Message types end */
 } raft_server_stats_t;
 
 /** Entry that is stored in the server's entry log. */

--- a/include/raft.h
+++ b/include/raft.h
@@ -85,6 +85,19 @@ typedef enum {
     RAFT_LOGTYPE_NUM = 100,
 } raft_logtype_e;
 
+typedef struct raft_server_stats {
+    unsigned long long appendreq_received;
+    unsigned long long appendreq_with_entry_received;
+    unsigned long long appendreq_failed;
+    unsigned long long snapshots_created;
+    unsigned long long snapshots_received;
+    unsigned long long snapshotreq_received;
+    unsigned long long reqvote_prevote_received;
+    unsigned long long reqvote_prevote_granted;
+    unsigned long long reqvote_received;
+    unsigned long long reqvote_granted;
+} raft_server_stats_t;
+
 /** Entry that is stored in the server's entry log. */
 typedef struct raft_entry
 {
@@ -1458,6 +1471,13 @@ int raft_transfer_leader(raft_server_t* me, raft_node_id_t node_id, long timeout
  *         RAFT_NODE_ID_NONE otherwise
  */
 raft_node_id_t raft_get_transfer_leader(raft_server_t *me);
+
+/** Retrieves collected raft stats
+ *
+ * @param[in] me The Raft raft_server_t
+ * @param[out] stats a pointer to a client allocated buffer to fill collected stats
+ */
+void raft_get_server_stats(raft_server_t *me, raft_server_stats_t *stats);
 
 /** Force this server to start an election
  *

--- a/include/raft.h
+++ b/include/raft.h
@@ -93,33 +93,27 @@ typedef struct raft_server_stats {
     unsigned long long exec_throttled;
 
     /** Message types */
-    unsigned long long appendentries_req_sent;           /* Sender side metric */
-    unsigned long long appendentries_req_received;       /* Receiver side metric */
-    unsigned long long appendentries_req_failed;         /* Sender side metric */
-
-    unsigned long long appendentries_resp_received;      /* Sender side metric */
-
-    /* --------------------------- */
+    unsigned long long appendentries_req_sent;
+    unsigned long long appendentries_req_received;
+    unsigned long long appendentries_req_failed;
+    unsigned long long appendentries_resp_received;
 
     unsigned long long snapshot_req_sent;
     unsigned long long snapshot_req_received;
     unsigned long long snapshot_req_failed;
-
     unsigned long long snapshot_resp_received;
 
-    /* --------------------------- */
     unsigned long long requestvote_prevote_req_sent;
-    unsigned long long requestvote_req_sent;
     unsigned long long requestvote_prevote_req_received;
+    unsigned long long requestvote_prevote_req_failed;
+    unsigned long long requestvote_prevote_req_granted;
+    unsigned long long requestvote_prevote_resp_received;
+
+    unsigned long long requestvote_req_sent;
     unsigned long long requestvote_req_received;
     unsigned long long requestvote_req_failed;
-    unsigned long long requestvote_prevote_req_failed;
-    unsigned long long requestvote_prevote_req_granted;  /* receive side metric */
-    unsigned long long requestvote_req_granted;          /* receive side metric */
-
-    unsigned long long requestvote_prevote_resp_received;
+    unsigned long long requestvote_req_granted;
     unsigned long long requestvote_resp_received;
-    /** Message types end */
 } raft_server_stats_t;
 
 /** Entry that is stored in the server's entry log. */

--- a/include/raft.h
+++ b/include/raft.h
@@ -112,6 +112,8 @@ typedef struct raft_server_stats {
     unsigned long long requestvote_req_sent;
     unsigned long long requestvote_prevote_req_received;
     unsigned long long requestvote_req_received;
+    unsigned long long requestvote_req_failed;
+    unsigned long long requestvote_prevote_req_failed;
     unsigned long long requestvote_prevote_req_granted;  /* receive side metric */
     unsigned long long requestvote_req_granted;          /* receive side metric */
 

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -131,6 +131,8 @@ struct raft_server {
     int auto_flush;        /* Automatically call raft_flush() */
     int log_enabled;       /* Enable library logs */
     int disable_apply;     /* Do not apply entries, useful for testing */
+
+    raft_server_stats_t stats;
 };
 
 int raft_election_start(raft_server_t *me, int skip_precandidate);

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1841,10 +1841,10 @@ int raft_end_snapshot(raft_server_t *me)
              me->log_impl->first_idx(me->log) - 1, me->commit_idx,
              raft_get_current_idx(me));
 
+    me->stats.snapshots_created++;
+
     if (!raft_is_leader(me))
         return 0;
-
-    me->stats.snapshots_created++;
 
     for (int i = 0; i < me->num_nodes; i++)
     {

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -294,13 +294,5 @@ void raft_get_server_stats(raft_server_t *me, raft_server_stats_t *stats)
         return;
     }
 
-    stats->appendreq_received = me->stats.appendreq_received;
-    stats->appendreq_with_entry_received = me->stats.appendreq_with_entry_received;
-    stats->appendreq_failed = me->stats.appendreq_failed;
-    stats->snapshots_created = me->stats.snapshots_created;
-    stats->snapshots_received = me->stats.snapshots_received;
-    stats->reqvote_prevote_received = me->stats.reqvote_prevote_received;
-    stats->reqvote_prevote_granted = me->stats.reqvote_prevote_granted;
-    stats->reqvote_received = me->stats.reqvote_received;
-    stats->reqvote_granted = me->stats.reqvote_granted;
+    *stats = me->stats;
 }

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -288,3 +288,19 @@ raft_node_id_t raft_get_transfer_leader(raft_server_t *me)
     return me->node_transferring_leader_to;
 }
 
+void raft_get_server_stats(raft_server_t *me, raft_server_stats_t *stats)
+{
+    if (stats == NULL) {
+        return;
+    }
+
+    stats->appendreq_received = me->stats.appendreq_received;
+    stats->appendreq_with_entry_received = me->stats.appendreq_with_entry_received;
+    stats->appendreq_failed = me->stats.appendreq_failed;
+    stats->snapshots_created = me->stats.snapshots_created;
+    stats->snapshots_received = me->stats.snapshots_received;
+    stats->reqvote_prevote_received = me->stats.reqvote_prevote_received;
+    stats->reqvote_prevote_granted = me->stats.reqvote_prevote_granted;
+    stats->reqvote_received = me->stats.reqvote_received;
+    stats->reqvote_granted = me->stats.reqvote_granted;
+}

--- a/src/raft_server_properties.c
+++ b/src/raft_server_properties.c
@@ -290,9 +290,5 @@ raft_node_id_t raft_get_transfer_leader(raft_server_t *me)
 
 void raft_get_server_stats(raft_server_t *me, raft_server_stats_t *stats)
 {
-    if (stats == NULL) {
-        return;
-    }
-
     *stats = me->stats;
 }


### PR DESCRIPTION
Record counts for raft RPC stats, sending / retrieving / success / failure and the like.

cover append entry, requestvote (including prevote) and snapshots