### PR TITLE
Fixed an issue where snapshot during committing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,8 @@ set(RAFT_SOURCE_FILES
         src/raft_log.c
         src/raft_server.c
         src/raft_node.c
-        src/raft_server_properties.c)
+        src/raft_server_properties.c
+        src/raft_ring_buffer.c)
 
 add_library(raft STATIC ${RAFT_SOURCE_FILES})
 
@@ -140,6 +141,7 @@ target_compile_options(raft_shared PRIVATE -g -Wall -Wextra -pedantic)
 define_test(test_log)
 define_test(test_log_impl)
 define_test(test_node)
+define_test(test_ring_buffer)
 define_test(test_scenario)
 define_test(test_server)
 define_test(test_snapshotting)

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ OBJECTS = \
 	$(BUILD_DIR)/raft_server.o \
 	$(BUILD_DIR)/raft_server_properties.o \
 	$(BUILD_DIR)/raft_node.o \
-	$(BUILD_DIR)/raft_log.o
+	$(BUILD_DIR)/raft_log.o \
+	$(BUILD_DIR)/raft_ring_buffer.o
 
 TEST_OBJECTS = $(patsubst $(BUILD_DIR)/%.o,$(BUILD_DIR)/test-%.o,$(OBJECTS))
 

--- a/include/raft.h
+++ b/include/raft.h
@@ -1229,7 +1229,15 @@ void *raft_get_udata(raft_server_t *me);
  *  0 on success */
 int raft_set_current_term(raft_server_t *me, raft_term_t term);
 
+/** Confirm the entry at idx has been committed.
+ * This function can be used if you do not call raft_msg_entry_response_committed in the future
+ * because the entry is deleted after taking a snapshot.
+ * @param[in] idx The entry's index */
+void raft_confirm_entry_committed(raft_server_t* me, raft_index_t idx);
+
 /** Confirm if a msg_entry_response has been committed.
+ * Once this function returns non-zero for an entry, it should not be called again for that entry
+ * because the entry is deleted after taking a snapshot.
  * @param[in] r The response we want to check */
 int raft_msg_entry_response_committed(raft_server_t* me,
                                       const raft_entry_resp_t* r);
@@ -1515,6 +1523,8 @@ int raft_timeout_now(raft_server_t* me);
 
 /** Return number of entries that can be compacted
  *
+ * If there is only one entry, this function returns 0 because we need at least
+ * two entries to take a snapshot internally.
  * @param[in] me The Raft server
  * @return number of entries that can be compacted
  */

--- a/include/raft_private.h
+++ b/include/raft_private.h
@@ -10,6 +10,7 @@
 #ifndef RAFT_PRIVATE_H_
 #define RAFT_PRIVATE_H_
 
+#include "raft_ring_buffer.h"
 #include "raft_types.h"
 
 struct raft_log_impl;
