### PR TITLE
Add snapshot_index to raft_snapshot_resp_t struct

### DIFF
--- a/include/raft.h
+++ b/include/raft.h
@@ -216,6 +216,9 @@ typedef struct
     /** the msg_id this response refers to */
     raft_msg_id_t msg_id;
 
+    /** last included index of the snapshot this response refers to */
+    raft_index_t snapshot_index;
+
     /** currentTerm, to force other leader to step down */
     raft_term_t term;
 

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1389,6 +1389,7 @@ int raft_recv_snapshot(raft_server_t *me,
              req->chunk.last_chunk);
 
     resp->msg_id = req->msg_id;
+    resp->snapshot_index = req->snapshot_index;
     resp->last_chunk = req->chunk.last_chunk;
     resp->offset = 0;
     resp->success = 0;
@@ -1461,9 +1462,10 @@ out:
     }
 
     raft_log(me, "%d --> %d, sent snapshot_resp "
-             "id:%lu, t:%ld, s:%d, o:%llu, lc:%d",
+             "id:%lu, si:%ld, t:%ld, s:%d, o:%llu, lc:%d",
              raft_get_nodeid(me), raft_node_get_id(node), resp->msg_id,
-             resp->term, resp->success, resp->offset, resp->last_chunk);
+             resp->snapshot_index, resp->term, resp->success, resp->offset,
+             resp->last_chunk);
     return e;
 }
 
@@ -1472,9 +1474,10 @@ int raft_recv_snapshot_response(raft_server_t *me,
                                 raft_snapshot_resp_t *resp)
 {
     raft_log(me, "%d <-- %d, recv snapshot_resp "
-             "id:%lu, t:%ld, s:%d, o:%llu, lc:%d",
+             "id:%lu, si:%ld, t:%ld, s:%d, o:%llu, lc:%d",
              raft_get_nodeid(me), raft_node_get_id(node), resp->msg_id,
-             resp->term, resp->success, resp->offset, resp->last_chunk);
+             resp->snapshot_index, resp->term, resp->success, resp->offset,
+             resp->last_chunk);
 
     if (!node || !raft_is_leader(me)) {
         return 0;
@@ -1497,6 +1500,11 @@ int raft_recv_snapshot_response(raft_server_t *me,
 
     raft_node_set_match_msgid(node, resp->msg_id);
 
+    /* Do not update the offset if we have a more recent snapshot now. */
+    if (resp->snapshot_index != me->snapshot_last_idx) {
+        goto out;
+    }
+
     if (!resp->success) {
         raft_node_set_snapshot_offset(node, resp->offset);
     }
@@ -1507,6 +1515,7 @@ int raft_recv_snapshot_response(raft_server_t *me,
                                          raft_node_get_next_idx(node)));
     }
 
+out:
     if (me->auto_flush) {
         return raft_flush(me, 0);
     }


### PR DESCRIPTION
Normally, receiver side has checks if the chunk is for the correct index and offset.
Adding snapshot_index to raft_snapshot_resp_t just to be sure we don't update snapshot offset for the node unnecessarily. 
Also, it makes debugging easier as we know the snapshot index that response refers to. 