@@ -46,6 +47,8 @@ struct raft_server {
 
     /* idx of highest log entry applied to state machine */
     raft_index_t last_applied_idx;
+
+    raft_ring_buffer_t* under_commit_idxes;
 
     /* term of the highest log entry applied to the state machine */
     raft_term_t last_applied_term;

--- a/include/raft_ring_buffer.h
+++ b/include/raft_ring_buffer.h
@@ -1,0 +1,147 @@
+/**
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef RAFT_RING_BUFFER_H_
+#define RAFT_RING_BUFFER_H_
+
+#include <stdint.h>
+
+/**
+ * A ring buffer of intptr_t values.
+ *
+ * The ring buffer is implemented as a variable-size array of intptr_t values. The
+ * array is indexed by two variables, begin and end, which indicate the first
+ * and last element of the ring buffer, respectively. The ring buffer is empty
+ * when begin == end. But it is also possible that begin == end even if the ring
+ * buffer is full. In that case, the ring buffer is full if num == capacity, and
+ * empty otherwise.
+ */
+struct raft_ring_buffer {
+    int capacity;
+    int begin;
+    int end;
+    int num;
+    intptr_t* data;
+};
+
+/**
+ * Ring buffer.
+ */
+typedef struct raft_ring_buffer raft_ring_buffer_t;
+
+/**
+ * Initialize a ring buffer.
+ *
+ * @param capacity The initial maximum number of elements that the ring buffer can hold.
+ * @return The ring buffer, or NULL if memory could not be allocated.
+ */
+raft_ring_buffer_t* raft_ring_buffer_new(int capacity);
+
+/**
+ * Release all memory used by the ring buffer.
+ *
+ * @param[in] rb The ring buffer.
+ */
+void raft_ring_buffer_free(raft_ring_buffer_t* rb);
+
+/**
+ * Push a value to the front of the ring buffer.
+ *
+ * @param[in] rb The ring buffer.
+ * @param[in] value The value to push.
+ * @return 0 on success, or -1 if memory could not be allocated.
+ */
+int raft_ring_buffer_push_front(raft_ring_buffer_t* rb, intptr_t value);
+
+/**
+ * Push a value to the back of the ring buffer.
+ *
+ * @param[in] rb The ring buffer.
+ * @param[in] value The value to push.
+ * @return 0 on success, or -1 if memory could not be allocated.
+ */
+int raft_ring_buffer_push_back(raft_ring_buffer_t* rb, intptr_t value);
+
+/**
+ * Pop a value from the front of the ring buffer.
+ *
+ * The ring buffer must not be empty.
+ * @param[in] rb The ring buffer.
+ * @return The value.
+ */
+intptr_t raft_ring_buffer_pop_front(raft_ring_buffer_t* rb);
+
+/**
+ * Pop a value from the back of the ring buffer.
+ *
+ * The ring buffer must not be empty.
+ * @param[in] rb The ring buffer.
+ * @return The value.
+ */
+intptr_t raft_ring_buffer_pop_back(raft_ring_buffer_t* rb);
+
+/**
+ * Return the number of elements in the ring buffer.
+ *
+ * @param[in] rb The ring buffer.
+ * @return The number of elements.
+ */
+int raft_ring_buffer_size(raft_ring_buffer_t* rb);
+
+/**
+ * Return the current maximum number of elements that the ring buffer can hold.
+ *
+ * Capacity will be increased automatically when the ring buffer is full.
+ * @param[in] rb The ring buffer.
+ * @return The capacity.
+ */
+int raft_ring_buffer_capacity(raft_ring_buffer_t* rb);
+
+/**
+ * Return the value at the front of the ring buffer.
+ *
+ * The ring buffer must not be empty.
+ * @param[in] rb The ring buffer.
+ * @return The value.
+ */
+intptr_t raft_ring_buffer_front(raft_ring_buffer_t* rb);
+
+/**
+ * Return the value at the back of the ring buffer.
+ *
+ * The ring buffer must not be empty.
+ * @param[in] rb The ring buffer.
+ * @return The value.
+ */
+intptr_t raft_ring_buffer_back(raft_ring_buffer_t* rb);
+
+/**
+ * Remove a value from the ring buffer by value.
+ *
+ * Search from front for the first occurrence of the given value and remove it. If the
+ * value is not found, the ring buffer is left unchanged.
+ * @param[in] rb The ring buffer.
+ * @param[in] value The value to remove.
+ */ 
+void raft_ring_buffer_remove_from_front(raft_ring_buffer_t* rb, intptr_t value);
+
+/**
+ * Remove a value from the ring buffer by value.
+ *
+ * Search from back for the first occurrence of the given value and remove it. If the
+ * value is not found, the ring buffer is left unchanged.
+ * @param[in] rb The ring buffer.
+ * @param[in] value The value to remove.
+ */
+void raft_ring_buffer_remove_from_back(raft_ring_buffer_t* rb, intptr_t value);
+
+/**
+ * Clear the ring buffer.
+ *
+ * @param[in] rb The ring buffer.
+ */
+void raft_ring_buffer_clear(raft_ring_buffer_t* rb);
+
+#endif  /* RAFT_RING_BUFFER_H_ */

--- a/src/raft_ring_buffer.c
+++ b/src/raft_ring_buffer.c
@@ -1,0 +1,164 @@
+/**
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include <assert.h>
+
+#include "raft.h"
+#include "raft_private.h"
+#include "raft_ring_buffer.h"
+#include "raft_types.h"
+
+raft_ring_buffer_t* raft_ring_buffer_new(int capacity)
+{
+    raft_ring_buffer_t* rb = raft_malloc(sizeof(raft_ring_buffer_t));
+    if (!rb) {
+        return NULL;
+    }
+    rb->capacity = capacity;
+    rb->begin = 0;
+    rb->end = 0;
+    rb->num = 0;
+    rb->data = raft_malloc(sizeof(*rb->data) * capacity);
+    if (!rb->data) {
+        raft_free(rb);
+        return NULL;
+    }
+    return rb;
+}
+
+void raft_ring_buffer_free(raft_ring_buffer_t* rb)
+{
+    raft_free(rb->data);
+    raft_free(rb);
+}
+
+static int raft_ring_buffer_increase_capacity(raft_ring_buffer_t* rb)
+{
+    int new_capacity = rb->capacity * 2;
+    intptr_t* new_data = raft_malloc(sizeof(*new_data) * new_capacity);
+    if (!new_data) {
+        return -1;
+    }
+    int i;
+    for (i = 0; i < rb->num; ++i) {
+        new_data[i] = rb->data[(rb->begin + i) % rb->capacity];
+    }
+    raft_free(rb->data);
+    rb->data = new_data;
+    rb->capacity = new_capacity;
+    rb->begin = 0;
+    rb->end = rb->num;
+    return 0;
+}
+
+int raft_ring_buffer_push_front(raft_ring_buffer_t* rb, intptr_t value)
+{
+    if (rb->num == rb->capacity) {
+        if (raft_ring_buffer_increase_capacity(rb) != 0) {
+            return -1;
+        }
+    }
+    rb->begin = (rb->begin - 1 + rb->capacity) % rb->capacity;
+    rb->data[rb->begin] = value;
+    ++rb->num;
+    return 0;
+}
+
+int raft_ring_buffer_push_back(raft_ring_buffer_t* rb, intptr_t value)
+{
+    if (rb->num == rb->capacity) {
+        if (raft_ring_buffer_increase_capacity(rb) != 0) {
+            return -1;
+        }
+    }
+    rb->data[rb->end] = value;
+    rb->end = (rb->end + 1) % rb->capacity;
+    ++rb->num;
+    return 0;
+}
+
+intptr_t raft_ring_buffer_pop_front(raft_ring_buffer_t* rb)
+{
+    assert(rb->num > 0);
+    intptr_t value = rb->data[rb->begin];
+    rb->begin = (rb->begin + 1) % rb->capacity;
+    --rb->num;
+    return value;
+}
+
+intptr_t raft_ring_buffer_pop_back(raft_ring_buffer_t* rb)
+{
+    assert(rb->num > 0);
+    rb->end = (rb->end - 1 + rb->capacity) % rb->capacity;
+    --rb->num;
+    return rb->data[rb->end];
+}
+
+int raft_ring_buffer_size(raft_ring_buffer_t* rb)
+{
+    return rb->num;
+}
+
+int raft_ring_buffer_capacity(raft_ring_buffer_t* rb)
+{
+    return rb->capacity;
+}
+
+intptr_t raft_ring_buffer_front(raft_ring_buffer_t* rb)
+{
+    assert(rb->num > 0);
+    return rb->data[rb->begin];
+}
+
+intptr_t raft_ring_buffer_back(raft_ring_buffer_t* rb)
+{
+    assert(rb->num > 0);
+    return rb->data[(rb->begin + rb->num - 1) % rb->capacity];
+}
+
+void raft_ring_buffer_remove_from_front(raft_ring_buffer_t* rb, intptr_t value)
+{
+    int i;
+    for (i = 0; i < rb->num; ++i) {
+        if (rb->data[(rb->begin + i) % rb->capacity] == value) {
+            break;
+        }
+    }
+    if (i == rb->num) {
+        return;
+    }
+    for (; i > 0; --i) {
+        rb->data[(rb->begin + i) % rb->capacity] =
+            rb->data[(rb->begin + i - 1) % rb->capacity];
+    }
+    rb->begin = (rb->begin + 1) % rb->capacity;
+    --rb->num;
+}
+
+void raft_ring_buffer_remove_from_back(raft_ring_buffer_t* rb, intptr_t value)
+{
+    int i;
+    for (i = 0; i < rb->num; ++i) {
+        if (rb->data[(rb->begin + i) % rb->capacity] == value) {
+            break;
+        }
+    }
+    if (i == rb->num) {
+        return;
+    }
+    for (; i < rb->num - 1; ++i) {
+        rb->data[(rb->begin + i) % rb->capacity] =
+            rb->data[(rb->begin + i + 1) % rb->capacity];
+    }
+    rb->end = (rb->end - 1 + rb->capacity) % rb->capacity;
+    --rb->num;
+}
+
+void raft_ring_buffer_clear(raft_ring_buffer_t* rb)
+{
+    rb->begin = 0;
+    rb->end = 0;
+    rb->num = 0;
+}

--- a/src/raft_server.c
+++ b/src/raft_server.c
@@ -1767,12 +1767,17 @@ int raft_msg_entry_response_committed(raft_server_t* me,
     raft_term_t ety_term = ety->term;
     raft_entry_release(ety);
 
-    raft_confirm_entry_committed(me, r->idx);
-
     /* entry from another leader has invalidated this entry message */
-    if (r->term != ety_term)
+    if (r->term != ety_term) {
+        raft_confirm_entry_committed(me, r->idx);
         return -1;
-    return r->idx <= me->commit_idx;
+    }
+
+    int result = r->idx <= me->commit_idx;
+    if (result != 0)
+        raft_confirm_entry_committed(me, r->idx);
+
+    return result;
 }
 
 int raft_pending_operations(raft_server_t *me)

--- a/tests/test_ring_buffer.c
+++ b/tests/test_ring_buffer.c
@@ -1,0 +1,136 @@
+#include <stdbool.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "CuTest.h"
+
+#include "raft.h"
+#include "raft_private.h"
+#include "raft_ring_buffer.h"
+
+void TestRaft_ring_buffer(CuTest * tc)
+{
+    /* push_back */
+    {
+        raft_ring_buffer_t* rb = raft_ring_buffer_new(2);
+        raft_ring_buffer_push_back(rb, 1);
+        raft_ring_buffer_push_back(rb, 2);
+        raft_ring_buffer_push_back(rb, 3);
+        /* [1, 2, 3] */
+
+        CuAssertTrue(tc, 3 == raft_ring_buffer_size(rb));
+        CuAssertTrue(tc, 1 == raft_ring_buffer_front(rb));
+        CuAssertTrue(tc, 3 == raft_ring_buffer_back(rb));
+
+        CuAssertTrue(tc, 1 == raft_ring_buffer_pop_front(rb));
+        CuAssertTrue(tc, 3 == raft_ring_buffer_pop_back(rb));
+        CuAssertTrue(tc, 2 == raft_ring_buffer_pop_front(rb));
+        CuAssertTrue(tc, 0 == raft_ring_buffer_size(rb));
+        raft_ring_buffer_free(rb);
+    }
+
+    /* push_front */
+    {
+        raft_ring_buffer_t* rb = raft_ring_buffer_new(2);
+        raft_ring_buffer_push_front(rb, 1);
+        raft_ring_buffer_push_front(rb, 2);
+        raft_ring_buffer_push_front(rb, 3);
+        /* [3, 2, 1] */
+
+        CuAssertTrue(tc, 3 == raft_ring_buffer_size(rb));
+        CuAssertTrue(tc, 3 == raft_ring_buffer_front(rb));
+        CuAssertTrue(tc, 1 == raft_ring_buffer_back(rb));
+
+        CuAssertTrue(tc, 3 == raft_ring_buffer_pop_front(rb));
+        CuAssertTrue(tc, 1 == raft_ring_buffer_pop_back(rb));
+        CuAssertTrue(tc, 2 == raft_ring_buffer_pop_front(rb));
+        CuAssertTrue(tc, 0 == raft_ring_buffer_size(rb));
+        raft_ring_buffer_free(rb);
+    }
+
+    /* remove_from_front */
+    {
+        raft_ring_buffer_t* rb = raft_ring_buffer_new(2);
+        raft_ring_buffer_push_back(rb, 1);
+        raft_ring_buffer_push_back(rb, 2);
+        raft_ring_buffer_push_back(rb, 3);
+        CuAssertTrue(tc, 3 == raft_ring_buffer_size(rb));
+
+        raft_ring_buffer_remove_from_front(rb, 2);
+        CuAssertTrue(tc, 2 == raft_ring_buffer_size(rb));
+        CuAssertTrue(tc, 1 == raft_ring_buffer_pop_front(rb));
+        CuAssertTrue(tc, 3 == raft_ring_buffer_pop_front(rb));
+        CuAssertTrue(tc, 0 == raft_ring_buffer_size(rb));
+        raft_ring_buffer_free(rb);
+    }
+
+    /* remove_from_back */
+    {
+        raft_ring_buffer_t* rb = raft_ring_buffer_new(2);
+        raft_ring_buffer_push_back(rb, 1);
+        raft_ring_buffer_push_back(rb, 2);
+        raft_ring_buffer_push_back(rb, 3);
+        CuAssertTrue(tc, 3 == raft_ring_buffer_size(rb));
+
+        raft_ring_buffer_remove_from_back(rb, 2);
+        CuAssertTrue(tc, 2 == raft_ring_buffer_size(rb));
+        CuAssertTrue(tc, 1 == raft_ring_buffer_pop_front(rb));
+        CuAssertTrue(tc, 3 == raft_ring_buffer_pop_front(rb));
+        CuAssertTrue(tc, 0 == raft_ring_buffer_size(rb));
+        raft_ring_buffer_free(rb);
+    }
+
+    /* many elements */
+    {
+        raft_ring_buffer_t* rb = raft_ring_buffer_new(2);
+        int i;
+        for (i = 0; i < 100; ++i) {
+            raft_ring_buffer_push_back(rb, i);
+        }
+        CuAssertTrue(tc, 100 == raft_ring_buffer_size(rb));
+
+        for (i = 0; i < 50; ++i) {
+            raft_ring_buffer_remove_from_front(rb, i);
+        }
+
+        CuAssertTrue(tc, 50 == raft_ring_buffer_size(rb));
+        CuAssertTrue(tc, 50 == raft_ring_buffer_front(rb));
+        CuAssertTrue(tc, 99 == raft_ring_buffer_back(rb));
+
+        for (i = 100; i < 200; ++i) {
+            raft_ring_buffer_push_back(rb, i);
+        }
+
+        CuAssertTrue(tc, 150 == raft_ring_buffer_size(rb));
+        CuAssertTrue(tc, 50 == raft_ring_buffer_front(rb));
+        CuAssertTrue(tc, 199 == raft_ring_buffer_back(rb));
+
+        for (i = 50; i < 200; ++i) {
+            raft_ring_buffer_remove_from_back(rb, i);
+        }
+
+        CuAssertTrue(tc, 0 == raft_ring_buffer_size(rb));
+        raft_ring_buffer_free(rb);
+    }
+}
+
+int main(void)
+{
+    CuString *output = CuStringNew();
+    CuSuite* suite = CuSuiteNew();
+
+    SUITE_ADD_TEST(suite, TestRaft_ring_buffer);
+
+    CuSuiteRun(suite);
+    CuSuiteDetails(suite, output);
+    printf("%s\n", output->buffer);
+
+    int rc = suite->failCount == 0 ? 0 : 1;
+
+    CuStringFree(output);
+    CuSuiteFree(suite);
+
+    return rc;
+}


### PR DESCRIPTION
I have found that if you create a snapshot when there is an entry in a commit in progress, raft_msg_entry_response_committed() will not detect the completion of that commit.

This was due to the fact that when the snapshot was taken and compaction was performed, the log entry for the commit in question was deleted.

To solve this problem, I have made it possible to remember the log index of the log entry of the commit in progress, so that it is not deleted when compaction is performed.

As there was no suitable container to store the log index, I implemented a ring buffer. This has resulted in a large number of change lines.
raft_msg_entry_response_committed() now has side effects. Once this function detects the completion of a commit and then takes a snapshot, it reverts back to not detecting the completion of the commit as before.
Please use this as a reference for your modifications. Or if you have another good solution, please let me know.
